### PR TITLE
refactor: consistent 'lexutil' naming

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -17,7 +17,7 @@ import (
 	"github.com/bluesky-social/indigo/carstore"
 	"github.com/bluesky-social/indigo/events"
 	"github.com/bluesky-social/indigo/indexer"
-	"github.com/bluesky-social/indigo/lex/util"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/models"
 	"github.com/bluesky-social/indigo/plc"
 	"github.com/bluesky-social/indigo/repomgr"
@@ -172,7 +172,7 @@ func (bgs *BGS) EventsHandler(c echo.Context) error {
 				return err
 			}
 
-			var obj util.CBOR
+			var obj lexutil.CBOR
 
 			switch {
 			case evt.Append != nil:

--- a/gen/main.go
+++ b/gen/main.go
@@ -5,7 +5,7 @@ import (
 	atproto "github.com/bluesky-social/indigo/api/atproto"
 	bsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/events"
-	"github.com/bluesky-social/indigo/lex/util"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 	mst "github.com/bluesky-social/indigo/mst"
 	"github.com/bluesky-social/indigo/repo"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -32,7 +32,7 @@ func main() {
 		panic(err)
 	}
 
-	if err := cbg.WriteMapEncodersToFile("lex/util/cbor_gen.go", "util", util.CborChecker{}, util.Blob{}); err != nil {
+	if err := cbg.WriteMapEncodersToFile("lex/util/cbor_gen.go", "util", lexutil.CborChecker{}, lexutil.Blob{}); err != nil {
 		panic(err)
 	}
 

--- a/notifs/notifs.go
+++ b/notifs/notifs.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	appbskytypes "github.com/bluesky-social/indigo/api/bsky"
-	"github.com/bluesky-social/indigo/lex/util"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/models"
 	bsutil "github.com/bluesky-social/indigo/util"
 	"github.com/ipfs/go-cid"
@@ -174,7 +174,7 @@ func (nm *DBNotifMan) hydrateNotificationUpVote(ctx context.Context, nrec *Notif
 	rsub := "at://" + postAuthor.Did + "/app.bsky.feed.post/" + votedOn.Rkey
 
 	return &appbskytypes.NotificationList_Notification{
-		Record:        util.LexiconTypeDecoder{Val: rec},
+		Record:        lexutil.LexiconTypeDecoder{Val: rec},
 		IsRead:        nrec.CreatedAt.Before(lastSeen),
 		IndexedAt:     nrec.CreatedAt.Format(time.RFC3339),
 		Uri:           "at://" + voter.Did + "/app.bsky.feed.vote/" + vote.Rkey,
@@ -214,7 +214,7 @@ func (nm *DBNotifMan) hydrateNotificationRepost(ctx context.Context, nrec *Notif
 	rsub := "at://" + postAuthor.Did + "/app.bsky.feed.post/" + reposted.Rkey
 
 	return &appbskytypes.NotificationList_Notification{
-		Record:        util.LexiconTypeDecoder{rec},
+		Record:        lexutil.LexiconTypeDecoder{rec},
 		IsRead:        nrec.CreatedAt.Before(lastSeen),
 		IndexedAt:     nrec.CreatedAt.Format(time.RFC3339),
 		Uri:           "at://" + reposter.Did + "/app.bsky.feed.repost/" + repost.Rkey,
@@ -254,7 +254,7 @@ func (nm *DBNotifMan) hydrateNotificationReply(ctx context.Context, nrec *NotifR
 	rsub := "at://" + opAuthor.Did + "/app.bsky.feed.post/" + replyTo.Rkey
 
 	return &appbskytypes.NotificationList_Notification{
-		Record:        util.LexiconTypeDecoder{rec},
+		Record:        lexutil.LexiconTypeDecoder{rec},
 		IsRead:        nrec.CreatedAt.Before(lastSeen),
 		IndexedAt:     nrec.CreatedAt.Format(time.RFC3339),
 		Uri:           "at://" + author.Did + "/app.bsky.feed.post/" + fp.Rkey,
@@ -282,7 +282,7 @@ func (nm *DBNotifMan) hydrateNotificationFollow(ctx context.Context, nrec *Notif
 	}
 
 	return &appbskytypes.NotificationList_Notification{
-		Record:    util.LexiconTypeDecoder{rec},
+		Record:    lexutil.LexiconTypeDecoder{rec},
 		IsRead:    nrec.CreatedAt.Before(lastSeen),
 		IndexedAt: nrec.CreatedAt.Format(time.RFC3339),
 		Uri:       "at://" + follower.Did + "/app.bsky.graph.follow/" + frec.Rkey,

--- a/pds/feedgen.go
+++ b/pds/feedgen.go
@@ -9,7 +9,7 @@ import (
 
 	bsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/indexer"
-	"github.com/bluesky-social/indigo/lex/util"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/models"
 	bsutil "github.com/bluesky-social/indigo/util"
 	"github.com/ipfs/go-cid"
@@ -32,7 +32,7 @@ func NewFeedGenerator(db *gorm.DB, ix *indexer.Indexer, readRecord ReadRecordFun
 	}, nil
 }
 
-type ReadRecordFunc func(context.Context, bsutil.Uid, cid.Cid) (util.CBOR, error)
+type ReadRecordFunc func(context.Context, bsutil.Uid, cid.Cid) (lexutil.CBOR, error)
 
 /*
 type HydratedFeedItem struct {
@@ -149,7 +149,7 @@ func (fg *FeedGenerator) hydrateItem(ctx context.Context, item *models.FeedPost)
 		return nil, err
 	}
 
-	out.Post.Record = util.LexiconTypeDecoder{rec}
+	out.Post.Record = lexutil.LexiconTypeDecoder{rec}
 
 	return out, nil
 }

--- a/pds/handlers.go
+++ b/pds/handlers.go
@@ -9,7 +9,7 @@ import (
 
 	comatprototypes "github.com/bluesky-social/indigo/api/atproto"
 	appbskytypes "github.com/bluesky-social/indigo/api/bsky"
-	"github.com/bluesky-social/indigo/lex/util"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 	"github.com/ipfs/go-cid"
 	jwt "github.com/lestrrat-go/jwx/jwt"
 )
@@ -87,7 +87,7 @@ func (s *Server) handleAppBskyActorUpdateProfile(ctx context.Context, input *app
 	return &appbskytypes.ActorUpdateProfile_Output{
 		Cid:    ncid.String(),
 		Uri:    "at://" + u.Did + "/app.bsky.actor.profile/self",
-		Record: util.LexiconTypeDecoder{profile},
+		Record: lexutil.LexiconTypeDecoder{profile},
 	}, nil
 }
 
@@ -540,7 +540,7 @@ func (s *Server) handleComAtprotoRepoGetRecord(ctx context.Context, c string, co
 	return &comatprototypes.RepoGetRecord_Output{
 		Cid:   &ccstr,
 		Uri:   "at://" + targetUser.Did + "/" + collection + "/" + rkey,
-		Value: util.LexiconTypeDecoder{rec},
+		Value: lexutil.LexiconTypeDecoder{rec},
 	}, nil
 }
 

--- a/pds/server.go
+++ b/pds/server.go
@@ -17,7 +17,7 @@ import (
 	"github.com/bluesky-social/indigo/carstore"
 	"github.com/bluesky-social/indigo/events"
 	"github.com/bluesky-social/indigo/indexer"
-	"github.com/bluesky-social/indigo/lex/util"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/models"
 	"github.com/bluesky-social/indigo/notifs"
 	"github.com/bluesky-social/indigo/plc"
@@ -283,7 +283,7 @@ func (s *Server) repoEventToFedEvent(ctx context.Context, evt *repomgr.RepoEvent
 	return out, nil
 }
 
-func (s *Server) readRecordFunc(ctx context.Context, user bsutil.Uid, c cid.Cid) (util.CBOR, error) {
+func (s *Server) readRecordFunc(ctx context.Context, user bsutil.Uid, c cid.Cid) (lexutil.CBOR, error) {
 	bs, err := s.cs.ReadOnlySession(user)
 	if err != nil {
 		return nil, err
@@ -294,7 +294,7 @@ func (s *Server) readRecordFunc(ctx context.Context, user bsutil.Uid, c cid.Cid)
 		return nil, err
 	}
 
-	return util.CborDecodeValue(blk.RawData())
+	return lexutil.CborDecodeValue(blk.RawData())
 }
 
 func loadKey(kfile string) (*did.PrivKey, error) {
@@ -657,7 +657,7 @@ func (s *Server) EventsHandler(c echo.Context) error {
 			return err
 		}
 
-		var obj util.CBOR
+		var obj lexutil.CBOR
 
 		switch {
 		case evt.Append != nil:

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -24,7 +24,7 @@ import (
 	"github.com/bluesky-social/indigo/carstore"
 	"github.com/bluesky-social/indigo/events"
 	"github.com/bluesky-social/indigo/indexer"
-	"github.com/bluesky-social/indigo/lex/util"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/notifs"
 	"github.com/bluesky-social/indigo/pds"
 	"github.com/bluesky-social/indigo/plc"
@@ -225,7 +225,7 @@ func (u *testUser) Reply(t *testing.T, replyto, root *atproto.RepoStrongRef, bod
 	resp, err := atproto.RepoCreateRecord(ctx, u.client, &atproto.RepoCreateRecord_Input{
 		Collection: "app.bsky.feed.post",
 		Did:        u.did,
-		Record: util.LexiconTypeDecoder{&bsky.FeedPost{
+		Record: lexutil.LexiconTypeDecoder{&bsky.FeedPost{
 			CreatedAt: time.Now().Format(time.RFC3339),
 			Text:      body,
 			Reply: &bsky.FeedPost_ReplyRef{
@@ -252,7 +252,7 @@ func (u *testUser) Post(t *testing.T, body string) *atproto.RepoStrongRef {
 	resp, err := atproto.RepoCreateRecord(ctx, u.client, &atproto.RepoCreateRecord_Input{
 		Collection: "app.bsky.feed.post",
 		Did:        u.did,
-		Record: util.LexiconTypeDecoder{&bsky.FeedPost{
+		Record: lexutil.LexiconTypeDecoder{&bsky.FeedPost{
 			CreatedAt: time.Now().Format(time.RFC3339),
 			Text:      body,
 		}},
@@ -275,7 +275,7 @@ func (u *testUser) Like(t *testing.T, post *atproto.RepoStrongRef) {
 	_, err := atproto.RepoCreateRecord(ctx, u.client, &atproto.RepoCreateRecord_Input{
 		Collection: "app.bsky.feed.vote",
 		Did:        u.did,
-		Record: util.LexiconTypeDecoder{&bsky.FeedVote{
+		Record: lexutil.LexiconTypeDecoder{&bsky.FeedVote{
 			LexiconTypeID: "app.bsky.feed.vote",
 			CreatedAt:     time.Now().Format(time.RFC3339),
 			Direction:     "up",
@@ -295,7 +295,7 @@ func (u *testUser) Follow(t *testing.T, did string) string {
 	resp, err := atproto.RepoCreateRecord(ctx, u.client, &atproto.RepoCreateRecord_Input{
 		Collection: "app.bsky.graph.follow",
 		Did:        u.did,
-		Record: util.LexiconTypeDecoder{&bsky.GraphFollow{
+		Record: lexutil.LexiconTypeDecoder{&bsky.GraphFollow{
 			CreatedAt: time.Now().Format(time.RFC3339),
 			Subject: &bsky.ActorRef{
 				DeclarationCid: "bafyreid27zk7lbis4zw5fz4podbvbs4fc5ivwji3dmrwa6zggnj4bnd57u",


### PR DESCRIPTION
I might also soon recommend that we refactor the package itself to `lex/lexutil/`, or top-level `lexutil/`.