### PR TITLE
Labelmaker v0 / "first phase"

### DIFF
--- a/cmd/labelmaker/main.go
+++ b/cmd/labelmaker/main.go
@@ -117,7 +117,9 @@ func main() {
 		// NOTE: connecting to PDS for now, not actual BGS
 		//bgsUrl := "localhost:2470"
 		bgsUrl := "localhost:4989"
-		srv, err := labeling.NewServer(db, cs, "data/labelmaker/labelmaker.key", repoDid, repoHandle, bgsUrl)
+		//plcUrl := "https://plc.directory"
+		plcUrl := "http://localhost:2582"
+		srv, err := labeling.NewServer(db, cs, "data/labelmaker/labelmaker.key", repoDid, repoHandle, bgsUrl, plcUrl)
 		if err != nil {
 			return err
 		}

--- a/cmd/labelmaker/main.go
+++ b/cmd/labelmaker/main.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"os"
+
+	"github.com/bluesky-social/indigo/api"
+	"github.com/bluesky-social/indigo/carstore"
+	"github.com/bluesky-social/indigo/pds"
+	"github.com/bluesky-social/indigo/plc"
+	"github.com/urfave/cli/v2"
+	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/jaeger"
+	"go.opentelemetry.io/otel/sdk/resource"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	"gorm.io/plugin/opentelemetry/tracing"
+)
+
+func main() {
+	app := cli.NewApp()
+
+	app.Flags = []cli.Flag{
+		&cli.BoolFlag{
+			Name: "jaeger",
+		},
+		&cli.BoolFlag{
+			// Temp flag for testing, eventually will just pass db connection strings here
+			Name: "postgres",
+		},
+		&cli.BoolFlag{
+			Name: "dbtracing",
+		},
+		&cli.StringFlag{
+			Name:  "labelmakerhost",
+			Usage: "hostname of the labelmaker",
+			Value: "localhost:2210",
+		},
+		&cli.StringFlag{
+			Name:  "plc",
+			Usage: "hostname of the plc",
+		},
+	}
+
+	app.Action = func(cctx *cli.Context) error {
+
+		if cctx.Bool("jaeger") {
+			url := "http://localhost:14268/api/traces"
+			exp, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(url)))
+			if err != nil {
+				return err
+			}
+			tp := tracesdk.NewTracerProvider(
+				// Always be sure to batch in production.
+				tracesdk.WithBatcher(exp),
+				// Record information about this application in a Resource.
+				tracesdk.WithResource(resource.NewWithAttributes(
+					semconv.SchemaURL,
+					semconv.ServiceNameKey.String("labelmaker"),
+					attribute.String("environment", "test"),
+					attribute.Int64("ID", 1),
+				)),
+			)
+
+			otel.SetTracerProvider(tp)
+		}
+
+		pgdb := cctx.Bool("postgres")
+		dbtracing := cctx.Bool("dbtracing")
+
+		// ensure data directory exists; won't error if it does
+		os.MkdirAll("data/labelmaker/", os.ModePerm)
+
+		var pdsdial gorm.Dialector
+		if pgdb {
+			dsn := "host=localhost user=postgres password=password dbname=pdsdb port=5432 sslmode=disable"
+			pdsdial = postgres.Open(dsn)
+		} else {
+			pdsdial = sqlite.Open("data/labelmaker/pds.sqlite")
+		}
+		db, err := gorm.Open(pdsdial, &gorm.Config{})
+		if err != nil {
+			return err
+		}
+
+		if dbtracing {
+			if err := db.Use(tracing.NewPlugin()); err != nil {
+				return err
+			}
+		}
+
+		var cardial gorm.Dialector
+		if pgdb {
+			dsn2 := "host=localhost user=postgres password=password dbname=cardb port=5432 sslmode=disable"
+			cardial = postgres.Open(dsn2)
+		} else {
+			cardial = sqlite.Open("data/labelmaker/carstore.sqlite")
+		}
+		carstdb, err := gorm.Open(cardial, &gorm.Config{})
+		if err != nil {
+			return err
+		}
+
+		if dbtracing {
+			if err := carstdb.Use(tracing.NewPlugin()); err != nil {
+				return err
+			}
+		}
+
+		cs, err := carstore.NewCarStore(carstdb, "data/labelmaker/carstore")
+		if err != nil {
+			return err
+		}
+
+		var didr plc.PLCClient
+		if plchost := cctx.String("plc"); plchost != "" {
+			didr = &api.PLCServer{Host: plchost}
+		} else {
+			didr = plc.NewFakeDid(db)
+		}
+
+		labelmakerhost := cctx.String("labelmakerhost")
+		srv, err := pds.NewServer(db, cs, "data/labelmaker/labelmaker.key", ".labelmakertest", labelmakerhost, didr, []byte("jwtsecretplaceholder"))
+		if err != nil {
+			return err
+		}
+
+		return srv.RunAPI(":2210")
+	}
+
+	app.RunAndExitOnError()
+}

--- a/cmd/labelmaker/main.go
+++ b/cmd/labelmaker/main.go
@@ -112,11 +112,10 @@ func main() {
 			return err
 		}
 
-		//labelmakerhost := cctx.String("labelmakerhost")
 		repoDid := "did:plc:FAKE"
 		repoHandle := "labelmaker.test"
-		//bgsUrl := "ws://localhost:2470/events"
-		//bgsUrl := "ws://[::1]:4989/events"
+		// NOTE: connecting to PDS for now, not actual BGS
+		//bgsUrl := "localhost:2470"
 		bgsUrl := "localhost:4989"
 		srv, err := labeling.NewServer(db, cs, "data/labelmaker/labelmaker.key", repoDid, repoHandle, bgsUrl)
 		if err != nil {

--- a/events/cbor_gen.go
+++ b/events/cbor_gen.go
@@ -1024,3 +1024,493 @@ func (t *ErrorFrame) UnmarshalCBOR(r io.Reader) (err error) {
 
 	return nil
 }
+func (t *Label) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write([]byte{167}); err != nil {
+		return err
+	}
+
+	// t.Timestamp (string) (string)
+	if len("ts") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ts\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("ts"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ts")); err != nil {
+		return err
+	}
+
+	if len(t.Timestamp) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field t.Timestamp was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Timestamp))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string(t.Timestamp)); err != nil {
+		return err
+	}
+
+	// t.SubjectCid (string) (string)
+	if len("cid") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"cid\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("cid"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("cid")); err != nil {
+		return err
+	}
+
+	if t.SubjectCid == nil {
+		if _, err := cw.Write(cbg.CborNull); err != nil {
+			return err
+		}
+	} else {
+		if len(*t.SubjectCid) > cbg.MaxLength {
+			return xerrors.Errorf("Value in field t.SubjectCid was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.SubjectCid))); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(w, string(*t.SubjectCid)); err != nil {
+			return err
+		}
+	}
+
+	// t.SourceDid (string) (string)
+	if len("src") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"src\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("src"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("src")); err != nil {
+		return err
+	}
+
+	if len(t.SourceDid) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field t.SourceDid was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.SourceDid))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string(t.SourceDid)); err != nil {
+		return err
+	}
+
+	// t.SubjectUri (string) (string)
+	if len("uri") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"uri\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("uri"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("uri")); err != nil {
+		return err
+	}
+
+	if len(t.SubjectUri) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field t.SubjectUri was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.SubjectUri))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string(t.SubjectUri)); err != nil {
+		return err
+	}
+
+	// t.Value (string) (string)
+	if len("val") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"val\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("val"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("val")); err != nil {
+		return err
+	}
+
+	if len(t.Value) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field t.Value was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Value))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string(t.Value)); err != nil {
+		return err
+	}
+
+	// t.LexiconTypeID (string) (string)
+	if len("$type") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"$type\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("$type"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("$type")); err != nil {
+		return err
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("app.bsky.label.label"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("app.bsky.label.label")); err != nil {
+		return err
+	}
+
+	// t.LabelUri (string) (string)
+	if len("labeluri") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"labeluri\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("labeluri"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("labeluri")); err != nil {
+		return err
+	}
+
+	if t.LabelUri == nil {
+		if _, err := cw.Write(cbg.CborNull); err != nil {
+			return err
+		}
+	} else {
+		if len(*t.LabelUri) > cbg.MaxLength {
+			return xerrors.Errorf("Value in field t.LabelUri was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.LabelUri))); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(w, string(*t.LabelUri)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *Label) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = Label{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("Label: map struct too large (%d)", extra)
+	}
+
+	var name string
+	n := extra
+
+	for i := uint64(0); i < n; i++ {
+
+		{
+			sval, err := cbg.ReadString(cr)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
+		}
+
+		switch name {
+		// t.Timestamp (string) (string)
+		case "ts":
+
+			{
+				sval, err := cbg.ReadString(cr)
+				if err != nil {
+					return err
+				}
+
+				t.Timestamp = string(sval)
+			}
+			// t.SubjectCid (string) (string)
+		case "cid":
+
+			{
+				b, err := cr.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := cr.UnreadByte(); err != nil {
+						return err
+					}
+
+					sval, err := cbg.ReadString(cr)
+					if err != nil {
+						return err
+					}
+
+					t.SubjectCid = (*string)(&sval)
+				}
+			}
+			// t.SourceDid (string) (string)
+		case "src":
+
+			{
+				sval, err := cbg.ReadString(cr)
+				if err != nil {
+					return err
+				}
+
+				t.SourceDid = string(sval)
+			}
+			// t.SubjectUri (string) (string)
+		case "uri":
+
+			{
+				sval, err := cbg.ReadString(cr)
+				if err != nil {
+					return err
+				}
+
+				t.SubjectUri = string(sval)
+			}
+			// t.Value (string) (string)
+		case "val":
+
+			{
+				sval, err := cbg.ReadString(cr)
+				if err != nil {
+					return err
+				}
+
+				t.Value = string(sval)
+			}
+			// t.LexiconTypeID (string) (string)
+		case "$type":
+
+			{
+				sval, err := cbg.ReadString(cr)
+				if err != nil {
+					return err
+				}
+
+				t.LexiconTypeID = string(sval)
+			}
+			// t.LabelUri (string) (string)
+		case "labeluri":
+
+			{
+				b, err := cr.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := cr.UnreadByte(); err != nil {
+						return err
+					}
+
+					sval, err := cbg.ReadString(cr)
+					if err != nil {
+						return err
+					}
+
+					t.LabelUri = (*string)(&sval)
+				}
+			}
+
+		default:
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(r, func(cid.Cid) {})
+		}
+	}
+
+	return nil
+}
+func (t *LabelEvent) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write([]byte{162}); err != nil {
+		return err
+	}
+
+	// t.Seq (int64) (int64)
+	if len("seq") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"seq\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("seq"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("seq")); err != nil {
+		return err
+	}
+
+	if t.Seq >= 0 {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Seq)); err != nil {
+			return err
+		}
+	} else {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Seq-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.Labels ([]events.Label) (slice)
+	if len("labels") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"labels\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("labels"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("labels")); err != nil {
+		return err
+	}
+
+	if len(t.Labels) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Labels was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Labels))); err != nil {
+		return err
+	}
+	for _, v := range t.Labels {
+		if err := v.MarshalCBOR(cw); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *LabelEvent) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = LabelEvent{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("LabelEvent: map struct too large (%d)", extra)
+	}
+
+	var name string
+	n := extra
+
+	for i := uint64(0); i < n; i++ {
+
+		{
+			sval, err := cbg.ReadString(cr)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
+		}
+
+		switch name {
+		// t.Seq (int64) (int64)
+		case "seq":
+			{
+				maj, extra, err := cr.ReadHeader()
+				var extraI int64
+				if err != nil {
+					return err
+				}
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative overflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				t.Seq = int64(extraI)
+			}
+			// t.Labels ([]events.Label) (slice)
+		case "labels":
+
+			maj, extra, err = cr.ReadHeader()
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.MaxLength {
+				return fmt.Errorf("t.Labels: array too large (%d)", extra)
+			}
+
+			if maj != cbg.MajArray {
+				return fmt.Errorf("expected cbor array")
+			}
+
+			if extra > 0 {
+				t.Labels = make([]Label, extra)
+			}
+
+			for i := 0; i < int(extra); i++ {
+
+				var v Label
+				if err := v.UnmarshalCBOR(cr); err != nil {
+					return err
+				}
+
+				t.Labels[i] = v
+			}
+
+		default:
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(r, func(cid.Cid) {})
+		}
+	}
+
+	return nil
+}

--- a/events/cbor_gen.go
+++ b/events/cbor_gen.go
@@ -1351,7 +1351,7 @@ func (t *Label) UnmarshalCBOR(r io.Reader) (err error) {
 
 	return nil
 }
-func (t *LabelEvent) MarshalCBOR(w io.Writer) error {
+func (t *LabelBatch) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -1412,8 +1412,8 @@ func (t *LabelEvent) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *LabelEvent) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = LabelEvent{}
+func (t *LabelBatch) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = LabelBatch{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -1432,7 +1432,7 @@ func (t *LabelEvent) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("LabelEvent: map struct too large (%d)", extra)
+		return fmt.Errorf("LabelBatch: map struct too large (%d)", extra)
 	}
 
 	var name string

--- a/events/label_events.go
+++ b/events/label_events.go
@@ -1,0 +1,151 @@
+package events
+
+import (
+	"fmt"
+)
+
+type LabelEventManager struct {
+	subs []*LabelSubscriber
+
+	ops        chan *LabelOperation
+	closed     chan struct{}
+	bufferSize int
+
+	persister LabelEventPersistence
+}
+
+func NewLabelEventManager() *LabelEventManager {
+	return &LabelEventManager{
+		ops:        make(chan *LabelOperation),
+		closed:     make(chan struct{}),
+		bufferSize: 1024,
+		persister:  NewMemLabelPersister(),
+	}
+}
+
+type LabelOperation struct {
+	op  int
+	sub *LabelSubscriber
+	evt *LabelEvent
+}
+
+func (em *LabelEventManager) Run() {
+	for op := range em.ops {
+		switch op.op {
+		case opSubscribe:
+			em.subs = append(em.subs, op.sub)
+			op.sub.outgoing <- &LabelEvent{}
+		case opUnsubscribe:
+			for i, s := range em.subs {
+				if s == op.sub {
+					em.subs[i] = em.subs[len(em.subs)-1]
+					em.subs = em.subs[:len(em.subs)-1]
+					break
+				}
+			}
+		case opSend:
+			em.persister.Persist(op.evt)
+
+			for _, s := range em.subs {
+				if s.filter(op.evt) {
+					select {
+					case s.outgoing <- op.evt:
+					default:
+						log.Error("event overflow")
+					}
+				}
+			}
+		default:
+			log.Errorf("unrecognized eventmgr operation: %d", op.op)
+		}
+	}
+}
+
+type LabelSubscriber struct {
+	outgoing chan *LabelEvent
+
+	filter func(*LabelEvent) bool
+
+	done chan struct{}
+}
+
+type LabelEvent struct {
+	Seq    int64   `cborgen:"seq"`
+	Labels []Label `cborgen:"labels"`
+}
+
+// this is here, instead of under 'labeling' package, to avoid an import loop
+type Label struct {
+	LexiconTypeID string  `json:"$type" cborgen:"$type,const=app.bsky.label.label"`
+	SourceDid     string  `json:"src" cborgen:"src"`
+	SubjectUri    string  `json:"uri" cborgen:"uri"`
+	SubjectCid    *string `json:"cid,omitempty" cborgen:"cid"`
+	Value         string  `json:"val" cborgen:"val"`
+	Timestamp     string  `json:"ts" cborgen:"ts"` // TODO: actual timestamp?
+	LabelUri      *string `json:"labeluri,omitempty" cborgen:"labeluri"`
+}
+
+func (em *LabelEventManager) AddEvent(ev *LabelEvent) error {
+	select {
+	case em.ops <- &LabelOperation{
+		op:  opSend,
+		evt: ev,
+	}:
+		return nil
+	case <-em.closed:
+		return fmt.Errorf("event manager shut down")
+	}
+}
+
+func (em *LabelEventManager) Subscribe(filter func(*LabelEvent) bool, since *int64) (<-chan *LabelEvent, func(), error) {
+	if filter == nil {
+		filter = func(*LabelEvent) bool { return true }
+	}
+
+	done := make(chan struct{})
+	sub := &LabelSubscriber{
+		outgoing: make(chan *LabelEvent, em.bufferSize),
+		filter:   filter,
+		done:     done,
+	}
+
+	select {
+	case em.ops <- &LabelOperation{
+		op:  opSubscribe,
+		sub: sub,
+	}:
+	case <-em.closed:
+		return nil, nil, fmt.Errorf("event manager shut down")
+	}
+
+	// receive the 'ack' that ensures our sub was received
+	<-sub.outgoing
+
+	if since != nil {
+		go func() {
+			if err := em.persister.Playback(*since, func(e *LabelEvent) error {
+				select {
+				case <-done:
+					return fmt.Errorf("shutting down")
+				case sub.outgoing <- e:
+					return nil
+				}
+			}); err != nil {
+				log.Errorf("events playback: %s", err)
+			}
+		}()
+	}
+
+	cleanup := func() {
+		close(done)
+		select {
+		case em.ops <- &LabelOperation{
+			op:  opUnsubscribe,
+			sub: sub,
+		}:
+		case <-em.closed:
+		}
+	}
+
+	return sub.outgoing, cleanup, nil
+}

--- a/events/label_persist.go
+++ b/events/label_persist.go
@@ -1,0 +1,47 @@
+package events
+
+import "sync"
+
+type LabelEventPersistence interface {
+	Persist(e *LabelEvent)
+	Playback(since int64, cb func(*LabelEvent) error) error
+}
+
+// MemLabelPersister is the most naive implementation of event persistence
+// ill do better later
+type MemLabelPersister struct {
+	buf []*LabelEvent
+	lk  sync.Mutex
+	seq int64
+}
+
+func NewMemLabelPersister() *MemLabelPersister {
+	return &MemLabelPersister{}
+}
+
+func (mp *MemLabelPersister) Persist(e *LabelEvent) {
+	mp.lk.Lock()
+	defer mp.lk.Unlock()
+	mp.seq++
+	e.Seq = mp.seq
+	mp.buf = append(mp.buf, e)
+}
+
+func (mp *MemLabelPersister) Playback(since int64, cb func(*LabelEvent) error) error {
+	mp.lk.Lock()
+	l := len(mp.buf)
+	mp.lk.Unlock()
+
+	if since >= int64(l) {
+		return nil
+	}
+
+	// TODO: abusing the fact that buf[0].seq is currently always 1
+	for _, e := range mp.buf[since:l] {
+		if err := cb(e); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/gen/main.go
+++ b/gen/main.go
@@ -36,7 +36,7 @@ func main() {
 		panic(err)
 	}
 
-	if err := cbg.WriteMapEncodersToFile("events/cbor_gen.go", "events", events.EventHeader{}, events.RepoAppend{}, events.RepoOp{}, events.InfoFrame{}, events.ErrorFrame{}, events.Label{}, events.LabelEvent{}); err != nil {
+	if err := cbg.WriteMapEncodersToFile("events/cbor_gen.go", "events", events.EventHeader{}, events.RepoAppend{}, events.RepoOp{}, events.InfoFrame{}, events.ErrorFrame{}, events.Label{}, events.LabelBatch{}); err != nil {
 		panic(err)
 	}
 }

--- a/gen/main.go
+++ b/gen/main.go
@@ -36,7 +36,7 @@ func main() {
 		panic(err)
 	}
 
-	if err := cbg.WriteMapEncodersToFile("events/cbor_gen.go", "events", events.EventHeader{}, events.RepoAppend{}, events.RepoOp{}, events.InfoFrame{}, events.ErrorFrame{}); err != nil {
+	if err := cbg.WriteMapEncodersToFile("events/cbor_gen.go", "events", events.EventHeader{}, events.RepoAppend{}, events.RepoOp{}, events.InfoFrame{}, events.ErrorFrame{}, events.Label{}, events.LabelEvent{}); err != nil {
 		panic(err)
 	}
 }

--- a/labeling/labelers.go
+++ b/labeling/labelers.go
@@ -3,16 +3,15 @@ package labeling
 import (
 	"strings"
 
-	"github.com/bluesky-social/indigo/api"
-	bskyapi "github.com/bluesky-social/indigo/api/bsky"
+	bsky "github.com/bluesky-social/indigo/api/bsky"
 )
 
 // simple record labeling (without pre-fetched blobs)
 type SimplePostLabeler interface {
-	labelPost(p api.PostRecord) []string
+	labelPost(p bsky.FeedPost) []string
 }
 type SimpleActorProfileLabeler interface {
-	labelActorProfile(ap bskyapi.ActorProfile) []string
+	labelActorProfile(ap bsky.ActorProfile) []string
 }
 
 type KeywordLabeler struct {
@@ -30,11 +29,11 @@ func (kl KeywordLabeler) labelText(txt string) []string {
 	return []string{}
 }
 
-func (kl KeywordLabeler) labelPost(p api.PostRecord) []string {
+func (kl KeywordLabeler) labelPost(p bsky.FeedPost) []string {
 	return kl.labelText(p.Text)
 }
 
-func (kl KeywordLabeler) labelActorProfile(ap bskyapi.ActorProfile) []string {
+func (kl KeywordLabeler) labelActorProfile(ap bsky.ActorProfile) []string {
 	txt := ap.DisplayName
 	if ap.Description != nil {
 		txt += *ap.Description

--- a/labeling/labelers.go
+++ b/labeling/labelers.go
@@ -1,0 +1,43 @@
+package labeling
+
+import (
+	"strings"
+
+	"github.com/bluesky-social/indigo/api"
+	bskyapi "github.com/bluesky-social/indigo/api/bsky"
+)
+
+// simple record labeling (without pre-fetched blobs)
+type SimplePostLabeler interface {
+	labelPost(p api.PostRecord) []string
+}
+type SimpleActorProfileLabeler interface {
+	labelActorProfile(ap bskyapi.ActorProfile) []string
+}
+
+type KeywordLabeler struct {
+	keywords []string
+	value    string
+}
+
+func (kl KeywordLabeler) labelText(txt string) []string {
+	txt = strings.ToLower(txt)
+	for _, word := range kl.keywords {
+		if strings.Contains(txt, word) {
+			return []string{kl.value}
+		}
+	}
+	return []string{}
+}
+
+func (kl KeywordLabeler) labelPost(p api.PostRecord) []string {
+	return kl.labelText(p.Text)
+}
+
+func (kl KeywordLabeler) labelActorProfile(ap bskyapi.ActorProfile) []string {
+	txt := ap.DisplayName
+	if ap.Description != nil {
+		txt += *ap.Description
+	}
+	return kl.labelText(txt)
+}

--- a/labeling/labelers_test.go
+++ b/labeling/labelers_test.go
@@ -5,20 +5,19 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/bluesky-social/indigo/api"
-	bskyapi "github.com/bluesky-social/indigo/api/bsky"
+	bsky "github.com/bluesky-social/indigo/api/bsky"
 )
 
 func TestKeywordFilter(t *testing.T) {
 	var kl = KeywordLabeler{value: "rude", keywords: []string{"🍆", "sex"}}
 
 	postCases := []struct {
-		record   api.PostRecord
+		record   bsky.FeedPost
 		expected []string
 	}{
-		{api.PostRecord{Text: "boring inoffensive tweet"}, []string{}},
-		{api.PostRecord{Text: "I love Aubergine 🍆"}, []string{"rude"}},
-		{api.PostRecord{Text: "SeXyTiMe"}, []string{"rude"}},
+		{bsky.FeedPost{Text: "boring inoffensive tweet"}, []string{}},
+		{bsky.FeedPost{Text: "I love Aubergine 🍆"}, []string{"rude"}},
+		{bsky.FeedPost{Text: "SeXyTiMe"}, []string{"rude"}},
 	}
 
 	for _, c := range postCases {
@@ -32,13 +31,13 @@ func TestKeywordFilter(t *testing.T) {
 	var desc = "yadda yadda"
 	var descRude = "yadda yadda 🍆"
 	profileCases := []struct {
-		record   bskyapi.ActorProfile
+		record   bsky.ActorProfile
 		expected []string
 	}{
-		{bskyapi.ActorProfile{DisplayName: "Robyn Hood"}, []string{}},
-		{bskyapi.ActorProfile{DisplayName: "Robyn Hood", Description: &desc}, []string{}},
-		{bskyapi.ActorProfile{DisplayName: "Robyn Hood", Description: &descRude}, []string{"rude"}},
-		{bskyapi.ActorProfile{DisplayName: "Sexy Robyn Hood"}, []string{"rude"}},
+		{bsky.ActorProfile{DisplayName: "Robyn Hood"}, []string{}},
+		{bsky.ActorProfile{DisplayName: "Robyn Hood", Description: &desc}, []string{}},
+		{bsky.ActorProfile{DisplayName: "Robyn Hood", Description: &descRude}, []string{"rude"}},
+		{bsky.ActorProfile{DisplayName: "Sexy Robyn Hood"}, []string{"rude"}},
 	}
 
 	for _, c := range profileCases {

--- a/labeling/labelers_test.go
+++ b/labeling/labelers_test.go
@@ -1,0 +1,51 @@
+package labeling
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/bluesky-social/indigo/api"
+	bskyapi "github.com/bluesky-social/indigo/api/bsky"
+)
+
+func TestKeywordFilter(t *testing.T) {
+	var kl = KeywordLabeler{value: "rude", keywords: []string{"🍆", "sex"}}
+
+	postCases := []struct {
+		record   api.PostRecord
+		expected []string
+	}{
+		{api.PostRecord{Text: "boring inoffensive tweet"}, []string{}},
+		{api.PostRecord{Text: "I love Aubergine 🍆"}, []string{"rude"}},
+		{api.PostRecord{Text: "SeXyTiMe"}, []string{"rude"}},
+	}
+
+	for _, c := range postCases {
+		vals := kl.labelPost(c.record)
+		if !reflect.DeepEqual(vals, c.expected) {
+			t.Log(fmt.Sprintf("labels expected:%s got:%s", c.expected, vals))
+			t.Fail()
+		}
+	}
+
+	var desc = "yadda yadda"
+	var descRude = "yadda yadda 🍆"
+	profileCases := []struct {
+		record   bskyapi.ActorProfile
+		expected []string
+	}{
+		{bskyapi.ActorProfile{DisplayName: "Robyn Hood"}, []string{}},
+		{bskyapi.ActorProfile{DisplayName: "Robyn Hood", Description: &desc}, []string{}},
+		{bskyapi.ActorProfile{DisplayName: "Robyn Hood", Description: &descRude}, []string{"rude"}},
+		{bskyapi.ActorProfile{DisplayName: "Sexy Robyn Hood"}, []string{"rude"}},
+	}
+
+	for _, c := range profileCases {
+		vals := kl.labelActorProfile(c.record)
+		if !reflect.DeepEqual(vals, c.expected) {
+			t.Log(fmt.Sprintf("labels expected:%s got:%s", c.expected, vals))
+			t.Fail()
+		}
+	}
+}

--- a/labeling/service.go
+++ b/labeling/service.go
@@ -1,0 +1,283 @@
+package labeling
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"os"
+	"time"
+
+	//"github.com/bluesky-social/indigo/api"
+	bsky "github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/indigo/carstore"
+	"github.com/bluesky-social/indigo/events"
+	"github.com/bluesky-social/indigo/key"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
+	"github.com/bluesky-social/indigo/pds"
+	"github.com/bluesky-social/indigo/repo"
+	"github.com/bluesky-social/indigo/repomgr"
+	util "github.com/bluesky-social/indigo/util"
+
+	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/lestrrat-go/jwx/jwa"
+	jwk "github.com/lestrrat-go/jwx/jwk"
+	"gorm.io/gorm"
+)
+
+var log = logging.Logger("labelmaker")
+
+type Server struct {
+	db         *gorm.DB
+	cs         *carstore.CarStore
+	repoman    *repomgr.RepoManager
+	bgsSlurper *pds.Slurper
+	levents    *events.LabelEventManager
+	echo       *echo.Echo
+	user       *LabelmakerRepoConfig
+	kwl        []KeywordLabeler
+}
+
+type LabelmakerRepoConfig struct {
+	handle     string
+	did        string
+	signingKey *key.Key
+	userId     uint
+}
+
+func NewServer(db *gorm.DB, cs *carstore.CarStore, keyFile, repoDid, repoHandle, bgsUrl string) (*Server, error) {
+
+	serkey, err := loadKey(keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	db.AutoMigrate(&pds.User{})
+	db.AutoMigrate(&pds.Peering{})
+
+	levtman := events.NewLabelEventManager()
+	repoman := repomgr.NewRepoManager(db, cs)
+
+	user := &LabelmakerRepoConfig{
+		handle:     repoHandle,
+		did:        repoDid,
+		signingKey: serkey,
+		userId:     1,
+	}
+
+	var kl = KeywordLabeler{value: "rude", keywords: []string{"🍆", "sex", "ab"}}
+
+	// TODO: also do outgoing repo events?
+	s := &Server{
+		db:      db,
+		repoman: repoman,
+		levents: levtman,
+		user:    user,
+		kwl:     []KeywordLabeler{kl},
+		// sluper configured below
+	}
+
+	// ensure that local labelmaker repo exists
+	// NOTE: doesn't need to have app.bsky profile and actor config, this is just expedient (reusing helper)
+	ctx := context.Background()
+	head, _ := s.repoman.GetRepoRoot(ctx, s.user.userId)
+	if head == cid.Undef {
+		log.Info("initializing labelmaker repo")
+		if err := s.repoman.InitNewActor(ctx, s.user.userId, s.user.handle, s.user.did, "Label Maker", pds.UserActorDeclCid, pds.UserActorDeclType); err != nil {
+			return nil, fmt.Errorf("creating labelmaker repo: %w", err)
+		}
+	} else {
+		log.Infof("found labelmaker repo: %s", head)
+	}
+
+	// ensure that we can "peer" with upstream BGS
+	// TODO: rip out this peering stuff (?)
+	bgsPeering := pds.Peering{
+		Host: bgsUrl,
+		// TODO: remote did?
+		Did:      repoDid,
+		Approved: true,
+	}
+	if err := s.db.Create(&bgsPeering).Error; err != nil {
+		return nil, err
+	}
+
+	slurp := pds.NewSlurper(s.handleBgsRepoEvent, db, s.user.signingKey)
+	s.bgsSlurper = &slurp
+
+	// subscribe our RepoEvent slurper to the BGS, to receive incoming records for labeler
+	s.bgsSlurper.SubscribeToPds(ctx, bgsUrl)
+
+	// TODO: this is where.... outgoing RepoEvents could be generated?
+	// should skip indexing (we are not a PDS) and just ship out repo event stream
+	/*
+		repoman.SetEventHandler(func(ctx context.Context, evt *repomgr.RepoEvent) {
+			if err := ix.HandleRepoEvent(ctx, evt); err != nil {
+				log.Errorw("handle repo event failed", "user", evt.User, "err", err)
+			}
+		})
+	*/
+
+	go levtman.Run()
+
+	return s, nil
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.echo.Shutdown(ctx)
+}
+
+// incoming repo events
+func (s *Server) handleBgsRepoEvent(ctx context.Context, host *pds.Peering, evt *events.RepoEvent) error {
+	log.Info("got RepoEvent from BGS")
+	now := time.Now().Format(util.ISO8601)
+	switch {
+	case evt.RepoAppend != nil:
+		if evt.RepoAppend.Rebase {
+			// TODO: guess we could label the whole repo here, or something?
+			log.Warn("TODO: rebase events not yet labeled/handled in any special way")
+		}
+		// this is where we take incoming RepoEvents and label them
+		// TODO: extract new/updated records and paths
+		// TODO: use an in-memory blockstore with repo wrapper to parse CAR?
+		// TODO: refactor to parse opes first, so we don't bother parsing the CAR if there are no posts/profiles to handle
+		sliceRepo, err := repo.ReadRepoFromCar(ctx, bytes.NewReader(evt.RepoAppend.Car))
+		if err != nil {
+			log.Warnw("failed to parse CAR slice", "repoErr", err)
+			return err
+		}
+		var labels []events.Label = []events.Label{}
+		for _, op := range evt.RepoAppend.Ops {
+			uri := "at://" + evt.Repo + "/" + op.Col + "/" + op.Rkey
+			// TODO: how do I switch on a tuple here in golang, instead of nested switch?
+			// filter to creation/update of ony post/profile records
+			switch op.Kind {
+			case "createRecord", "updateRecord":
+				switch op.Col {
+				case "app.bsky.feed.post":
+					cid, rec, err := sliceRepo.GetRecord(ctx, op.Col+"/"+op.Rkey)
+					if err != nil {
+						return fmt.Errorf("post record not in CAR slice: %s", uri)
+					}
+					cidStr := cid.String()
+					//post, suc := rec.(*api.PostRecord)
+					post, suc := rec.(*bsky.FeedPost)
+					if !suc {
+						return fmt.Errorf("post record failed to deserialize from CBOR: %s", rec)
+						//return fmt.Errorf("post record failed to deserialize from CBOR: %w", suc)
+					}
+					// run through all the keyword labelers on posts, saving any resulting labels
+					for _, labeler := range s.kwl {
+						for _, val := range labeler.labelPost(*post) {
+							labels = append(labels, events.Label{
+								SourceDid:  s.user.did,
+								SubjectUri: uri,
+								SubjectCid: &cidStr,
+								Value:      val,
+								Timestamp:  now,
+							})
+						}
+					}
+				case "app.bsky.actor.profile":
+					// TODO: handle profile
+					continue
+				default:
+					continue
+				}
+			default:
+				continue
+			}
+		}
+
+		// if any labels generated, persist them to repo...
+		for i, l := range labels {
+			path, _, err := s.repoman.CreateRecord(ctx, s.user.userId, "com.atproto.label.label", &l)
+			if err != nil {
+				return fmt.Errorf("failed to persist label in local repo: %w", err)
+			}
+			labeluri := "at://" + s.user.did + "/" + path
+			labels[i].LabelUri = &labeluri
+			log.Infof("persisted label: %s", labeluri)
+		}
+
+		// ... then re-publish as LabelEvent
+		log.Infof("%s", labels)
+		if len(labels) > 0 {
+			lev := events.LabelEvent{
+				// TODO: what should sequence number be? do I need to record that?
+				Seq:    0,
+				Labels: labels,
+			}
+			err = s.levents.AddEvent(&lev)
+			if err != nil {
+				return fmt.Errorf("failed to publish LabelEvent: %w", err)
+			}
+		}
+		// TODO: update state that we successfully processed the repo event (aka, persist "last" seq)
+		return nil
+	default:
+		return fmt.Errorf("invalid fed event")
+	}
+}
+
+func (s *Server) readRecordFunc(ctx context.Context, user uint, c cid.Cid) (lexutil.CBOR, error) {
+	bs, err := s.cs.ReadOnlySession(user)
+	if err != nil {
+		return nil, err
+	}
+
+	blk, err := bs.Get(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	return lexutil.CborDecodeValue(blk.RawData())
+}
+
+func loadKey(kfile string) (*key.Key, error) {
+	kb, err := os.ReadFile(kfile)
+	if err != nil {
+		return nil, err
+	}
+
+	sk, err := jwk.ParseKey(kb)
+	if err != nil {
+		return nil, err
+	}
+
+	var spk ecdsa.PrivateKey
+	if err := sk.Raw(&spk); err != nil {
+		return nil, err
+	}
+	curve, ok := sk.Get("crv")
+	if !ok {
+		return nil, fmt.Errorf("need a curve set")
+	}
+
+	return &key.Key{
+		Raw:  &spk,
+		Type: string(curve.(jwa.EllipticCurveAlgorithm)),
+	}, nil
+}
+
+func (s *Server) RunAPI(listen string) error {
+	e := echo.New()
+	s.echo = e
+	e.HideBanner = true
+	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
+		Format: "method=${method}, uri=${uri}, status=${status} latency=${latency_human}\n",
+	}))
+
+	e.HTTPErrorHandler = func(err error, ctx echo.Context) {
+		fmt.Printf("HANDLER ERROR: (%s) %s\n", ctx.Path(), err)
+		ctx.Response().WriteHeader(500)
+	}
+
+	s.RegisterHandlersComAtproto(e)
+	e.GET("/events/v0/labels", s.EventsLabelsWebsocket)
+
+	return e.Start(listen)
+}

--- a/labeling/service.go
+++ b/labeling/service.go
@@ -3,31 +3,27 @@ package labeling
 import (
 	"bytes"
 	"context"
-	"crypto/ecdsa"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/bluesky-social/indigo/api"
-	bsky "github.com/bluesky-social/indigo/api/bsky"
+	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/bgs"
 	"github.com/bluesky-social/indigo/carstore"
 	"github.com/bluesky-social/indigo/events"
 	"github.com/bluesky-social/indigo/indexer"
-	lexutil "github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/models"
 	"github.com/bluesky-social/indigo/pds"
 	"github.com/bluesky-social/indigo/repo"
 	"github.com/bluesky-social/indigo/repomgr"
 	util "github.com/bluesky-social/indigo/util"
+	cbg "github.com/whyrusleeping/cbor-gen"
 
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	"github.com/lestrrat-go/jwx/jwa"
-	jwk "github.com/lestrrat-go/jwx/jwk"
 	"github.com/whyrusleeping/go-did"
 	"gorm.io/gorm"
 )
@@ -52,7 +48,9 @@ type LabelmakerRepoConfig struct {
 	userId     util.Uid
 }
 
-func NewServer(db *gorm.DB, cs *carstore.CarStore, keyFile, repoDid, repoHandle, bgsUrl, plcUrl string) (*Server, error) {
+// In addition to configuring the service, will connect to upstream BGS and start processing events. Won't handle HTTP or WebSocket endpoints until RunAPI() is called.
+// 'useWss' is a flag to use SSL for outbound WebSocket connections
+func NewServer(db *gorm.DB, cs *carstore.CarStore, keyFile, repoDid, repoHandle, plcUrl string, useWss bool) (*Server, error) {
 
 	serkey, err := loadKey(keyFile)
 	if err != nil {
@@ -73,7 +71,7 @@ func NewServer(db *gorm.DB, cs *carstore.CarStore, keyFile, repoDid, repoHandle,
 		userId:     1,
 	}
 
-	var kl = KeywordLabeler{value: "rude", keywords: []string{"🍆", "sex", "ab", "before", "yours", "the"}}
+	var kl = KeywordLabeler{value: "meta", keywords: []string{"the", "bluesky", "atproto"}}
 
 	s := &Server{
 		db:      db,
@@ -85,7 +83,7 @@ func NewServer(db *gorm.DB, cs *carstore.CarStore, keyFile, repoDid, repoHandle,
 	}
 
 	// ensure that local labelmaker repo exists
-	// NOTE: doesn't need to have app.bsky profile and actor config, this is just expedient (reusing helper)
+	// NOTE: doesn't need to have app.bsky profile and actor config, this is just expediant (reusing an existing helper function)
 	ctx := context.Background()
 	head, _ := s.repoman.GetRepoRoot(ctx, s.user.userId)
 	if head == cid.Undef {
@@ -97,190 +95,152 @@ func NewServer(db *gorm.DB, cs *carstore.CarStore, keyFile, repoDid, repoHandle,
 		log.Infof("found labelmaker repo: %s", head)
 	}
 
-	// TODO(bnewbold): enforce ssl (last boolean argument here)
-	slurp := bgs.NewSlurper(db, s.handleBgsRepoEvent, false)
+	slurp := bgs.NewSlurper(db, s.handleBgsRepoEvent, useWss)
 	s.bgsSlurper = slurp
-
-	// subscribe our RepoEvent slurper to the BGS, to receive incoming records for labeler
-	useWebsocketSSL := false
-	log.Infof("subscribing to BGS: %s (SSL=%v)", bgsUrl, useWebsocketSSL)
-	s.bgsSlurper.SubscribeToPds(ctx, bgsUrl, useWebsocketSSL)
-
-	// NOTE: this is where outgoing RepoEvents could be generated
-	// should skip indexing (we are not a PDS) and just ship out repo event stream
-	/*
-		repoman.SetEventHandler(func(ctx context.Context, evt *repomgr.RepoEvent) {
-			if err := ix.HandleRepoEvent(ctx, evt); err != nil {
-				log.Errorw("handle repo event failed", "user", evt.User, "err", err)
-			}
-		})
-	*/
 
 	go levtman.Run()
 
 	return s, nil
 }
 
-func (s *Server) Shutdown(ctx context.Context) error {
-	return s.echo.Shutdown(ctx)
+func (s *Server) SubscribeBGS(ctx context.Context, bgsUrl string, useWss bool) {
+	// subscribe our RepoEvent slurper to the BGS, to receive incoming records for labeler
+	log.Infof("subscribing to BGS: %s (SSL=%v)", bgsUrl, useWss)
+	s.bgsSlurper.SubscribeToPds(ctx, bgsUrl, useWss)
 }
 
-// incoming repo events
+// efficiency predicate to quickly discard events we know won't want to even parse
+func (s *Server) wantAnyRecords(ctx context.Context, ra *events.RepoAppend) bool {
+
+	for _, op := range ra.Ops {
+		if op.Action != "create" && op.Action != "update" {
+			continue
+		}
+		nsid := strings.SplitN(op.Path, "/", 2)[0]
+		switch nsid {
+		case "app.bsky.feed.post":
+			return true
+		case "app.bsky.actor.profile":
+			return true
+		default:
+			continue
+		}
+	}
+	return false
+}
+
+func (s *Server) labelRecord(ctx context.Context, did, nsid, uri, cid string, rec cbg.CBORMarshaler) ([]string, error) {
+	log.Infof("labeling record: %v", uri)
+	var labelVals []string
+	switch nsid {
+	case "app.bsky.feed.post":
+		post, suc := rec.(*appbsky.FeedPost)
+		if !suc {
+			return []string{}, fmt.Errorf("record failed to deserialize from CBOR: %s", rec)
+		}
+		// run through all the keyword labelers on posts, saving any resulting labels
+		for _, labeler := range s.kwl {
+			for _, val := range labeler.labelPost(*post) {
+				labelVals = append(labelVals, val)
+			}
+		}
+	case "app.bsky.actor.profile":
+		profile, suc := rec.(*appbsky.ActorProfile)
+		if !suc {
+			return []string{}, fmt.Errorf("record failed to deserialize from CBOR: %s", rec)
+		}
+		// run through all the keyword labelers on posts, saving any resulting labels
+		for _, labeler := range s.kwl {
+			for _, val := range labeler.labelActorProfile(*profile) {
+				labelVals = append(labelVals, val)
+			}
+		}
+	}
+	return labelVals, nil
+}
+
+// Process incoming repo events coming from BGS, which includes new and updated
+// records from any PDS. This function extracts records, handes them to the
+// labeling routine, and then persists and broadcasts any resulting labels
 func (s *Server) handleBgsRepoEvent(ctx context.Context, pds *models.PDS, evt *events.RepoStreamEvent) error {
+
+	if evt.Append == nil {
+		// TODO(bnewbold): is this really invalid? do we need to handle Info and Error events here?
+		return fmt.Errorf("invalid repo append event")
+	}
+
+	// quick check if we can skip processing the CAR slice entirely
+	if !s.wantAnyRecords(ctx, evt.Append) {
+		return nil
+	}
+
+	// use an in-memory blockstore with repo wrapper to parse CAR slice
+	sliceRepo, err := repo.ReadRepoFromCar(ctx, bytes.NewReader(evt.Append.Blocks))
+	if err != nil {
+		log.Warnw("failed to parse CAR slice", "repoErr", err)
+		return err
+	}
+
 	now := time.Now().Format(util.ISO8601)
-	switch {
-	case evt.Append != nil:
-		// this is where we take incoming RepoEvents and label them
-		// use an in-memory blockstore with repo wrapper to parse CAR
-		// NOTE: could refactor to parse ops first, so we don't bother parsing the CAR if there are no posts/profiles to process (a common case, for likes/follows/reposts/etc)
-		sliceRepo, err := repo.ReadRepoFromCar(ctx, bytes.NewReader(evt.Append.Blocks))
+	labels := []events.Label{}
+
+	for _, op := range evt.Append.Ops {
+		uri := "at://" + evt.Append.Repo + "/" + op.Path
+		nsid := strings.SplitN(op.Path, "/", 2)[0]
+
+		if !(op.Action == "create" || op.Action == "update") {
+			continue
+		}
+
+		cid, rec, err := sliceRepo.GetRecord(ctx, op.Path)
 		if err != nil {
-			log.Warnw("failed to parse CAR slice", "repoErr", err)
+			return fmt.Errorf("record not in CAR slice: %s", uri)
+		}
+		cidStr := cid.String()
+		labelVals, err := s.labelRecord(ctx, s.user.did, nsid, uri, cidStr, rec)
+		if err != nil {
 			return err
 		}
-		var labels []events.Label = []events.Label{}
-		for _, op := range evt.Append.Ops {
-			uri := "at://" + evt.Append.Repo + "/" + op.Path
-			nsid := strings.SplitN(op.Path, "/", 2)[0]
-			// filter to creation/update of ony post/profile records
-			// TODO(bnewbold): how do I 'switch' on a tuple here in golang, instead of nested switch?
-			switch op.Action {
-			case "create", "update":
-				log.Infof("labeling record: %v", uri)
-				switch nsid {
-				case "app.bsky.feed.post":
-					cid, rec, err := sliceRepo.GetRecord(ctx, op.Path)
-					if err != nil {
-						return fmt.Errorf("record not in CAR slice: %s", uri)
-					}
-					cidStr := cid.String()
-					post, suc := rec.(*bsky.FeedPost)
-					if !suc {
-						return fmt.Errorf("record failed to deserialize from CBOR: %s", rec)
-					}
-					// run through all the keyword labelers on posts, saving any resulting labels
-					for _, labeler := range s.kwl {
-						for _, val := range labeler.labelPost(*post) {
-							labels = append(labels, events.Label{
-								SourceDid:  s.user.did,
-								SubjectUri: uri,
-								SubjectCid: &cidStr,
-								Value:      val,
-								Timestamp:  now,
-							})
-						}
-					}
-				case "app.bsky.actor.profile":
-					// NOTE: copypasta from post above, could refactor to not duplicate
-					cid, rec, err := sliceRepo.GetRecord(ctx, op.Path)
-					if err != nil {
-						return fmt.Errorf("record not in CAR slice: %s", uri)
-					}
-					cidStr := cid.String()
-					profile, suc := rec.(*bsky.ActorProfile)
-					if !suc {
-						return fmt.Errorf("record failed to deserialize from CBOR: %s", rec)
-					}
-					// run through all the keyword labelers on profiles, saving any resulting labels
-					for _, labeler := range s.kwl {
-						for _, val := range labeler.labelActorProfile(*profile) {
-							labels = append(labels, events.Label{
-								SourceDid:  s.user.did,
-								SubjectUri: uri,
-								SubjectCid: &cidStr,
-								Value:      val,
-								Timestamp:  now,
-							})
-						}
-					}
-				default:
-					continue
-				}
-			default:
-				continue
-			}
+		for _, val := range labelVals {
+			labels = append(labels, events.Label{
+				SourceDid:  s.user.did,
+				SubjectUri: uri,
+				SubjectCid: &cidStr,
+				Value:      val,
+				Timestamp:  now,
+			})
 		}
+	}
 
-		// if any labels generated, persist them to repo...
-		for i, l := range labels {
-			path, _, err := s.repoman.CreateRecord(ctx, s.user.userId, "com.atproto.label.label", &l)
-			if err != nil {
-				return fmt.Errorf("failed to persist label in local repo: %w", err)
-			}
-			labeluri := "at://" + s.user.did + "/" + path
-			labels[i].LabelUri = &labeluri
-			log.Infof("persisted label: %s", labeluri)
+	// if any labels generated, persist them to repo...
+	for i, l := range labels {
+		path, _, err := s.repoman.CreateRecord(ctx, s.user.userId, "com.atproto.label.label", &l)
+		if err != nil {
+			return fmt.Errorf("failed to persist label in local repo: %w", err)
 		}
+		labeluri := "at://" + s.user.did + "/" + path
+		labels[i].LabelUri = &labeluri
+		log.Infof("persisted label: %s", labeluri)
+	}
 
-		// ... then re-publish as LabelStreamEvent
-		log.Infof("%s", labels)
-		if len(labels) > 0 {
-			lev := events.LabelStreamEvent{
-				// XXX(bnewbold): what should sequence number be? do I need to maintain that?
-				Batch: &events.LabelBatch{
-					Seq:    0,
-					Labels: labels,
-				},
-			}
-			err = s.levents.AddEvent(&lev)
-			if err != nil {
-				return fmt.Errorf("failed to publish LabelStreamEvent: %w", err)
-			}
+	// ... then re-publish as LabelStreamEvent
+	log.Infof("%s", labels)
+	if len(labels) > 0 {
+		lev := events.LabelStreamEvent{
+			Batch: &events.LabelBatch{
+				// NOTE(bnewbold): seems like other code handles Seq field automatically
+				Labels: labels,
+			},
 		}
-		// TODO: update state that we successfully processed the repo event (aka, persist "last" seq in database, or something like that)
-		return nil
-	default:
-		return fmt.Errorf("invalid fed event")
+		err = s.levents.AddEvent(&lev)
+		if err != nil {
+			return fmt.Errorf("failed to publish LabelStreamEvent: %w", err)
+		}
 	}
-}
-
-func (s *Server) readRecordFunc(ctx context.Context, user util.Uid, c cid.Cid) (lexutil.CBOR, error) {
-	bs, err := s.cs.ReadOnlySession(user)
-	if err != nil {
-		return nil, err
-	}
-
-	blk, err := bs.Get(ctx, c)
-	if err != nil {
-		return nil, err
-	}
-
-	return lexutil.CborDecodeValue(blk.RawData())
-}
-
-func loadKey(kfile string) (*did.PrivKey, error) {
-	kb, err := os.ReadFile(kfile)
-	if err != nil {
-		return nil, err
-	}
-
-	sk, err := jwk.ParseKey(kb)
-	if err != nil {
-		return nil, err
-	}
-
-	var spk ecdsa.PrivateKey
-	if err := sk.Raw(&spk); err != nil {
-		return nil, err
-	}
-	curve, ok := sk.Get("crv")
-	if !ok {
-		return nil, fmt.Errorf("need a curve set")
-	}
-
-	var out string
-	kts := string(curve.(jwa.EllipticCurveAlgorithm))
-	switch kts {
-	case "P-256":
-		out = did.KeyTypeP256
-	default:
-		return nil, fmt.Errorf("unrecognized key type: %s", kts)
-	}
-
-	return &did.PrivKey{
-		Raw:  &spk,
-		Type: out,
-	}, nil
+	// TODO(bnewbold): persist state that we successfully processed the repo event (aka,
+	// persist "last" seq in database, or something like that). also above, at
+	// the short-circuit
+	return nil
 }
 
 func (s *Server) RunAPI(listen string) error {
@@ -288,16 +248,21 @@ func (s *Server) RunAPI(listen string) error {
 	s.echo = e
 	e.HideBanner = true
 	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
-		Format: "method=${method}, uri=${uri}, status=${status} latency=${latency_human}\n",
+		Format: "method=${method} uri=${uri} status=${status} latency=${latency_human}\n",
 	}))
 
 	e.HTTPErrorHandler = func(err error, ctx echo.Context) {
-		fmt.Printf("HANDLER ERROR: (%s) %s\n", ctx.Path(), err)
+		fmt.Printf("Error at path=%s: %v\n", ctx.Path(), err)
 		ctx.Response().WriteHeader(500)
 	}
 
 	s.RegisterHandlersComAtproto(e)
-	e.GET("/events/v0/labels", s.EventsLabelsWebsocket)
+	// TODO(bnewbold): this is a speculative endpoint name
+	e.GET("/xrpc/com.atproto.label.subscribeAllLabels", s.EventsLabelsWebsocket)
 
 	return e.Start(listen)
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.echo.Shutdown(ctx)
 }

--- a/labeling/util.go
+++ b/labeling/util.go
@@ -1,0 +1,47 @@
+package labeling
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"os"
+
+	"github.com/lestrrat-go/jwx/jwa"
+	jwk "github.com/lestrrat-go/jwx/jwk"
+	"github.com/whyrusleeping/go-did"
+)
+
+// TODO:(bnewbold): duplicates elsewhere; should refactor into cliutil
+func loadKey(kfile string) (*did.PrivKey, error) {
+	kb, err := os.ReadFile(kfile)
+	if err != nil {
+		return nil, err
+	}
+
+	sk, err := jwk.ParseKey(kb)
+	if err != nil {
+		return nil, err
+	}
+
+	var spk ecdsa.PrivateKey
+	if err := sk.Raw(&spk); err != nil {
+		return nil, err
+	}
+	curve, ok := sk.Get("crv")
+	if !ok {
+		return nil, fmt.Errorf("need a curve set")
+	}
+
+	var out string
+	kts := string(curve.(jwa.EllipticCurveAlgorithm))
+	switch kts {
+	case "P-256":
+		out = did.KeyTypeP256
+	default:
+		return nil, fmt.Errorf("unrecognized key type: %s", kts)
+	}
+
+	return &did.PrivKey{
+		Raw:  &spk,
+		Type: out,
+	}, nil
+}

--- a/labeling/ws_endpoints.go
+++ b/labeling/ws_endpoints.go
@@ -32,7 +32,8 @@ func (s *Server) EventsLabelsWebsocket(c echo.Context) error {
 	}
 	defer cancel()
 
-	header := events.EventHeader{Type: "data"}
+	// TODO: Op: events.EvtKindLabel
+	header := events.EventHeader{Op: events.EvtKindRepoAppend}
 	for evt := range evts {
 		wc, err := conn.NextWriter(websocket.BinaryMessage)
 		if err != nil {

--- a/labeling/ws_endpoints.go
+++ b/labeling/ws_endpoints.go
@@ -1,0 +1,56 @@
+package labeling
+
+import (
+	"fmt"
+
+	"github.com/bluesky-social/indigo/events"
+	"github.com/bluesky-social/indigo/pds"
+
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+)
+
+func (s *Server) EventsLabelsWebsocket(c echo.Context) error {
+	did := c.Request().Header.Get("DID")
+	conn, err := websocket.Upgrade(c.Response().Writer, c.Request(), c.Response().Header(), 1<<10, 1<<10)
+	if err != nil {
+		return err
+	}
+
+	var peering pds.Peering
+	if did != "" {
+		if err := s.db.First(&peering, "did = ?", did).Error; err != nil {
+			return err
+		}
+	}
+
+	evts, cancel, err := s.levents.Subscribe(func(evt *events.LabelEvent) bool {
+		return true
+	}, nil)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	header := events.EventHeader{Type: "data"}
+	for evt := range evts {
+		wc, err := conn.NextWriter(websocket.BinaryMessage)
+		if err != nil {
+			return err
+		}
+
+		if err := header.MarshalCBOR(wc); err != nil {
+			return fmt.Errorf("failed to write header: %w", err)
+		}
+
+		if err := evt.MarshalCBOR(wc); err != nil {
+			return fmt.Errorf("failed to write event: %w", err)
+		}
+
+		if err := wc.Close(); err != nil {
+			return fmt.Errorf("failed to flush-close our event write: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/labeling/ws_endpoints.go
+++ b/labeling/ws_endpoints.go
@@ -23,7 +23,6 @@ func (s *Server) EventsLabelsWebsocket(c echo.Context) error {
 
 	ctx := c.Request().Context()
 
-	// TODO: authhhh
 	conn, err := websocket.Upgrade(c.Response().Writer, c.Request(), c.Response().Header(), 1<<10, 1<<10)
 	if err != nil {
 		return fmt.Errorf("upgrading websocket: %w", err)

--- a/labeling/xrpc_endpoints.go
+++ b/labeling/xrpc_endpoints.go
@@ -134,13 +134,14 @@ func (s *Server) HandleComAtprotoSyncGetRepo(c echo.Context) error {
 	ctx, span := otel.Tracer("server").Start(c.Request().Context(), "HandleComAtprotoSyncGetRepo")
 	defer span.End()
 	did := c.QueryParam("did")
-	from := c.QueryParam("from")
+	earliest := c.QueryParam("earliest")
+	latest := c.QueryParam("latest")
 	var out io.Reader
 	var handleErr error
-	// func (s *Server) handleComAtprotoSyncGetRepo(ctx context.Context,did string,from string) (io.Reader, error)
-	out, handleErr = s.handleComAtprotoSyncGetRepo(ctx, did, from)
+	// func (s *Server) handleComAtprotoSyncGetRepo(ctx context.Context,did string,earliest string,latest string) (io.Reader, error)
+	out, handleErr = s.handleComAtprotoSyncGetRepo(ctx, did, earliest, latest)
 	if handleErr != nil {
 		return handleErr
 	}
-	return c.Stream(200, "application/octet-stream", out)
+	return c.Stream(200, "application/vnd.ipld.car", out)
 }

--- a/labeling/xrpc_endpoints.go
+++ b/labeling/xrpc_endpoints.go
@@ -17,9 +17,7 @@ func (s *Server) RegisterHandlersComAtproto(e *echo.Echo) error {
 	e.GET("/xrpc/com.atproto.repo.getRecord", s.HandleComAtprotoRepoGetRecord)
 	e.GET("/xrpc/com.atproto.repo.listRecords", s.HandleComAtprotoRepoListRecords)
 	e.GET("/xrpc/com.atproto.server.getAccountsConfig", s.HandleComAtprotoServerGetAccountsConfig)
-	e.GET("/xrpc/com.atproto.sync.getRepo", s.HandleComAtprotoSyncGetRepo)
-	// TODO(bnewbold): after lexicons updated
-	//e.GET("/xrpc/com.atproto.sync.getHead", s.HandleComAtprotoSyncGetRoot)
+	e.GET("/xrpc/com.atproto.sync.getHead", s.HandleComAtprotoSyncGetHead)
 	return nil
 }
 
@@ -144,4 +142,18 @@ func (s *Server) HandleComAtprotoSyncGetRepo(c echo.Context) error {
 		return handleErr
 	}
 	return c.Stream(200, "application/vnd.ipld.car", out)
+}
+
+func (s *Server) HandleComAtprotoSyncGetHead(c echo.Context) error {
+	ctx, span := otel.Tracer("server").Start(c.Request().Context(), "HandleComAtprotoSyncGetHead")
+	defer span.End()
+	did := c.QueryParam("did")
+	var out *atproto.SyncGetHead_Output
+	var handleErr error
+	// func (s *Server) handleComAtprotoSyncGetHead(ctx context.Context,did string) (*comatprototypes.SyncGetHead_Output, error)
+	out, handleErr = s.handleComAtprotoSyncGetHead(ctx, did)
+	if handleErr != nil {
+		return handleErr
+	}
+	return c.JSON(200, out)
 }

--- a/labeling/xrpc_endpoints.go
+++ b/labeling/xrpc_endpoints.go
@@ -1,0 +1,108 @@
+package labeling
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	atproto "github.com/bluesky-social/indigo/api/atproto"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
+
+	"github.com/ipfs/go-cid"
+	"github.com/labstack/echo/v4"
+	"go.opentelemetry.io/otel"
+)
+
+func (s *Server) RegisterHandlersComAtproto(e *echo.Echo) error {
+	// TODO: which PDS methods need to implemented? some examples below
+	//e.GET("/xrpc/com.atproto.account.get", s.HandleComAtprotoAccountGet)
+	//e.GET("/xrpc/com.atproto.handle.resolve", s.HandleComAtprotoHandleResolve)
+	//e.GET("/xrpc/com.atproto.repo.describe", s.HandleComAtprotoRepoDescribe)
+	e.GET("/xrpc/com.atproto.repo.getRecord", s.HandleComAtprotoRepoGetRecord)
+	//e.GET("/xrpc/com.atproto.repo.listRecords", s.HandleComAtprotoRepoListRecords)
+	//e.GET("/xrpc/com.atproto.server.getAccountsConfig", s.HandleComAtprotoServerGetAccountsConfig)
+	e.GET("/xrpc/com.atproto.sync.getRepo", s.HandleComAtprotoSyncGetRepo)
+	//e.GET("/xrpc/com.atproto.sync.getRoot", s.HandleComAtprotoSyncGetRoot)
+	return nil
+}
+
+func (s *Server) HandleComAtprotoSyncGetRepo(c echo.Context) error {
+	ctx, span := otel.Tracer("server").Start(c.Request().Context(), "HandleComAtprotoSyncGetRepo")
+	defer span.End()
+	did := c.QueryParam("did")
+	from := c.QueryParam("from")
+	var out io.Reader
+	var handleErr error
+	// func (s *Server) handleComAtprotoSyncGetRepo(ctx context.Context,did string,from string) (io.Reader, error)
+	out, handleErr = s.handleComAtprotoSyncGetRepo(ctx, did, from)
+	if handleErr != nil {
+		return handleErr
+	}
+	return c.Stream(200, "application/octet-stream", out)
+}
+
+func (s *Server) handleComAtprotoSyncGetRepo(ctx context.Context, did string, from string) (io.Reader, error) {
+	// TODO: verify the DID/handle
+	var userId uint = 1
+	var fromcid cid.Cid
+	if from != "" {
+		cc, err := cid.Decode(from)
+		if err != nil {
+			return nil, err
+		}
+
+		fromcid = cc
+	}
+
+	buf := new(bytes.Buffer)
+	if err := s.repoman.ReadRepo(ctx, userId, fromcid, buf); err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
+func (s *Server) HandleComAtprotoRepoGetRecord(c echo.Context) error {
+	ctx, span := otel.Tracer("server").Start(c.Request().Context(), "HandleComAtprotoRepoGetRecord")
+	defer span.End()
+	cid := c.QueryParam("cid")
+	collection := c.QueryParam("collection")
+	rkey := c.QueryParam("rkey")
+	user := c.QueryParam("user")
+	var out *atproto.RepoGetRecord_Output
+	var handleErr error
+	// func (s *Server) handleComAtprotoRepoGetRecord(ctx context.Context,cid string,collection string,rkey string,user string) (*comatprototypes.RepoGetRecord_Output, error)
+	out, handleErr = s.handleComAtprotoRepoGetRecord(ctx, cid, collection, rkey, user)
+	if handleErr != nil {
+		return handleErr
+	}
+	return c.JSON(200, out)
+}
+
+func (s *Server) handleComAtprotoRepoGetRecord(ctx context.Context, c string, collection string, rkey string, user string) (*atproto.RepoGetRecord_Output, error) {
+	if user != s.user.did {
+		return nil, fmt.Errorf("unknown user: %s", user)
+	}
+
+	var maybeCid cid.Cid
+	if c != "" {
+		cc, err := cid.Decode(c)
+		if err != nil {
+			return nil, err
+		}
+		maybeCid = cc
+	}
+
+	reccid, rec, err := s.repoman.GetRecord(ctx, s.user.userId, collection, rkey, maybeCid)
+	if err != nil {
+		return nil, fmt.Errorf("repoman GetRecord: %w", err)
+	}
+
+	ccstr := reccid.String()
+	return &atproto.RepoGetRecord_Output{
+		Cid:   &ccstr,
+		Uri:   "at://" + s.user.did + "/" + collection + "/" + rkey,
+		Value: lexutil.LexiconTypeDecoder{rec},
+	}, nil
+}

--- a/labeling/xrpc_handlers.go
+++ b/labeling/xrpc_handlers.go
@@ -18,7 +18,7 @@ func (s *Server) handleComAtprotoAccountGet(ctx context.Context) error {
 }
 
 func (s *Server) handleComAtprotoHandleResolve(ctx context.Context, handle string) (*atproto.HandleResolve_Output, error) {
-	// TODO: only the one handle
+	// only the one handle, for labelmaker
 	if handle == "" {
 		return &atproto.HandleResolve_Output{Did: s.user.signingKey.DID()}, nil
 	} else if handle == s.user.handle {

--- a/labeling/xrpc_handlers.go
+++ b/labeling/xrpc_handlers.go
@@ -103,3 +103,7 @@ func (s *Server) handleComAtprotoRepoGetRecord(ctx context.Context, c string, co
 		Value: lexutil.LexiconTypeDecoder{rec},
 	}, nil
 }
+
+func (s *Server) handleComAtprotoSyncGetHead(ctx context.Context, did string) (*atproto.SyncGetHead_Output, error) {
+	panic("not yet implemented")
+}

--- a/labeling/xrpc_handlers.go
+++ b/labeling/xrpc_handlers.go
@@ -8,6 +8,7 @@ import (
 
 	atproto "github.com/bluesky-social/indigo/api/atproto"
 	lexutil "github.com/bluesky-social/indigo/lex/util"
+	util "github.com/bluesky-social/indigo/util"
 
 	"github.com/ipfs/go-cid"
 )
@@ -47,7 +48,7 @@ func (s *Server) handleComAtprotoServerGetAccountsConfig(ctx context.Context) (*
 
 func (s *Server) handleComAtprotoSyncGetRepo(ctx context.Context, did string, earliest, latest string) (io.Reader, error) {
 	// TODO: verify the DID/handle
-	var userId uint = 1
+	var userId util.Uid = 1
 	var earlyCid cid.Cid
 	if earliest != "" {
 		cc, err := cid.Decode(earliest)

--- a/labeling/xrpc_handlers.go
+++ b/labeling/xrpc_handlers.go
@@ -1,0 +1,94 @@
+package labeling
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	atproto "github.com/bluesky-social/indigo/api/atproto"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
+
+	"github.com/ipfs/go-cid"
+)
+
+func (s *Server) handleComAtprotoAccountGet(ctx context.Context) error {
+	// TODO: implementation
+	return nil
+}
+
+func (s *Server) handleComAtprotoHandleResolve(ctx context.Context, handle string) (*atproto.HandleResolve_Output, error) {
+	// TODO: only the one handle
+	if handle == "" {
+		return &atproto.HandleResolve_Output{Did: s.user.signingKey.DID()}, nil
+	} else if handle == s.user.handle {
+		return &atproto.HandleResolve_Output{Did: s.user.did}, nil
+	} else {
+		return nil, fmt.Errorf("handle not found: %s", handle)
+	}
+}
+
+func (s *Server) handleComAtprotoRepoDescribe(ctx context.Context, user string) (*atproto.RepoDescribe_Output, error) {
+	panic("not yet implemented")
+}
+
+func (s *Server) handleComAtprotoRepoListRecords(ctx context.Context, after string, before string, collection string, limit int, reverse *bool, user string) (*atproto.RepoListRecords_Output, error) {
+	panic("not yet implemented")
+}
+
+func (s *Server) handleComAtprotoServerGetAccountsConfig(ctx context.Context) (*atproto.ServerGetAccountsConfig_Output, error) {
+	invcode := true
+	return &atproto.ServerGetAccountsConfig_Output{
+		InviteCodeRequired:   &invcode,
+		AvailableUserDomains: []string{},
+		Links:                &atproto.ServerGetAccountsConfig_Links{},
+	}, nil
+}
+
+func (s *Server) handleComAtprotoSyncGetRepo(ctx context.Context, did string, from string) (io.Reader, error) {
+	// TODO: verify the DID/handle
+	var userId uint = 1
+	var fromcid cid.Cid
+	if from != "" {
+		cc, err := cid.Decode(from)
+		if err != nil {
+			return nil, err
+		}
+
+		fromcid = cc
+	}
+
+	buf := new(bytes.Buffer)
+	if err := s.repoman.ReadRepo(ctx, userId, fromcid, buf); err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
+func (s *Server) handleComAtprotoRepoGetRecord(ctx context.Context, c string, collection string, rkey string, user string) (*atproto.RepoGetRecord_Output, error) {
+	if user != s.user.did {
+		return nil, fmt.Errorf("unknown user: %s", user)
+	}
+
+	var maybeCid cid.Cid
+	if c != "" {
+		cc, err := cid.Decode(c)
+		if err != nil {
+			return nil, err
+		}
+		maybeCid = cc
+	}
+
+	reccid, rec, err := s.repoman.GetRecord(ctx, s.user.userId, collection, rkey, maybeCid)
+	if err != nil {
+		return nil, fmt.Errorf("repoman GetRecord: %w", err)
+	}
+
+	ccstr := reccid.String()
+	return &atproto.RepoGetRecord_Output{
+		Cid:   &ccstr,
+		Uri:   "at://" + s.user.did + "/" + collection + "/" + rkey,
+		Value: lexutil.LexiconTypeDecoder{rec},
+	}, nil
+}

--- a/labeling/xrpc_handlers.go
+++ b/labeling/xrpc_handlers.go
@@ -20,7 +20,7 @@ func (s *Server) handleComAtprotoAccountGet(ctx context.Context) error {
 func (s *Server) handleComAtprotoHandleResolve(ctx context.Context, handle string) (*atproto.HandleResolve_Output, error) {
 	// only the one handle, for labelmaker
 	if handle == "" {
-		return &atproto.HandleResolve_Output{Did: s.user.signingKey.DID()}, nil
+		return &atproto.HandleResolve_Output{Did: s.user.signingKey.Public().DID()}, nil
 	} else if handle == s.user.handle {
 		return &atproto.HandleResolve_Output{Did: s.user.did}, nil
 	} else {
@@ -45,21 +45,31 @@ func (s *Server) handleComAtprotoServerGetAccountsConfig(ctx context.Context) (*
 	}, nil
 }
 
-func (s *Server) handleComAtprotoSyncGetRepo(ctx context.Context, did string, from string) (io.Reader, error) {
+func (s *Server) handleComAtprotoSyncGetRepo(ctx context.Context, did string, earliest, latest string) (io.Reader, error) {
 	// TODO: verify the DID/handle
 	var userId uint = 1
-	var fromcid cid.Cid
-	if from != "" {
-		cc, err := cid.Decode(from)
+	var earlyCid cid.Cid
+	if earliest != "" {
+		cc, err := cid.Decode(earliest)
 		if err != nil {
 			return nil, err
 		}
 
-		fromcid = cc
+		earlyCid = cc
+	}
+
+	var lateCid cid.Cid
+	if latest != "" {
+		cc, err := cid.Decode(latest)
+		if err != nil {
+			return nil, err
+		}
+
+		lateCid = cc
 	}
 
 	buf := new(bytes.Buffer)
-	if err := s.repoman.ReadRepo(ctx, userId, fromcid, buf); err != nil {
+	if err := s.repoman.ReadRepo(ctx, userId, earlyCid, lateCid, buf); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This is an updated/refactored version of the trivial keyword-based labelmaker. I tested it locally to work directly with Typescript PDS ("subscribeAllRepos"), and can see websocket events coming out of this labelmaker end-to-end.

I'm submitting this for review to @whyrusleeping mostly w/r/t how i'm linking in with existing BGS slurper and events code. Eg, should we refactor the event processing code to be more generic (across repo events and label events)? Especially things like the non-trivial persist implementaitons.

Also, for any feedback on the label event schema.

Things that will happen in next phases (which I will start building on top of this branch this weekend), but not in this PR:

- calls out to APIs during the label process, eg for NSFW image labeling and SQRL integration
- concurrent label processing, especially in the context of API calls
- possibly removing or changing repo persistence of labels. might use an existing PDS implementation for simplicity (and to remove need for a local disk for carstore)
- Lexicon additions
- productionized: docs, Dockerfile, metrics, logging