### PR TITLE
lex/util: error, not panic, on nil marshaling of LexiconTypeDecoder

### DIFF
--- a/lex/util/decoder.go
+++ b/lex/util/decoder.go
@@ -109,6 +109,9 @@ func (ltd *LexiconTypeDecoder) UnmarshalJSON(b []byte) error {
 }
 
 func (ltd *LexiconTypeDecoder) MarshalJSON() ([]byte, error) {
+	if ltd == nil || ltd.Val == nil {
+		return nil, fmt.Errorf("LexiconTypeDecoder MarshalJSON called on a nil")
+	}
 	v := reflect.ValueOf(ltd.Val)
 	t := v.Type()
 	sf, ok := t.Elem().FieldByName("LexiconTypeID")

--- a/lex/util/decoder_test.go
+++ b/lex/util/decoder_test.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestLTDMarshal(t *testing.T) {
+
+	var empty *LexiconTypeDecoder
+
+	_, err := empty.MarshalJSON()
+	if err == nil {
+		t.Fatal("expected an error marshalling a nil (but not a panic)")
+	}
+
+	emptyVal := LexiconTypeDecoder{}
+
+	_, err = emptyVal.MarshalJSON()
+	if err == nil {
+		t.Fatal("expected an error marshalling a nil (but not a panic)")
+	}
+}


### PR DESCRIPTION
Small change to have JSON marshaling error instead of panic (segfault). This came up during labelmaker development. Includes tests.