### PR TITLE
start refactoring away old `api/*.go` clients

### DIFF
--- a/api/bsky.go
+++ b/api/bsky.go
@@ -1,17 +1,5 @@
 package api
 
-import (
-	"context"
-	"fmt"
-
-	bsky "github.com/bluesky-social/indigo/api/bsky"
-	"github.com/bluesky-social/indigo/xrpc"
-)
-
-type BskyApp struct {
-	C *xrpc.Client
-}
-
 type PostEntity struct {
 	Index *TextSlice `json:"index" cborgen:"index"`
 	Type  string     `json:"type" cborgen:"type"`
@@ -73,42 +61,6 @@ type User struct {
 	Declaration *Declaration `json:"declaration"`
 }
 
-func (b *BskyApp) FeedGetTimeline(ctx context.Context, algo string, limit int, before *string) (*bsky.FeedGetTimeline_Output, error) {
-	params := map[string]interface{}{
-		"algorithm": algo,
-		"limit":     limit,
-	}
-
-	if before != nil {
-		params["before"] = *before
-	}
-
-	var out bsky.FeedGetTimeline_Output
-	if err := b.C.Do(ctx, xrpc.Query, encJson, "app.bsky.feed.getTimeline", params, nil, &out); err != nil {
-		return nil, err
-	}
-
-	return &out, nil
-}
-
-func (b *BskyApp) FeedGetAuthorFeed(ctx context.Context, author string, limit int, before *string) (*bsky.FeedGetAuthorFeed_Output, error) {
-	params := map[string]interface{}{
-		"author": author,
-		"limit":  limit,
-	}
-
-	if before != nil {
-		params["before"] = *before
-	}
-
-	var out bsky.FeedGetAuthorFeed_Output
-	if err := b.C.Do(ctx, xrpc.Query, encJson, "app.bsky.feed.getAuthorFeed", params, nil, &out); err != nil {
-		return nil, err
-	}
-
-	return &out, nil
-}
-
 type GSADeclaration struct {
 	Cid       string `json:"cid"`
 	ActorType string `json:"actorType"`
@@ -128,59 +80,8 @@ type GetSuggestionsResp struct {
 	Actors []GetSuggestionsActor `json:"actors"`
 }
 
-func (b *BskyApp) ActorGetSuggestions(ctx context.Context, limit int, cursor *string) (*GetSuggestionsResp, error) {
-	params := map[string]interface{}{
-		"limit": limit,
-	}
-
-	if cursor != nil {
-		params["cursor"] = *cursor
-	}
-
-	var out GetSuggestionsResp
-	if err := b.C.Do(ctx, xrpc.Query, "", "app.bsky.actor.getSuggestions", params, nil, &out); err != nil {
-		return nil, err
-	}
-
-	return &out, nil
-}
-
-func (b *BskyApp) FeedSetVote(ctx context.Context, subject *PostRef, direction string) error {
-	body := map[string]interface{}{
-		"subject":   subject,
-		"direction": direction,
-	}
-
-	var out map[string]interface{}
-	if err := b.C.Do(ctx, xrpc.Procedure, encJson, "app.bsky.feed.setVote", nil, body, &out); err != nil {
-		return err
-	}
-
-	fmt.Println(out)
-
-	return nil
-}
-
 type GetFollowsResp struct {
 	Subject *User  `json:"subject"`
 	Cursor  string `json:"cursor"`
 	Follows []User `json:"follows"`
-}
-
-func (b *BskyApp) GraphGetFollows(ctx context.Context, user string, limit int, before *string) (*GetFollowsResp, error) {
-	params := map[string]interface{}{
-		"user":  user,
-		"limit": limit,
-	}
-
-	if before != nil {
-		params["before"] = *before
-	}
-
-	var out GetFollowsResp
-	if err := b.C.Do(ctx, xrpc.Query, "", "app.bsky.graph.getFollows", params, nil, &out); err != nil {
-		return nil, err
-	}
-
-	return &out, nil
 }

--- a/cmd/stress/main.go
+++ b/cmd/stress/main.go
@@ -9,9 +9,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/bluesky-social/indigo/api"
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
+	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/carstore"
 	cliutil "github.com/bluesky-social/indigo/cmd/gosky/util"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/repo"
 	"github.com/bluesky-social/indigo/testing"
 	"github.com/bluesky-social/indigo/xrpc"
@@ -91,10 +93,13 @@ var postingCmd = &cli.Command{
 					buf := make([]byte, 100)
 					rand.Read(buf)
 
-					res, err := atp.RepoCreateRecord(ctx, acc.Did, "app.bsky.feed.post", true, &api.PostRecord{
-						Type:      "app.bsky.feed.post",
-						Text:      hex.EncodeToString(buf),
-						CreatedAt: time.Now().Format(time.RFC3339),
+					res, err := comatproto.RepoCreateRecord(context.TODO(), atp.C, &comatproto.RepoCreateRecord_Input{
+						Collection: "app.bsky.feed.post",
+						Did:        acc.Did,
+						Record: lexutil.LexiconTypeDecoder{&appbsky.FeedPost{
+							Text:      hex.EncodeToString(buf),
+							CreatedAt: time.Now().Format(time.RFC3339),
+						}},
 					})
 					if err != nil {
 						fmt.Printf("errored on worker %d loop %d: %s\n", worker, i, err)


### PR DESCRIPTION
I did some big chunks of `gosky` and a bit of `stress`. Was able to get rid of the `BskyApp` client type.

The `testscript` worked, but i'm not confident that there are not runtime bugs in the other parts of `gosky` (I didn't test all the individual commands).

There is a bunch more of this to do; the `ATProto` client type is used all over. A good start would be refactoring the existing methods on that client (in `api/atproto.go`) to use the lexgen stuff and work with `xrpc.Client`. That is, turn them in to high-level helpers, particularly for account+session management, and record creation/deletion. And maybe post creation, because that is so common in existing code with just text+createdAt (not the full-featured record type).

Sending this for review for your thoughts on the above, as much as for review of the changes.