### PR TITLE
fakermaker: use PNGs for avatars (fixed upstream)

### DIFF
--- a/cmd/fakermaker/main.go
+++ b/cmd/fakermaker/main.go
@@ -419,18 +419,14 @@ func pdsGenProfile(xrpcc *xrpc.Client, acc *AccountContext, genAvatar, genBanner
 
 	var avatar *lexutil.Blob
 	if genAvatar {
-		// TODO: PNG uploads currently broken with PDS
-		//img := gofakeit.ImagePng(200, 200)
-		img := gofakeit.ImageJpeg(200, 200)
+		img := gofakeit.ImagePng(200, 200)
 		resp, err := comatproto.BlobUpload(context.TODO(), xrpcc, bytes.NewReader(img))
 		if err != nil {
 			return err
 		}
 		avatar = &lexutil.Blob{
-			Cid: resp.Cid,
-			// TODO: see above
-			//MimeType: "image/png",
-			MimeType: "image/jpeg",
+			Cid:      resp.Cid,
+			MimeType: "image/png",
 		}
 	}
 	var banner *lexutil.Blob


### PR DESCRIPTION
Tagging @dholms for eyes on this trivial change to re-enable use of PNGs for avatars in the fakermaker profile generation code path.

This was fixed yesterday in `atproto` (https://github.com/bluesky-social/atproto/pull/570), and I just tested locally.

If you want to try testing fakermaker against PDS, the current flow would be to run `make run-pds` in atproto repo (maybe need postgresql set up with default auth ahead of time; and `make run-plc` might need to be running as well). In a separate terminal, in `indigo`, create a `.env` file at the top level dir with the low-security default auth settings:

```
BSKY_ADMIN_AUTH=password
ATP_PDS_HOST=http://localhost:2583
ATP_AUTH_HANDLE="admin.test"
ATP_AUTH_PASSWORD="admin"
```

Then run these commands to get through profile generation with the default batch size of a hundred user accounts:

```
go run ./cmd/fakermaker gen-accounts
go run ./cmd/fakermaker gen-profiles
```