### PR TITLE
ci: run actions on pull_request

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -1,5 +1,9 @@
 name: golang
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -1,9 +1,15 @@
 name: golang
+
 on:
   pull_request:
   push:
     branches:
       - main
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -1,5 +1,5 @@
 name: golang
-on: [push]
+on: [push, pull_request]
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This seems to be the correct and safe way to enable github actions CI runs for third party forks (when they are submitted as a PR).

The important detail is that the `.github/*` action stuff does not run from the fork, it runs from the previous `main` (or whatever branch) that the fork branched off from. This should prevent exfiltration of secrets?

Still possible for folks to, eg, mine cryptocurrency on our dime, I think. The current behavior from the github UI side should be that first-time contributors need to be approved before the CI job runs.