### PR TITLE
fix issue with gap filling in index crawler

### DIFF
--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -344,7 +344,7 @@ func (cs *CarStore) ReadUserCar(ctx context.Context, user util.Uid, earlyCid, la
 		lateSeq = fromShard.Seq
 	}
 
-	q := cs.meta.Order("seq desc").Where("usr = ? AND seq >= ?", user, earlySeq)
+	q := cs.meta.Order("seq desc").Where("usr = ? AND seq > ?", user, earlySeq)
 	if lateCid.Defined() {
 		q = q.Where("seq <= ?", lateSeq)
 	}

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -901,7 +901,8 @@ func (ix *Indexer) FetchAndIndexRepo(ctx context.Context, job *crawlWork) error 
 	// this process will send individual indexing events back to the indexer, doing a 'fast forward' of the users entire history
 	// we probably want alternative ways of doing this for 'very large' or 'very old' repos, but this works for now
 	if err := ix.repomgr.ImportNewRepo(ctx, ai.Uid, ai.Did, bytes.NewReader(repo), curHead); err != nil {
-		return fmt.Errorf("importing fetched repo: %w", err)
+		span.RecordError(err)
+		return fmt.Errorf("importing fetched repo (curHead: %s): %w", from, err)
 	}
 
 	// TODO: this is currently doing too much work, allowing us to ignore the catchup events we've gotten

--- a/repomgr/ingest_test.go
+++ b/repomgr/ingest_test.go
@@ -1,12 +1,17 @@
 package repomgr
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	bsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/carstore"
+	"github.com/bluesky-social/indigo/models"
+	"github.com/bluesky-social/indigo/repo"
 	"github.com/bluesky-social/indigo/util"
 	"github.com/ipfs/go-cid"
 	"gorm.io/driver/sqlite"
@@ -65,4 +70,109 @@ func TestLoadNewRepo(t *testing.T) {
 	if err := repoman.ImportNewRepo(ctx, 2, "", fi, cid.Undef); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func testCarstore(t *testing.T, dir string) *carstore.CarStore {
+	cardb, err := gorm.Open(sqlite.Open(filepath.Join(dir, "car.sqlite")))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cspath := filepath.Join(dir, "carstore")
+	if err := os.Mkdir(cspath, 0775); err != nil {
+		t.Fatal(err)
+	}
+
+	cs, err := carstore.NewCarStore(cardb, cspath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cs
+}
+
+func TestIngestWithGap(t *testing.T) {
+	dir, err := os.MkdirTemp("", "integtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	maindb, err := gorm.Open(sqlite.Open(filepath.Join(dir, "test.sqlite")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	maindb.AutoMigrate(models.ActorInfo{})
+
+	did := "did:plc:beepboop"
+	maindb.Create(&models.ActorInfo{
+		Did: did,
+		Uid: 1,
+	})
+
+	cs := testCarstore(t, dir)
+
+	repoman := NewRepoManager(maindb, cs, &util.FakeKeyManager{})
+
+	dir2, err := os.MkdirTemp("", "integtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs2 := testCarstore(t, dir2)
+
+	ctx := context.TODO()
+	var prev *cid.Cid
+	for i := 0; i < 5; i++ {
+		slice, head := doPost(t, cs2, did, prev, i)
+
+		if err := repoman.HandleExternalUserEvent(ctx, 1, 1, did, prev, slice); err != nil {
+			t.Fatal(err)
+		}
+
+		prev = &head
+	}
+
+	latest := *prev
+
+	// now do a few outside of the standard event stream flow
+	for i := 0; i < 5; i++ {
+		_, head := doPost(t, cs2, did, prev, i)
+		prev = &head
+	}
+
+	buf := new(bytes.Buffer)
+	if err := cs2.ReadUserCar(ctx, 1, latest, *prev, true, buf); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repoman.ImportNewRepo(ctx, 1, did, buf, latest); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func doPost(t *testing.T, cs *carstore.CarStore, did string, prev *cid.Cid, postid int) ([]byte, cid.Cid) {
+	ctx := context.TODO()
+	ds, err := cs.NewDeltaSession(ctx, 1, prev)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := repo.NewRepo(ctx, did, ds)
+
+	if _, _, err := r.CreateRecord(ctx, "app.bsky.feed.post", &bsky.FeedPost{
+		Text: fmt.Sprintf("hello friend %d", postid),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := r.Commit(ctx, func(context.Context, string, []byte) ([]byte, error) { return nil, nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	slice, err := ds.CloseWithRoot(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return slice, root
 }

--- a/repomgr/repomgr.go
+++ b/repomgr/repomgr.go
@@ -839,7 +839,6 @@ func (rm *RepoManager) ImportNewRepo(ctx context.Context, user util.Uid, repoDid
 
 		var ops []RepoOp
 		for _, op := range diffops {
-
 			out, err := processOp(ctx, bs, op)
 			if err != nil {
 				log.Errorw("failed to process repo op", "err", err, "path", op.Rpath)
@@ -883,7 +882,7 @@ func (rm *RepoManager) ImportNewRepo(ctx context.Context, user util.Uid, repoDid
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("process new repo: %w:", err)
+		return fmt.Errorf("process new repo (current head: %s): %w:", head, err)
 	}
 
 	return nil
@@ -993,6 +992,16 @@ func (rm *RepoManager) processNewRepo(ctx context.Context, user util.Uid, r io.R
 		seen[until] = true
 	}
 
+	var baseBs blockstore.Blockstore
+	if until.Defined() {
+		bs, err := rm.cs.ReadOnlySession(user)
+		if err != nil {
+			return err
+		}
+
+		baseBs = bs
+	}
+
 	prev := until
 	for i := len(commits) - 1; i >= 0; i-- {
 		root := commits[i]
@@ -1025,8 +1034,13 @@ func (rm *RepoManager) processNewRepo(ctx context.Context, user util.Uid, r io.R
 			return ds.CloseWithRoot(ctx, root)
 		}
 
-		if err := cb(ctx, prev, root, finish, membs); err != nil {
-			return fmt.Errorf("cb errored (%d/%d): %w", i, len(commits)-1, err)
+		cbs := membs
+		if i == len(commits)-1 {
+			cbs = util.NewReadThroughBstore(baseBs, membs)
+		}
+
+		if err := cb(ctx, prev, root, finish, cbs); err != nil {
+			return fmt.Errorf("cb errored (%d/%d) root: %s, prev: %s: %w", i, len(commits)-1, root, prev, err)
 		}
 
 		prev = root


### PR DESCRIPTION
The source of the bug is the one line change in the carstore, the repomanager changes are the part that could use the closest look, basically i'm allowing the first commit in the gap fill process to dip into the carstore for the blocks it needs for the diff, later diffs are isolated and must pull blocks from the car file.
