### PR TITLE
remove io/ioutil package

### DIFF
--- a/api/plc.go
+++ b/api/plc.go
@@ -8,7 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -110,7 +110,7 @@ func (s *PLCServer) CreateDID(ctx context.Context, sigkey *did.PrivKey, recovery
 	}
 
 	if resp.StatusCode != 200 {
-		b, _ := ioutil.ReadAll(resp.Body)
+		b, _ := io.ReadAll(resp.Body)
 		fmt.Println(string(b))
 		return "", fmt.Errorf("bad response from create call: %d %s", resp.StatusCode, resp.Status)
 

--- a/carstore/repo_test.go
+++ b/carstore/repo_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,7 +21,7 @@ import (
 )
 
 func testCarStore() (*CarStore, func(), error) {
-	tempdir, err := ioutil.TempDir("", "msttest-")
+	tempdir, err := os.MkdirTemp("", "msttest-")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -53,7 +52,7 @@ func testCarStore() (*CarStore, func(), error) {
 }
 
 func testFlatfsBs() (blockstore.Blockstore, func(), error) {
-	tempdir, err := ioutil.TempDir("", "msttest-")
+	tempdir, err := os.MkdirTemp("", "msttest-")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/gosky/util/util.go
+++ b/cmd/gosky/util/util.go
@@ -3,7 +3,6 @@ package cliutil
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -130,7 +129,7 @@ func loadAuthFromEnv(cctx *cli.Context, req bool) (*xrpc.AuthInfo, error) {
 }
 
 func ReadAuth(fname string) (*xrpc.AuthInfo, error) {
-	b, err := ioutil.ReadFile(fname)
+	b, err := io.ReadFile(fname)
 	if err != nil {
 		return nil, err
 	}

--- a/indexer/posts_test.go
+++ b/indexer/posts_test.go
@@ -2,7 +2,6 @@ package indexer
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,7 +30,7 @@ type testIx struct {
 func testIndexer(t *testing.T) *testIx {
 	t.Helper()
 
-	dir, err := ioutil.TempDir("", "ixtest")
+	dir, err := os.MkdirTemp("", "ixtest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +84,7 @@ func (ix *testIx) Cleanup() {
 // TODO: dedupe this out into some testing utility package
 func testPLC(t *testing.T) *plc.FakeDid {
 	// TODO: just do in memory...
-	tdir, err := ioutil.TempDir("", "plcserv")
+	tdir, err := os.MkdirTemp("", "plcserv")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/repomgr/ingest_test.go
+++ b/repomgr/ingest_test.go
@@ -2,7 +2,6 @@ package repomgr
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +28,7 @@ func skipIfNoFile(t *testing.T, f string) {
 func TestLoadNewRepo(t *testing.T) {
 	skipIfNoFile(t, "testrepo.car")
 
-	dir, err := ioutil.TempDir("", "integtest")
+	dir, err := os.MkdirTemp("", "integtest")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base32"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	mathrand "math/rand"
 	"net/http"
 	"os"
@@ -104,7 +103,7 @@ func mustSetupPDS(t *testing.T, host, suffix string, plc plc.PLCClient) *testPDS
 }
 
 func SetupPDS(host, suffix string, plc plc.PLCClient) (*testPDS, error) {
-	dir, err := ioutil.TempDir("", "integtest")
+	dir, err := os.MkdirTemp("", "integtest")
 	if err != nil {
 		return nil, err
 	}
@@ -347,7 +346,7 @@ func (u *testUser) GetNotifs(t *testing.T) []*bsky.NotificationList_Notification
 
 func testPLC(t *testing.T) *plc.FakeDid {
 	// TODO: just do in memory...
-	tdir, err := ioutil.TempDir("", "plcserv")
+	tdir, err := os.MkdirTemp("", "plcserv")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -374,7 +373,7 @@ func mustSetupBGS(t *testing.T, host string, didr plc.PLCClient) *testBGS {
 }
 
 func SetupBGS(host string, didr plc.PLCClient) (*testBGS, error) {
-	dir, err := ioutil.TempDir("", "integtest")
+	dir, err := os.MkdirTemp("", "integtest")
 	if err != nil {
 		return nil, err
 	}
@@ -633,7 +632,7 @@ func RandSentence(words []string, maxl int) string {
 }
 
 func ReadWords() ([]string, error) {
-	b, err := ioutil.ReadFile("/usr/share/dict/words")
+	b, err := os.ReadFile("/usr/share/dict/words")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
io/ioutil is deprecated as of Go 1.16.