### PR TITLE
quick and dirty mod report notification bot for slack

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -8,6 +8,7 @@ Commands (run with, eg, `go run ./cmd/bigsky`):
 - `cmd/lexgen`: codegen tool for lexicons (Lexicon JSON to golang package)
 - `cmd/pds`: PDS daemon
 - `cmd/stress`: connects to local/default PDS and creates a ton of random posts
+- `cmd/beemo`: slack bot for moderation reporting (Bluesky Moderation Observer)
 - `gen`: dev tool to run CBOR type codegen
 
 Packages:
@@ -97,3 +98,32 @@ Send the BGS a ding-dong:
 Set the log level to be more verbose, using an env variable:
 
     GOLOG_LOG_LEVEL=info go run ./cmd/pds
+
+
+## gosky basic usage
+
+Running against local typescript PDS in `dev-env` mode:
+
+	# as "alice" user
+	go run ./cmd/gosky/ --pds http://localhost:2583 createSession alice.test hunter2 > bsky.auth
+
+The `bsky.auth` file is the default place that `gosky` and other client
+commands will look for auth info.
+
+
+## slack report bot basic usage
+
+You need an admin token, slack webhook URL, and auth file (see gosky above).
+The auth file isn't actually used, only the admin token.
+
+    # configure a slack webhook
+    export SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T028K87/B04NBDB/oWbsHasdf23r2d
+
+    # example pulling admin token out of `pass` password manager
+    export BSKY_ADMIN_AUTH=`pass bsky/pds-admin-staging | head -n1`
+
+    # example just setting admin token directly
+    export BSKY_ADMIN_AUTH="someinsecurething123"
+
+    # run the bot
+    GOLOG_LOG_LEVEL=debug go run ./cmd/beemo/ --pds https://pds.staging.example.com --auth bsky.auth notify-reports

--- a/api/atproto/admingetModerationReports.go
+++ b/api/atproto/admingetModerationReports.go
@@ -1,0 +1,94 @@
+// NOTE: this is a hand-rolled implementation of this endpoint, until lexgen supports generating this endpoint
+// see: https://github.com/bluesky-social/indigo/issues/10
+
+package atproto
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/bluesky-social/indigo/lex/util"
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+func init() {
+	//util.RegisterType("app.bsky.admin.moderationReport", &AdminGetModerationReports_Report{})
+}
+
+// schema: com.atproto.admin.getModerationReports
+
+type AdminGetModerationReports_Report struct {
+	LexiconTypeID       string                             `json:"$type,omitempty"`
+	Id                  int64                              `json:"id" cborgen:"id"`
+	ReasonType          string                             `json:"reasonType" cborgen:"reasonType"`
+	Reason              string                             `json:"reason" cborgen:"reason"`
+	Subject             *AdminGetModerationReports_Subject `json:"subject" cborgen:"subject"`
+	ReportedByDid       string                             `json:"reportedByDid" cborgen:"reportedByDid"`
+	CreatedAt           string                             `json:"createdAt" cborgen:"createdAt"`
+	ResolvedByActionIds []int64                            `json:"resolvedByActionIds" cborgen:"resolvedByActionIds"`
+}
+
+type AdminGetModerationReports_Subject struct {
+	RepoRepoRef   *RepoRepoRef
+	RepoStrongRef *RepoStrongRef
+}
+
+func (t *AdminGetModerationReports_Subject) MarshalJSON() ([]byte, error) {
+	if t.RepoRepoRef != nil {
+		t.RepoRepoRef.LexiconTypeID = "com.atproto.repo.repoRef"
+		return json.Marshal(t.RepoRepoRef)
+	}
+	if t.RepoStrongRef != nil {
+		t.RepoStrongRef.LexiconTypeID = "com.atproto.repo.strongRef"
+		return json.Marshal(t.RepoStrongRef)
+	}
+	return nil, fmt.Errorf("cannot marshal empty enum")
+}
+func (t *AdminGetModerationReports_Subject) UnmarshalJSON(b []byte) error {
+	typ, err := util.TypeExtract(b)
+	if err != nil {
+		return err
+	}
+
+	switch typ {
+	case "com.atproto.repo.repoRef":
+		t.RepoRepoRef = new(RepoRepoRef)
+		return json.Unmarshal(b, t.RepoRepoRef)
+	case "com.atproto.repo.strongRef":
+		t.RepoStrongRef = new(RepoStrongRef)
+		return json.Unmarshal(b, t.RepoStrongRef)
+
+	default:
+		return fmt.Errorf("closed enums must have a matching value")
+	}
+}
+
+type AdminGetModerationReports_Output struct {
+	LexiconTypeID string                              `json:"$type,omitempty"`
+	Cursor        string                              `json:"cursor" cborgen:"cursor"`
+	Reports       []*AdminGetModerationReports_Report `json:"reports" cborgen:"reports"`
+}
+
+func AdminGetModerationReports(ctx context.Context, c *xrpc.Client, subject *string, resolved *bool, before *string, limit *int64) (*AdminGetModerationReports_Output, error) {
+	var out AdminGetModerationReports_Output
+
+	params := map[string]interface{}{}
+	if subject != nil {
+		params["subject"] = *subject
+	}
+	if resolved != nil {
+		params["resolved"] = resolved
+	}
+	if limit != nil {
+		params["limit"] = *limit
+	}
+	if before != nil {
+		params["before"] = *before
+	}
+	if err := c.Do(ctx, xrpc.Query, "", "com.atproto.admin.getModerationReports", params, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}

--- a/cmd/beemo/main.go
+++ b/cmd/beemo/main.go
@@ -1,0 +1,174 @@
+// Bluesky MOderation bot (BMO), a chatops helper for slack
+// For now, polls a PDS for new moderation reports and publishes notifications to slack
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
+	cliutil "github.com/bluesky-social/indigo/cmd/gosky/util"
+
+	logging "github.com/ipfs/go-log"
+	"github.com/urfave/cli/v2"
+)
+
+var log = logging.Logger("beemo")
+
+func main() {
+
+	app := &cli.App{
+		Name:  "beemo",
+		Usage: "bluesky moderation reporting bot",
+	}
+
+	app.Flags = []cli.Flag{
+		&cli.StringFlag{
+			// TODO: Name:    "pds-host",
+			Name:    "pds",
+			Usage:   "hostname and port of PDS instance",
+			Value:   "http://localhost:4849",
+			EnvVars: []string{"ATP_PDS_HOST"},
+		},
+		&cli.StringFlag{
+			// TODO: Name:     "auth-token",
+			Name:     "auth",
+			Usage:    "authentication token for PDS",
+			Required: true,
+			// TODO: EnvVars:  []string{"ATP_AUTH_TOKEN"},
+			EnvVars: []string{"BSKY_AUTH"},
+		},
+		&cli.StringFlag{
+			Name:     "admin-token",
+			Usage:    "admin authentication token for PDS",
+			Required: true,
+			// TODO: EnvVars:  []string{"ATP_ADMIN_TOKEN"},
+			EnvVars: []string{"BSKY_ADMIN_AUTH"},
+		},
+		&cli.StringFlag{
+			Name: "slack-webhook-url",
+			// eg: https://hooks.slack.com/services/X1234
+			Usage:    "full URL of slack webhook",
+			Required: true,
+			EnvVars:  []string{"SLACK_WEBHOOK_URL"},
+		},
+		&cli.IntFlag{
+			Name:    "poll-period",
+			Usage:   "API poll period in seconds",
+			Value:   30,
+			EnvVars: []string{"POLL_PERIOD"},
+		},
+	}
+	app.Commands = []*cli.Command{
+		&cli.Command{
+			Name:   "notify-reports",
+			Usage:  "watch for new moderation reports, notify in slack",
+			Action: pollNewReports,
+		},
+	}
+	app.RunAndExitOnError()
+}
+
+func pollNewReports(cctx *cli.Context) error {
+	// record last-seen report timestamp
+	since := time.Now()
+	// NOTE: uncomment this for testing
+	//since = time.Now().Add(time.Duration(-12) * time.Hour)
+	period := time.Duration(cctx.Int("poll-period")) * time.Second
+	atpc, err := cliutil.GetATPClient(cctx, false)
+	if err != nil {
+		return err
+	}
+	adminToken := cctx.String("admin-token")
+	if len(adminToken) > 0 {
+		atpc.C.AdminToken = &adminToken
+	}
+	log.Infof("report polling bot starting up...")
+	// can flip this bool to false to prevent spamming slack channel on startup
+	if true {
+		err := sendSlackMsg(cctx, fmt.Sprintf("restarted bot, monitoring for reports since `%s`...", since.Format(time.RFC3339)))
+		if err != nil {
+			return err
+		}
+	}
+	for {
+		// AdminGetModerationReports(ctx context.Context, c *xrpc.Client, subject *string, resolved *bool, before *string, limit *int64)
+		resolved := false
+		var limit int64 = 50
+		mrr, err := comatproto.AdminGetModerationReports(context.TODO(), atpc.C, nil, &resolved, nil, &limit)
+		if err != nil {
+			return err
+		}
+		// this works out to iterate from newest to oldest, which is the behavior we want (report only newest, then break)
+		for _, report := range mrr.Reports {
+			if len(report.ResolvedByActionIds) > 0 {
+				continue
+			}
+			createdAt, err := time.Parse(time.RFC3339, report.CreatedAt)
+			if err != nil {
+				return fmt.Errorf("invalid time format for 'createdAt': %w", err)
+			}
+			if createdAt.After(since) {
+				// ok, we found a "new" report, need to notify
+				msg := fmt.Sprintf("===== New moderation report received =====\n")
+				msg += fmt.Sprintf("PDS: `%s`\t", cctx.String("pds"))
+				msg += fmt.Sprintf("report id: `%d`\t", report.Id)
+				msg += fmt.Sprintf("recent unresolved: `%d`\n", len(mrr.Reports))
+				msg += fmt.Sprintf("createdAt: `%s`\n", report.CreatedAt)
+				msg += fmt.Sprintf("reasonType: `%s`\n", report.ReasonType)
+				if report.Subject.RepoRepoRef != nil {
+					msg += fmt.Sprintf("subject: `%s`\n", report.Subject.RepoRepoRef.Did)
+				} else {
+					msg += fmt.Sprintf("subject: `%s`\n", report.Subject.RepoStrongRef.Uri)
+				}
+				//msg += fmt.Sprintf("reportedByDid: `%s`\n", report.ReportedByDid)
+				log.Infof("found new report, notifying slack: %s", report)
+				err := sendSlackMsg(cctx, msg)
+				if err != nil {
+					return fmt.Errorf("failed to send slack message: %w", err)
+				}
+				since = createdAt
+				break
+			} else {
+				log.Debugf("skipping report: %s", report)
+			}
+		}
+		log.Infof("... sleeping for %s", period)
+		time.Sleep(period)
+	}
+}
+
+type SlackWebhookBody struct {
+	Text string `json:"text"`
+}
+
+// sends a simple slack message to a channel via "incoming webhook"
+// The slack incoming webhook must be already configured in the slack workplace.
+func sendSlackMsg(cctx *cli.Context, msg string) error {
+	// loosely based on: https://golangcode.com/send-slack-messages-without-a-library/
+
+	webhookUrl := cctx.String("slack-webhook-url")
+	body, _ := json.Marshal(SlackWebhookBody{Text: msg})
+	req, err := http.NewRequest(http.MethodPost, webhookUrl, bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+	if resp.StatusCode != 200 || buf.String() != "ok" {
+		// TODO: in some cases print body? eg, if short and text
+		return fmt.Errorf("failed slack webhook POST request. status=%d", resp.StatusCode)
+	}
+	return nil
+}


### PR DESCRIPTION
This polls a PDS instances periodically (default: 30sec) looking for moderation reports since the bot started up. When it finds one, it sends a message to a slack channel via an "incoming webhook". There is basically no state in the bot itself (eg, no database or file with "last seen" info), which makes this simple to deploy.

The way I hacked in admin auth in `xrpc/xrpc.go` probably isn't the best.