### PR TITLE
github.com/ipfs/go-block-format is deprecated

### DIFF
--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -14,13 +14,13 @@ import (
 
 	util "github.com/bluesky-social/indigo/util"
 
-	blocks "github.com/ipfs/go-block-format"
 	carutil "github.com/ipfs/go-car/util"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	ipld "github.com/ipfs/go-ipld-format"
+	"github.com/ipfs/go-libipfs/blocks"
 	car "github.com/ipld/go-car"
 	"go.opentelemetry.io/otel"
 	"gorm.io/gorm"

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/golang-lru v0.5.4
-	github.com/ipfs/go-block-format v0.1.1
 	github.com/ipfs/go-bs-sqlite3 v0.0.0-20221122195556-bfcee1be620d
 	github.com/ipfs/go-car v0.0.4
 	github.com/ipfs/go-cid v0.3.2
@@ -62,6 +61,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
+	github.com/ipfs/go-block-format v0.1.1 // indirect
 	github.com/ipfs/go-blockservice v0.5.0 // indirect
 	github.com/ipfs/go-ipfs-ds-help v1.1.0 // indirect
 	github.com/ipfs/go-ipfs-exchange-interface v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -636,10 +636,6 @@ github.com/whyrusleeping/cbor v0.0.0-20171005072247-63513f603b11 h1:5HZfQkwe0mIf
 github.com/whyrusleeping/cbor-gen v0.0.0-20230126041949-52956bd4c9aa h1:EyA027ZAkuaCLoxVX4r1TZMPy1d31fM6hbfQ4OU4I5o=
 github.com/whyrusleeping/cbor-gen v0.0.0-20230126041949-52956bd4c9aa/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f h1:jQa4QT2UP9WYv2nzyawpKMOCl+Z/jW7djv2/J50lj9E=
-github.com/whyrusleeping/go-did v0.0.0-20230217165439-d09707c62f1c h1:BA9D0ELokkaTqWDW44jMVrnggCllH+HulydBp3rZvs4=
-github.com/whyrusleeping/go-did v0.0.0-20230217165439-d09707c62f1c/go.mod h1:qPtRyexGM5XMHFIfjH+EiA/A/1n2JakWEdMPC53pJAE=
-github.com/whyrusleeping/go-did v0.0.0-20230301192113-6594b853455d h1:3JYVTm7jNsS5LRx0qW8pWwFxOJSM/6W2pSKBVT6AmBY=
-github.com/whyrusleeping/go-did v0.0.0-20230301192113-6594b853455d/go.mod h1:qPtRyexGM5XMHFIfjH+EiA/A/1n2JakWEdMPC53pJAE=
 github.com/whyrusleeping/go-did v0.0.0-20230301193428-2146016fc220 h1:EO/9z3yDvx1van1/0esdcqhalZZQGRj3I1BPTWr5k3A=
 github.com/whyrusleeping/go-did v0.0.0-20230301193428-2146016fc220/go.mod h1:qPtRyexGM5XMHFIfjH+EiA/A/1n2JakWEdMPC53pJAE=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=


### PR DESCRIPTION
The package `github.com/ipfs/go-block-format` is deprecated  and moved to `github.com/ipfs/go-libipfs/blocks`