### PR TITLE
handle 'genesis' events such as rebases

### DIFF
--- a/events/repostream.go
+++ b/events/repostream.go
@@ -13,12 +13,38 @@ import (
 
 type LiteStreamHandleFunc func(op repomgr.EventKind, seq int64, path string, did string, rcid *cid.Cid, rec any) error
 
-func ConsumeRepoStreamLite(ctx context.Context, con *websocket.Conn, cb LiteStreamHandleFunc) error {
+type GetRepoFunc func(ctx context.Context, did string, oldest *string, newest string) ([]byte, error)
+
+func ConsumeRepoStreamLite(ctx context.Context, con *websocket.Conn, cb LiteStreamHandleFunc, getrepo GetRepoFunc) error {
 	return HandleRepoStream(ctx, con, &RepoStreamCallbacks{
 		RepoAppend: func(evt *RepoAppend) error {
 			if evt.TooBig {
-				log.Errorf("skipping too big events for now: %d", evt.Seq)
-				return nil
+				if evt.Prev != nil {
+					log.Errorf("skipping non-genesis too big events for now: %d", evt.Seq)
+					return nil
+				}
+
+				slice, err := getrepo(ctx, evt.Repo, nil, evt.Commit)
+				if err != nil {
+					return fmt.Errorf("fetching repo data for 'too big' event slice failed (seq: %d, remote: %s): %w", evt.Seq, con.RemoteAddr(), err)
+				}
+
+				rep, err := repo.ReadRepoFromCar(ctx, bytes.NewReader(slice))
+				if err != nil {
+					return err
+				}
+
+				return rep.ForEach(ctx, "", func(k string, v cid.Cid) error {
+					rc, rec, err := rep.GetRecord(ctx, k)
+					if err != nil {
+						return fmt.Errorf("failed to load referenced record from repo (rec: %s, seq: %d): %w", k, evt.Seq, err)
+					}
+
+					if err := cb(repomgr.EvtKindCreateRecord, evt.Seq, k, evt.Repo, &rc, rec); err != nil {
+						return err
+					}
+					return nil
+				})
 			}
 			r, err := repo.ReadRepoFromCar(ctx, bytes.NewReader(evt.Blocks))
 			if err != nil {


### PR DESCRIPTION
I'm sure this will change slightly after the lexicon refactor lands, but this is still strictly better for this codepath