### PR TITLE
error out if we dont read the entire response body

### DIFF
--- a/xrpc/xrpc.go
+++ b/xrpc/xrpc.go
@@ -117,7 +117,10 @@ func (c *Client) Do(ctx context.Context, kind XRPCRequestType, inpenc string, me
 
 	if out != nil {
 		if buf, ok := out.(*bytes.Buffer); ok {
-			io.Copy(buf, resp.Body)
+			_, err := io.CopyN(buf, resp.Body, resp.ContentLength)
+			if err != nil {
+				return fmt.Errorf("reading response body: %w", err)
+			}
 		} else {
 			if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
 				return fmt.Errorf("decoding xrpc response: %w", err)


### PR DESCRIPTION
probably should also handle chunked encoding..? Though i'm not convinced that should be allowed in xrpc