### PR TITLE
makefile: dev runners; fast `make build`; lexgen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,7 @@ help: ## Print info about all commands
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "    \033[01;32m%-20s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: build
-build: ## Build everything (to Go cache, not binaries)
-	go build ./...
-
-.PHONY: binaries
-binaries: ## Build all executables
+build: ## Build all executables
 	go build ./cmd/gosky
 	go build ./cmd/laputa
 	go build ./cmd/bigsky
@@ -24,9 +20,10 @@ binaries: ## Build all executables
 	go build ./cmd/lexgen
 	go build ./cmd/stress
 	go build ./cmd/fakermaker
+	go build ./cmd/labelmaker
 
 .PHONY: all
-all: binaries
+all: build
 
 .PHONY: test
 test: ## Run all tests
@@ -45,6 +42,10 @@ lint: ## Verify code style and run static checks
 .PHONY: fmt
 fmt: ## Run syntax re-formatting (modify in place)
 	go fmt ./...
+
+.PHONY: check
+check: ## Compile everything, checking syntax (does not output binaries)
+	go build ./...
 
 .PHONY: lexgen
 lexgen: ## Run syntax re-formatting (modify in place)

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,21 @@
 SHELL = /bin/bash
 .SHELLFLAGS = -o pipefail -c
 
+# base path for Lexicon document tree (for lexgen)
+LEXDIR?=../atproto/lexicons
+
 .PHONY: help
 help: ## Print info about all commands
 	@echo "Commands:"
 	@echo
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "    \033[01;32m%-20s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: all
-all: build
-
 .PHONY: build
-build: ## Build all executables
+build: ## Build everything (to Go cache, not binaries)
+	go build ./...
+
+.PHONY: binaries
+binaries: ## Build all executables
 	go build ./cmd/gosky
 	go build ./cmd/laputa
 	go build ./cmd/bigsky
@@ -20,6 +24,9 @@ build: ## Build all executables
 	go build ./cmd/lexgen
 	go build ./cmd/stress
 	go build ./cmd/fakermaker
+
+.PHONY: all
+all: binaries
 
 .PHONY: test
 test: ## Run all tests
@@ -31,10 +38,26 @@ coverage-html: ## Generate test coverage report and open in browser
 	go tool cover -html=test-coverage.out
 
 .PHONY: lint
-lint: ## Run style checks and verify syntax
+lint: ## Verify code style and run static checks
 	go vet -asmdecl -assign -atomic -bools -buildtag -cgocall -copylocks -httpresponse -loopclosure -lostcancel -nilfunc -printf -shift -stdmethods -structtag -tests -unmarshal -unreachable -unsafeptr -unusedresult ./...
 	test -z $(gofmt -l ./...)
 
 .PHONY: fmt
-fmt: ## Run syntax re-formatting
+fmt: ## Run syntax re-formatting (modify in place)
 	go fmt ./...
+
+.PHONY: lexgen
+lexgen: ## Run syntax re-formatting (modify in place)
+	go run ./cmd/lexgen/ --package bsky --prefix app.bsky --outdir api/bsky $(LEXDIR)
+	go run ./cmd/lexgen/ --package atproto --prefix com.atproto --outdir api/atproto $(LEXDIR)
+
+.env:
+	if [ ! -f ".env" ]; then cp example.dev.env .env; fi
+
+.PHONY: run-dev-bgs
+run-dev-bgs: .env ## Runs 'bigsky' BGS for local dev
+	GOLOG_LOG_LEVEL=info go run ./cmd/bigsky --crawl-insecure-ws
+
+.PHONY: run-dev-labelmaker
+run-dev-labelmaker: .env ## Runs labelmaker for local dev
+	GOLOG_LOG_LEVEL=info go run ./cmd/labelmaker --subscribe-insecure-ws

--- a/example.dev.env
+++ b/example.dev.env
@@ -1,0 +1,7 @@
+ATP_PLC_HOST=http://localhost:2582
+ATP_PDS_HOST=http://localhost:2583
+ATP_BGS_HOST=http://localhost:2470
+ATP_AUTH_HANDLE="admin.test"
+ATP_AUTH_PASSWORD="admin"
+ATP_AUTH_ADMIN_PASSWORD="admin"
+GOLOG_LOG_LEVEL=info


### PR DESCRIPTION
Switches `make build` back to `go build ./...` for speed. `make binaries` builds all the executables, and `make all` is an alias of that. Maybe a bit non-standard; `go build ./...` could be `make check` instead? But this is my current muscle memory.

Adds a `make lexgen` helper which looks in `../atproto/lexicons/` by default, but can be overridden by `LEXDIR` environment variable.

Adds `make run-dev-bgs` to match current behavior of `make run-pds` in `atproto` repo. This is quite helpful to me for getting local integeration dev work going. Note that the `GOLOG_LOG_LEVEL` environment variable can't currently be definted in `.env` config file because of import ordering.