### PR TITLE
HTTP retry helper; add as default for XRPC, beemo, labelmaker, fakermaker

### DIFF
--- a/cmd/beemo/main.go
+++ b/cmd/beemo/main.go
@@ -27,10 +27,12 @@ import (
 var log = logging.Logger("beemo")
 
 func main() {
-	run(os.Args)
+	if err := run(os.Args); err != nil {
+		log.Fatal(err)
+	}
 }
 
-func run(args []string) {
+func run(args []string) error {
 
 	app := cli.App{
 		Name:    "beemo",
@@ -90,7 +92,7 @@ func run(args []string) {
 			Action: pollNewReports,
 		},
 	}
-	app.RunAndExitOnError()
+	return app.Run(args)
 }
 
 func pollNewReports(cctx *cli.Context) error {

--- a/cmd/beemo/main.go
+++ b/cmd/beemo/main.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
-	cliutil "github.com/bluesky-social/indigo/cmd/gosky/util"
+	"github.com/bluesky-social/indigo/util"
 	"github.com/bluesky-social/indigo/version"
 	"github.com/bluesky-social/indigo/xrpc"
 
@@ -102,7 +102,7 @@ func pollNewReports(cctx *cli.Context) error {
 
 	// create a new session
 	xrpcc := &xrpc.Client{
-		Client: cliutil.NewHttpClient(),
+		Client: util.RobustHTTPClient(),
 		Host:   cctx.String("pds-host"),
 		Auth:   &xrpc.AuthInfo{Handle: cctx.String("handle")},
 	}
@@ -202,7 +202,7 @@ func sendSlackMsg(cctx *cli.Context, msg string) error {
 		return err
 	}
 	req.Header.Add("Content-Type", "application/json")
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := util.RobustHTTPClient()
 	resp, err := client.Do(req)
 	if err != nil {
 		return err

--- a/cmd/fakermaker/main.go
+++ b/cmd/fakermaker/main.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"net/http"
 	"os"
 	"runtime"
 	"time"
@@ -19,6 +18,7 @@ import (
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	cliutil "github.com/bluesky-social/indigo/cmd/gosky/util"
 	lexutil "github.com/bluesky-social/indigo/lex/util"
+	"github.com/bluesky-social/indigo/util"
 	"github.com/bluesky-social/indigo/version"
 	"github.com/bluesky-social/indigo/xrpc"
 
@@ -209,8 +209,7 @@ type AccountContext struct {
 
 func accountXrpcClient(cctx *cli.Context, ac *AccountContext) (*xrpc.Client, error) {
 	pdsHost := cctx.String("pds-host")
-	//httpClient := cliutil.NewHttpClient()
-	httpClient := &http.Client{Timeout: 5 * time.Second}
+	httpClient := util.RobustHTTPClient()
 	ua := "IndigoFakerMaker/" + version.Version
 	xrpcc := &xrpc.Client{
 		Client:    httpClient,

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/brianvoe/gofakeit/v6 v6.20.1
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gorilla/websocket v1.5.0
+	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/ipfs/go-bs-sqlite3 v0.0.0-20221122195556-bfcee1be620d
 	github.com/ipfs/go-car v0.0.4
@@ -60,6 +61,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
 	github.com/ipfs/go-block-format v0.1.1 // indirect
 	github.com/ipfs/go-blockservice v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,12 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
+github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=

--- a/labeling/hiveai.go
+++ b/labeling/hiveai.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
-	"time"
 
 	lexutil "github.com/bluesky-social/indigo/lex/util"
+	"github.com/bluesky-social/indigo/util"
 	"github.com/bluesky-social/indigo/version"
 )
 
@@ -43,17 +43,8 @@ type HiveAIResp_Class struct {
 }
 
 func NewHiveAILabeler(token string) HiveAILabeler {
-	client := http.Client{
-		Transport: &http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
-			MaxIdleConns:          20,
-			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-		},
-	}
 	return HiveAILabeler{
-		Client:   client,
+		Client:   *util.RobustHTTPClient(),
 		ApiToken: token,
 	}
 }

--- a/labeling/micro_nsfw_img.go
+++ b/labeling/micro_nsfw_img.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
-	"time"
 
 	lexutil "github.com/bluesky-social/indigo/lex/util"
+	util "github.com/bluesky-social/indigo/util"
 	"github.com/bluesky-social/indigo/version"
 )
 
@@ -28,17 +28,8 @@ type MicroNSFWImgResp struct {
 }
 
 func NewMicroNSFWImgLabeler(url string) MicroNSFWImgLabeler {
-	client := http.Client{
-		Transport: &http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
-			MaxIdleConns:          20,
-			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-		},
-	}
 	return MicroNSFWImgLabeler{
-		Client:   client,
+		Client:   *util.RobustHTTPClient(),
 		Endpoint: url,
 	}
 }

--- a/labeling/sqrl.go
+++ b/labeling/sqrl.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/indigo/util"
 	"github.com/bluesky-social/indigo/version"
 )
 
@@ -45,17 +45,8 @@ type SQRLResponse_Rule struct {
 }
 
 func NewSQRLLabeler(url string) SQRLLabeler {
-	client := http.Client{
-		Transport: &http.Transport{
-			Proxy:                 http.ProxyFromEnvironment,
-			MaxIdleConns:          20,
-			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-		},
-	}
 	return SQRLLabeler{
-		Client:   client,
+		Client:   *util.RobustHTTPClient(),
 		Endpoint: url,
 	}
 }

--- a/util/http.go
+++ b/util/http.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+	logging "github.com/ipfs/go-log"
+)
+
+var log = logging.Logger("http")
+
+type LeveledZap struct {
+	inner *logging.ZapEventLogger
+}
+
+// re-writes HTTP client ERROR to WARN level (because of retries)
+func (l LeveledZap) Error(msg string, keysAndValues ...interface{}) {
+	l.inner.Warnw(msg, keysAndValues...)
+}
+
+func (l LeveledZap) Warn(msg string, keysAndValues ...interface{}) {
+	l.inner.Warnw(msg, keysAndValues...)
+}
+
+func (l LeveledZap) Info(msg string, keysAndValues ...interface{}) {
+	l.inner.Infow(msg, keysAndValues...)
+}
+
+// re-writes HTTP client DEBUG to INFO level (this is where retry is logged)
+func (l LeveledZap) Debug(msg string, keysAndValues ...interface{}) {
+	l.inner.Infow(msg, keysAndValues...)
+}
+
+// Generates an HTTP client with decent general-purpose defaults around
+// timeouts and retries. The returned client has the stdlib http.Client
+// interface, but has Hashicorp retryablehttp logic internally.
+//
+// This client will retry on connection errors, 5xx status (except 501), and
+// 429 Backoff requests (respecting 'Retry-After' header). It will log
+// intermediate failures with WARN level. This does not start from
+// http.DefaultClient.
+//
+// This should be usable for XRPC clients, and other general inter-service
+// client needs. CLI tools might want shorter timeouts and fewer retries by
+// default.
+func RobustHTTPClient() *http.Client {
+
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryMax = 3
+	retryClient.RetryWaitMin = 1 * time.Second
+	retryClient.RetryWaitMax = 10 * time.Second
+	retryClient.Logger = retryablehttp.LeveledLogger(LeveledZap{log})
+	client := retryClient.StandardClient()
+	client.Timeout = 20 * time.Second
+	return client
+}

--- a/xrpc/xrpc.go
+++ b/xrpc/xrpc.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/bluesky-social/indigo/util"
 	"github.com/bluesky-social/indigo/version"
 )
 
@@ -24,7 +25,7 @@ type Client struct {
 
 func (c *Client) getClient() *http.Client {
 	if c.Client == nil {
-		return http.DefaultClient
+		return util.RobustHTTPClient()
 	}
 	return c.Client
 }


### PR DESCRIPTION
The initial motivation for this was for beemo to not crash on the very first HTTP 5xx it encounters, but to do a couple retries. An example where we expect occasional 5xx errors is when deploying some of our own services, or running complex database migrations.

I initially was going to hand-roll something simple like https://brandur.org/fragments/go-http-retry, with fixed backoffs, but it seems like the hashicorp lib is fairly light and slots in as a regular `http.Client`, which is nice.

Curious your thoughts on when/where to do this instead of just crashing and having the service restart. I think there are reasonable arguments in a variety of directions; having automatic retries everywhere for 429 and 502/503 has served me well. This could, technically, result in duplicate requests when the backend handled things fine and it was the load-balancer which returned a 5xx error.

I also didn't copy over all the transport configs you have in `gosky`, but we could include most of those. I don't think we should force HTTP/2 in the general case.