### PR TITLE
bigsky Dockerfile: include ca-certificates

### DIFF
--- a/cmd/bigsky/Dockerfile
+++ b/cmd/bigsky/Dockerfile
@@ -20,7 +20,7 @@ RUN go build -tags timetzdata -o /bigsky ./cmd/bigsky
 ### Run stage
 FROM alpine:3.17
 
-RUN apk add --no-cache --update dumb-init
+RUN apk add --no-cache --update dumb-init ca-certificates
 ENTRYPOINT ["dumb-init", "--"]
 
 WORKDIR /


### PR DESCRIPTION
This is to ensure that we have correct (or at least reasonable) SSL root certs when the BGS makes outbound connections to crawl PDS instances.