### PR TITLE
cleanup some lints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,8 @@ test: build ## Run all tests
 
 .PHONY: lint
 lint: ## Run style checks and verify syntax
-	go vet -a ./...
+	go vet -asmdecl -assign -atomic -bools -buildtag -cgocall -copylocks -httpresponse -loopclosure -lostcancel -nilfunc -printf -shift -stdmethods -structtag -tests -unmarshal -unreachable -unsafeptr -unusedresult ./...
 	test -z $(gofmt -l ./...)
-	# TODO: golangci-lint
 
 .PHONY: fmt
 fmt: ## Run syntax re-formatting

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -182,7 +182,6 @@ func (bgs *BGS) handleFedEvent(ctx context.Context, host *PDS, evt *events.RepoE
 	default:
 		return fmt.Errorf("invalid fed event")
 	}
-	return nil
 }
 
 func (s *BGS) createExternalUser(ctx context.Context, did string) (*types.ActorInfo, error) {

--- a/lex/gen.go
+++ b/lex/gen.go
@@ -1169,44 +1169,6 @@ func forEachProp(t TypeSchema, cb func(k string, ts TypeSchema) error) error {
 
 func (ts *TypeSchema) writeJsonMarshalerObject(name string, w io.Writer) error {
 	return nil // no need for a special json marshaler right now
-
-	if len(ts.Properties) == 0 {
-		// TODO: this is a hacky special casing of record types...
-		return nil
-	}
-
-	fmt.Fprintf(w, "func (t *%s) MarshalJSON() ([]byte, error) {\n", name)
-
-	if err := forEachProp(*ts, func(k string, ts TypeSchema) error {
-		if ts.Const != nil {
-			// TODO: maybe check for mutations before overwriting? mutations would mean bad code
-			switch ts.Const.(type) {
-			case string:
-				fmt.Fprintf(w, "\tt.%s = %q\n", strings.Title(k), ts.Const)
-			case bool:
-				fmt.Fprintf(w, "\tt.%s = %v\n", strings.Title(k), ts.Const)
-			default:
-				return fmt.Errorf("unsupported const type: %T", ts.Const)
-
-			}
-		}
-
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	// TODO: this is ugly since i can't just pass things through to json.Marshal without causing an infinite recursion...
-	fmt.Fprintf(w, "\tout := make(map[string]interface{})\n")
-	if err := forEachProp(*ts, func(k string, ts TypeSchema) error {
-		fmt.Fprintf(w, "\tout[%q] = t.%s\n", k, strings.Title(k))
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	fmt.Fprintf(w, "\treturn json.Marshal(out)\n}\n\n")
-	return nil
 }
 
 func (ts *TypeSchema) writeJsonMarshalerEnum(name string, w io.Writer) error {

--- a/server/server.go
+++ b/server/server.go
@@ -146,7 +146,6 @@ func (s *Server) handleFedEvent(ctx context.Context, host *Peering, evt *events.
 	default:
 		return fmt.Errorf("invalid fed event")
 	}
-	return nil
 }
 
 func (s *Server) createExternalUser(ctx context.Context, did string) (*types.ActorInfo, error) {


### PR DESCRIPTION
Nothing urgent here, just getting CI to "green" with current `go vet -a ./...` linting.

The "comment out a big function which isn't used" is definitely debatable. Would be fine adding a CI override comment or something there.