### PR TITLE
all: close http response body

### DIFF
--- a/api/plc.go
+++ b/api/plc.go
@@ -40,6 +40,8 @@ func (s *PLCServer) GetDocument(ctx context.Context, didstr string) (*did.Docume
 		return nil, err
 	}
 
+	defer resp.Body.Close()
+
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("get did request failed (code %d): %s", resp.StatusCode, resp.Status)
 	}
@@ -108,6 +110,8 @@ func (s *PLCServer) CreateDID(ctx context.Context, sigkey *did.PrivKey, recovery
 	if err != nil {
 		return "", err
 	}
+
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		b, _ := ioutil.ReadAll(resp.Body)

--- a/cmd/beemo/main.go
+++ b/cmd/beemo/main.go
@@ -207,6 +207,9 @@ func sendSlackMsg(cctx *cli.Context, msg string) error {
 	if err != nil {
 		return err
 	}
+
+	defer resp.Body.Close()
+
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(resp.Body)
 	if resp.StatusCode != 200 || buf.String() != "ok" {

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -172,6 +172,8 @@ func (tp *testPDS) RequestScraping(t *testing.T, b *testBGS) {
 		t.Fatal(err)
 	}
 
+	defer resp.Body.Close()
+
 	if resp.StatusCode != 200 {
 		t.Fatal("invalid response from bgs", resp.StatusCode)
 	}

--- a/xrpc/xrpc.go
+++ b/xrpc/xrpc.go
@@ -107,6 +107,8 @@ func (c *Client) Do(ctx context.Context, kind XRPCRequestType, inpenc string, me
 		return fmt.Errorf("request failed: %w", err)
 	}
 
+	defer resp.Body.Close()
+
 	if resp.StatusCode != 200 {
 		var i interface{}
 		_ = json.NewDecoder(resp.Body).Decode(&i)


### PR DESCRIPTION
Per official documentation, the client must close the response body when finished with it.

Refs: https://pkg.go.dev/net/http#pkg-overview