### PR TITLE
Additional dockerfiles and github actions: beemo and labelmaker

### DIFF
--- a/.github/workflows/container-beemo-ghcr.yaml
+++ b/.github/workflows/container-beemo-ghcr.yaml
@@ -1,0 +1,52 @@
+name: container-beemo-ghcr.yaml
+on:
+  push:
+    branches:
+      - main
+env:
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,enable=true,priority=100,prefix=beemo:,suffix=,format=long
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./cmd/beemo/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/container-labelmaker-ghcr.yaml
+++ b/.github/workflows/container-labelmaker-ghcr.yaml
@@ -1,0 +1,52 @@
+name: container-labelmaker-ghcr.yaml
+on:
+  push:
+    branches:
+      - main
+env:
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,enable=true,priority=100,prefix=labelmaker:,suffix=,format=long
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./cmd/labelmaker/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/cmd/beemo/Dockerfile
+++ b/cmd/beemo/Dockerfile
@@ -1,0 +1,35 @@
+# Run this dockerfile from the top level of the indigo git repository like:
+#
+#   podman build -f ./cmd/beemo/Dockerfile -t beemo .
+
+### Compile stage
+FROM alpine:3.17 AS build-env
+RUN apk add --no-cache build-base make go
+
+ADD . /dockerbuild
+WORKDIR /dockerbuild
+
+# timezone data for alpine builds
+RUN go build -tags timetzdata -o /beemo ./cmd/beemo
+
+### Run stage
+FROM alpine:3.17
+
+RUN apk add --no-cache --update dumb-init ca-certificates
+ENTRYPOINT ["dumb-init", "--"]
+
+WORKDIR /
+RUN mkdir -p data/beemo
+COPY --from=build-env /beemo /
+
+# small things to make golang binaries work well under alpine
+ENV GODEBUG=netdns=go
+ENV TZ=Etc/UTC
+
+EXPOSE 2470
+
+CMD ["/beemo"]
+
+LABEL org.opencontainers.image.source=https://github.com/bluesky-social/indigo
+LABEL org.opencontainers.image.description="ATP ChatOps Bot (beemo)"
+LABEL org.opencontainers.image.licenses=MIT

--- a/cmd/labelmaker/Dockerfile
+++ b/cmd/labelmaker/Dockerfile
@@ -1,0 +1,35 @@
+# Run this dockerfile from the top level of the indigo git repository like:
+#
+#   podman build -f ./cmd/labelmaker/Dockerfile -t labelmaker .
+
+### Compile stage
+FROM alpine:3.17 AS build-env
+RUN apk add --no-cache build-base make go
+
+ADD . /dockerbuild
+WORKDIR /dockerbuild
+
+# timezone data for alpine builds
+RUN go build -tags timetzdata -o /labelmaker ./cmd/labelmaker
+
+### Run stage
+FROM alpine:3.17
+
+RUN apk add --no-cache --update dumb-init ca-certificates
+ENTRYPOINT ["dumb-init", "--"]
+
+WORKDIR /
+RUN mkdir -p data/labelmaker
+COPY --from=build-env /labelmaker /
+
+# small things to make golang binaries work well under alpine
+ENV GODEBUG=netdns=go
+ENV TZ=Etc/UTC
+
+EXPOSE 2470
+
+CMD ["/labelmaker"]
+
+LABEL org.opencontainers.image.source=https://github.com/bluesky-social/indigo
+LABEL org.opencontainers.image.description="ATP Labeling Service (labelmaker)"
+LABEL org.opencontainers.image.licenses=MIT


### PR DESCRIPTION
Labelmaker will get deployed in the next week or so.

Beemo is currently running fine on render, but at some point we might want it deployed as a container. I could disable that container build by default if we want to hold off on it.

LMK if I should switch these up to use AWS instead of ghcr.io.

At some point maybe we could abstract these to be less duplication between files, but seems fine for now.