### PR TITLE
Get signing key from PLC using new did doc semantics

### DIFF
--- a/indexer/keymgr.go
+++ b/indexer/keymgr.go
@@ -48,7 +48,7 @@ func (km *KeyManager) getKey(ctx context.Context, did string) (*did.PubKey, erro
 		return nil, err
 	}
 
-	pubk, err := doc.GetPublicKey("#signingKey")
+	pubk, err := doc.GetPublicKey("#atproto")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In https://github.com/bluesky-social/did-method-plc/pull/5 there were some updates to how the did doc is laid out in PLC.  I was experiencing an issue with signature checks, and this small update seems to have done the trick.

For good measure, here's the error that was surfacing:
```
2023-03-07T10:59:57.689-0500    ERROR   indexer indexer/crawler.go:158  failed to perform repo crawl of "did:plc:wqzurwm3kmaig6e6hnc2gqwo": importing fetched repo: process new repo: cb errored (54/54): signature check failed: no key found by that ID:
```