### PR TITLE
Bump to golang 1.20

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go tooling
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: "1.20"
       - name: Build
         run: make build
       - name: Test
@@ -32,6 +32,6 @@ jobs:
       - name: Set up Go tooling
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: "1.20"
       - name: Lint
         run: make lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bluesky-social/indigo
 
-go 1.18
+go 1.20
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2


### PR DESCRIPTION
Main motivation for upgrading to 1.20 is the reverse proxy improvements in `net/http/httputil`.