### PR TITLE
fakermaker integration tests, both internal and against typescript (running locally in dev mode)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,16 @@ build: ## Build all executables
 all: build
 
 .PHONY: test
-test: ## Run all tests
+test: ## Run tests
 	go test ./...
+
+.PHONY: test-short
+test-short: ## Run tests, skipping slower integration tests
+	go test -test.short ./...
+
+.PHONY: test-interop
+test-interop: ## Run tests, including local interop (requires services running)
+	go test -tags=localinterop ./...
 
 .PHONY: coverage-html
 coverage-html: ## Generate test coverage report and open in browser

--- a/cmd/fakermaker/main.go
+++ b/cmd/fakermaker/main.go
@@ -5,32 +5,20 @@
 package main
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"os"
 	"runtime"
-	"time"
 
-	comatproto "github.com/bluesky-social/indigo/api/atproto"
-	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	cliutil "github.com/bluesky-social/indigo/cmd/gosky/util"
-	lexutil "github.com/bluesky-social/indigo/lex/util"
-	"github.com/bluesky-social/indigo/util"
+	"github.com/bluesky-social/indigo/fakedata"
 	"github.com/bluesky-social/indigo/version"
-	"github.com/bluesky-social/indigo/xrpc"
 
 	_ "github.com/joho/godotenv/autoload"
 
-	"github.com/brianvoe/gofakeit/v6"
-	logging "github.com/ipfs/go-log"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sync/errgroup"
 )
-
-var log = logging.Logger("fakermaker")
 
 func main() {
 	run(os.Args)
@@ -39,8 +27,9 @@ func main() {
 func run(args []string) {
 
 	app := cli.App{
-		Name:  "fakermaker",
-		Usage: "bluesky fake account/content generator",
+		Name:    "fakermaker",
+		Usage:   "bluesky fake account/content generator",
+		Version: version.Version,
 	}
 
 	app.Flags = []cli.Flag{
@@ -193,46 +182,9 @@ func run(args []string) {
 			},
 		},
 	}
-	all := measureIterations("entire command")
+	all := fakedata.MeasureIterations("entire command")
 	app.RunAndExitOnError()
 	all(1)
-}
-
-type AccountContext struct {
-	// 0-based index; should match index
-	Index       int           `json:"index"`
-	AccountType string        `json:"accountType"`
-	Email       string        `json:"email"`
-	Password    string        `json:"password"`
-	Auth        xrpc.AuthInfo `json:"auth"`
-}
-
-func accountXrpcClient(cctx *cli.Context, ac *AccountContext) (*xrpc.Client, error) {
-	pdsHost := cctx.String("pds-host")
-	httpClient := util.RobustHTTPClient()
-	ua := "IndigoFakerMaker/" + version.Version
-	xrpcc := &xrpc.Client{
-		Client:    httpClient,
-		Host:      pdsHost,
-		Auth:      &ac.Auth,
-		UserAgent: &ua,
-	}
-	// use XRPC client to re-auth using user/pass
-	auth, err := comatproto.ServerCreateSession(context.TODO(), xrpcc, &comatproto.ServerCreateSession_Input{
-		Identifier: &ac.Auth.Handle,
-		Password:   ac.Password,
-	})
-	if err != nil {
-		return nil, err
-	}
-	xrpcc.Auth.AccessJwt = auth.AccessJwt
-	xrpcc.Auth.RefreshJwt = auth.RefreshJwt
-	return xrpcc, nil
-}
-
-type AccountCatalog struct {
-	Celebs   []AccountContext
-	Regulars []AccountContext
 }
 
 // registers fake accounts with PDS, and spits out JSON-lines to stdout with auth info
@@ -256,11 +208,11 @@ func genAccounts(cctx *cli.Context) error {
 	countRegulars := countTotal - countCelebrities
 
 	// call helper to do actual creation
-	var usr *AccountContext
+	var usr *fakedata.AccountContext
 	var line []byte
-	t1 := measureIterations("register celebrity accounts")
+	t1 := fakedata.MeasureIterations("register celebrity accounts")
 	for i := 0; i < countCelebrities; i++ {
-		if usr, err = pdsGenAccount(xrpcc, i, "celebrity"); err != nil {
+		if usr, err = fakedata.GenAccount(xrpcc, i, "celebrity"); err != nil {
 			return err
 		}
 		// compact single-line JSON by default
@@ -271,9 +223,9 @@ func genAccounts(cctx *cli.Context) error {
 	}
 	t1(countCelebrities)
 
-	t2 := measureIterations("register regular accounts")
+	t2 := fakedata.MeasureIterations("register regular accounts")
 	for i := 0; i < countRegulars; i++ {
-		if usr, err = pdsGenAccount(xrpcc, i, "regular"); err != nil {
+		if usr, err = fakedata.GenAccount(xrpcc, i, "regular"); err != nil {
 			return err
 		}
 		// compact single-line JSON by default
@@ -286,109 +238,27 @@ func genAccounts(cctx *cli.Context) error {
 	return nil
 }
 
-func measureIterations(name string) func(int) {
-	start := time.Now()
-	return func(count int) {
-		if count == 0 {
-			return
-		}
-		total := time.Since(start)
-		log.Infof("%s wall runtime: count=%d total=%s mean=%s", name, count, total, total/time.Duration(count))
-	}
-}
-func pdsGenAccount(xrpcc *xrpc.Client, index int, accountType string) (*AccountContext, error) {
-	var suffix string
-	if accountType == "celebrity" {
-		suffix = "C"
-	} else {
-		suffix = ""
-	}
-	prefix := gofakeit.Username()
-	if len(prefix) > 10 {
-		prefix = prefix[0:10]
-	}
-	handle := fmt.Sprintf("%s-%s%d.test", prefix, suffix, index)
-	email := gofakeit.Email()
-	password := gofakeit.Password(true, true, true, true, true, 24)
-	ctx := context.TODO()
-	resp, err := comatproto.ServerCreateAccount(ctx, xrpcc, &comatproto.ServerCreateAccount_Input{
-		Email:    email,
-		Handle:   handle,
-		Password: password,
-	})
-	if err != nil {
-		return nil, err
-	}
-	auth := xrpc.AuthInfo{
-		AccessJwt:  resp.AccessJwt,
-		RefreshJwt: resp.RefreshJwt,
-		Handle:     resp.Handle,
-		Did:        resp.Did,
-	}
-	return &AccountContext{
-		Index:       index,
-		AccountType: accountType,
-		Email:       email,
-		Password:    password,
-		Auth:        auth,
-	}, nil
-}
-
-func readAccountCatalog(path string) (*AccountCatalog, error) {
-	catalog := &AccountCatalog{}
-	catFile, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer catFile.Close()
-
-	decoder := json.NewDecoder(catFile)
-	for decoder.More() {
-		var usr AccountContext
-		if err := decoder.Decode(&usr); err != nil {
-			return nil, fmt.Errorf("parse AccountContext: %w", err)
-		}
-		if usr.AccountType == "celebrity" {
-			catalog.Celebs = append(catalog.Celebs, usr)
-		} else {
-			catalog.Regulars = append(catalog.Regulars, usr)
-		}
-	}
-	// validate index numbers
-	for i, u := range catalog.Celebs {
-		if i != u.Index {
-			return nil, fmt.Errorf("account index didn't match: %d != %d (%s)", i, u.Index, u.AccountType)
-		}
-	}
-	for i, u := range catalog.Regulars {
-		if i != u.Index {
-			return nil, fmt.Errorf("account index didn't match: %d != %d (%s)", i, u.Index, u.AccountType)
-		}
-	}
-	log.Infof("loaded account catalog: regular=%d celebrity=%d", len(catalog.Regulars), len(catalog.Celebs))
-	return catalog, nil
-}
-
 func genProfiles(cctx *cli.Context) error {
-	catalog, err := readAccountCatalog(cctx.String("catalog"))
+	catalog, err := fakedata.ReadAccountCatalog(cctx.String("catalog"))
 	if err != nil {
 		return err
 	}
 
+	pdsHost := cctx.String("pds-host")
 	genAvatar := !cctx.Bool("no-avatars")
 	genBanner := !cctx.Bool("no-banners")
 	jobs := cctx.Int("jobs")
 
-	accChan := make(chan AccountContext, len(catalog.Celebs)+len(catalog.Regulars))
+	accChan := make(chan fakedata.AccountContext, len(catalog.Celebs)+len(catalog.Regulars))
 	eg := new(errgroup.Group)
 	for i := 0; i < jobs; i++ {
 		eg.Go(func() error {
 			for acc := range accChan {
-				xrpcc, err := accountXrpcClient(cctx, &acc)
+				xrpcc, err := fakedata.AccountXrpcClient(pdsHost, &acc)
 				if err != nil {
 					return err
 				}
-				if err = pdsGenProfile(xrpcc, &acc, genAvatar, genBanner); err != nil {
+				if err = fakedata.GenProfile(xrpcc, &acc, genAvatar, genBanner); err != nil {
 					return err
 				}
 			}
@@ -403,77 +273,27 @@ func genProfiles(cctx *cli.Context) error {
 	return eg.Wait()
 }
 
-func pdsGenProfile(xrpcc *xrpc.Client, acc *AccountContext, genAvatar, genBanner bool) error {
-
-	desc := gofakeit.HipsterSentence(12)
-	var name string
-	if acc.AccountType == "celebrity" {
-		name = gofakeit.CelebrityActor()
-	} else {
-		name = gofakeit.Name()
-	}
-
-	var avatar *lexutil.LexBlob
-	if genAvatar {
-		img := gofakeit.ImagePng(200, 200)
-		resp, err := comatproto.RepoUploadBlob(context.TODO(), xrpcc, bytes.NewReader(img))
-		if err != nil {
-			return err
-		}
-		avatar = &lexutil.LexBlob{
-			Ref:      resp.Blob.Ref,
-			MimeType: "image/png",
-			Size:     resp.Blob.Size,
-		}
-	}
-	var banner *lexutil.LexBlob
-	if genBanner {
-		img := gofakeit.ImageJpeg(800, 200)
-		resp, err := comatproto.RepoUploadBlob(context.TODO(), xrpcc, bytes.NewReader(img))
-		if err != nil {
-			return err
-		}
-		banner = &lexutil.LexBlob{
-			Ref:      resp.Blob.Ref,
-			MimeType: "image/jpeg",
-			Size:     resp.Blob.Size,
-		}
-	}
-
-	_, err := comatproto.RepoPutRecord(context.TODO(), xrpcc, &comatproto.RepoPutRecord_Input{
-		Repo:       acc.Auth.Did,
-		Collection: "app.bsky.actor.profile",
-		Rkey:       "self",
-		Record: &lexutil.LexiconTypeDecoder{&appbsky.ActorProfile{
-			Description: &desc,
-			DisplayName: &name,
-			Avatar:      avatar,
-			Banner:      banner,
-		}},
-	})
-	return err
-}
-
 func genGraph(cctx *cli.Context) error {
-	catalog, err := readAccountCatalog(cctx.String("catalog"))
+	catalog, err := fakedata.ReadAccountCatalog(cctx.String("catalog"))
 	if err != nil {
 		return err
 	}
 
+	pdsHost := cctx.String("pds-host")
 	maxFollows := cctx.Int("max-follows")
 	maxMutes := cctx.Int("max-mutes")
 	jobs := cctx.Int("jobs")
 
-	accChan := make(chan AccountContext, len(catalog.Celebs)+len(catalog.Regulars))
+	accChan := make(chan fakedata.AccountContext, len(catalog.Celebs)+len(catalog.Regulars))
 	eg := new(errgroup.Group)
 	for i := 0; i < jobs; i++ {
 		eg.Go(func() error {
 			for acc := range accChan {
-				xrpcc, err := accountXrpcClient(cctx, &acc)
+				xrpcc, err := fakedata.AccountXrpcClient(pdsHost, &acc)
 				if err != nil {
 					return err
 				}
-				if err = pdsGenFollowsAndMutes(xrpcc, catalog, &acc, maxFollows, maxMutes); err != nil {
+				if err = fakedata.GenFollowsAndMutes(xrpcc, catalog, &acc, maxFollows, maxMutes); err != nil {
 					return err
 				}
 			}
@@ -488,249 +308,28 @@ func genGraph(cctx *cli.Context) error {
 	return eg.Wait()
 }
 
-func pdsGenPosts(xrpcc *xrpc.Client, catalog *AccountCatalog, acc *AccountContext, maxPosts int, fracImage float64, fracMention float64) error {
-
-	var mention *appbsky.FeedPost_Entity
-	var tgt *AccountContext
-	var text string
-	ctx := context.TODO()
-
-	if maxPosts < 1 {
-		return nil
-	}
-	count := rand.Intn(maxPosts)
-
-	// celebrities make 2x the posts
-	if acc.AccountType == "celebrity" {
-		count = count * 2
-	}
-	t1 := measureIterations("generate posts")
-	for i := 0; i < count; i++ {
-		text = gofakeit.Sentence(10)
-		if len(text) > 200 {
-			text = text[0:200]
-		}
-
-		// half the time, mention a celeb
-		tgt = nil
-		mention = nil
-		if fracMention > 0.0 && rand.Float64() < fracMention/2 {
-			tgt = &catalog.Regulars[rand.Intn(len(catalog.Regulars))]
-		} else if fracMention > 0.0 && rand.Float64() < fracMention/2 {
-			tgt = &catalog.Celebs[rand.Intn(len(catalog.Celebs))]
-		}
-		if tgt != nil {
-			text = "@" + tgt.Auth.Handle + " " + text
-			mention = &appbsky.FeedPost_Entity{
-				Type:  "mention",
-				Value: tgt.Auth.Did,
-				Index: &appbsky.FeedPost_TextSlice{
-					Start: 0,
-					End:   int64(len(tgt.Auth.Handle) + 1),
-				},
-			}
-		}
-
-		var images []*appbsky.EmbedImages_Image
-		if fracImage > 0.0 && rand.Float64() < fracImage {
-			img := gofakeit.ImageJpeg(800, 800)
-			resp, err := comatproto.RepoUploadBlob(context.TODO(), xrpcc, bytes.NewReader(img))
-			if err != nil {
-				return err
-			}
-			images = append(images, &appbsky.EmbedImages_Image{
-				Alt: gofakeit.Lunch(),
-				Image: &lexutil.LexBlob{
-					Ref:      resp.Blob.Ref,
-					MimeType: "image/jpeg",
-					Size:     resp.Blob.Size,
-				},
-			})
-		}
-		post := appbsky.FeedPost{
-			Text:      text,
-			CreatedAt: time.Now().Format(time.RFC3339),
-		}
-		if mention != nil {
-			post.Entities = []*appbsky.FeedPost_Entity{mention}
-		}
-		if len(images) > 0 {
-			post.Embed = &appbsky.FeedPost_Embed{
-				EmbedImages: &appbsky.EmbedImages{
-					Images: images,
-				},
-			}
-		}
-		if _, err := comatproto.RepoCreateRecord(ctx, xrpcc, &comatproto.RepoCreateRecord_Input{
-			Collection: "app.bsky.feed.post",
-			Repo:       acc.Auth.Did,
-			Record:     &lexutil.LexiconTypeDecoder{&post},
-		}); err != nil {
-			return err
-		}
-	}
-	t1(count)
-	return nil
-}
-
-func pdsCreateFollow(xrpcc *xrpc.Client, tgt *AccountContext) error {
-	follow := &appbsky.GraphFollow{
-		CreatedAt: time.Now().Format(time.RFC3339),
-		Subject:   tgt.Auth.Did,
-	}
-	_, err := comatproto.RepoCreateRecord(context.TODO(), xrpcc, &comatproto.RepoCreateRecord_Input{
-		Collection: "app.bsky.graph.follow",
-		Repo:       xrpcc.Auth.Did,
-		Record:     &lexutil.LexiconTypeDecoder{follow},
-	})
-	return err
-}
-
-func pdsCreateLike(xrpcc *xrpc.Client, viewPost *appbsky.FeedDefs_FeedViewPost) error {
-	ctx := context.TODO()
-	like := appbsky.FeedLike{
-		Subject: &comatproto.RepoStrongRef{
-			Uri: viewPost.Post.Uri,
-			Cid: viewPost.Post.Cid,
-		},
-		CreatedAt: time.Now().Format(time.RFC3339),
-	}
-	// TODO: may have already like? in that case should ignore error
-	_, err := comatproto.RepoCreateRecord(ctx, xrpcc, &comatproto.RepoCreateRecord_Input{
-		Collection: "app.bsky.feed.like",
-		Repo:       xrpcc.Auth.Did,
-		Record:     &lexutil.LexiconTypeDecoder{&like},
-	})
-	return err
-}
-
-func pdsCreateRepost(xrpcc *xrpc.Client, viewPost *appbsky.FeedDefs_FeedViewPost) error {
-	repost := &appbsky.FeedRepost{
-		CreatedAt: time.Now().Format(time.RFC3339),
-		Subject: &comatproto.RepoStrongRef{
-			Uri: viewPost.Post.Uri,
-			Cid: viewPost.Post.Cid,
-		},
-	}
-	_, err := comatproto.RepoCreateRecord(context.TODO(), xrpcc, &comatproto.RepoCreateRecord_Input{
-		Collection: "app.bsky.feed.repost",
-		Repo:       xrpcc.Auth.Did,
-		Record:     &lexutil.LexiconTypeDecoder{repost},
-	})
-	return err
-}
-
-func pdsCreateReply(xrpcc *xrpc.Client, viewPost *appbsky.FeedDefs_FeedViewPost) error {
-	text := gofakeit.Sentence(10)
-	if len(text) > 200 {
-		text = text[0:200]
-	}
-	parent := &comatproto.RepoStrongRef{
-		Uri: viewPost.Post.Uri,
-		Cid: viewPost.Post.Cid,
-	}
-	root := parent
-	if viewPost.Reply != nil {
-		root = &comatproto.RepoStrongRef{
-			Uri: viewPost.Reply.Root.Uri,
-			Cid: viewPost.Reply.Root.Cid,
-		}
-	}
-	replyPost := &appbsky.FeedPost{
-		CreatedAt: time.Now().Format(time.RFC3339),
-		Text:      text,
-		Reply: &appbsky.FeedPost_ReplyRef{
-			Parent: parent,
-			Root:   root,
-		},
-	}
-	_, err := comatproto.RepoCreateRecord(context.TODO(), xrpcc, &comatproto.RepoCreateRecord_Input{
-		Collection: "app.bsky.feed.post",
-		Repo:       xrpcc.Auth.Did,
-		Record:     &lexutil.LexiconTypeDecoder{replyPost},
-	})
-	return err
-}
-
-func pdsGenFollowsAndMutes(xrpcc *xrpc.Client, catalog *AccountCatalog, acc *AccountContext, maxFollows int, maxMutes int) error {
-
-	// TODO: have a "shape" to likelihood of doing a follow
-	var tgt *AccountContext
-
-	if maxFollows > len(catalog.Regulars) {
-		return fmt.Errorf("not enought regulars to pick maxFollowers from")
-	}
-	if maxMutes > len(catalog.Regulars) {
-		return fmt.Errorf("not enought regulars to pick maxMutes from")
-	}
-
-	regCount := 0
-	celebCount := 0
-	if maxFollows >= 1 {
-		regCount = rand.Intn(maxFollows)
-		celebCount = rand.Intn(len(catalog.Celebs))
-	}
-	t1 := measureIterations("generate follows")
-	for idx := range rand.Perm(len(catalog.Celebs))[:celebCount] {
-		tgt = &catalog.Celebs[idx]
-		if tgt.Auth.Did == acc.Auth.Did {
-			continue
-		}
-		if err := pdsCreateFollow(xrpcc, tgt); err != nil {
-			return err
-		}
-	}
-	for idx := range rand.Perm(len(catalog.Regulars))[:regCount] {
-		tgt = &catalog.Regulars[idx]
-		if tgt.Auth.Did == acc.Auth.Did {
-			continue
-		}
-		if err := pdsCreateFollow(xrpcc, tgt); err != nil {
-			return err
-		}
-	}
-	t1(regCount + celebCount)
-
-	// only muting other users, not celebs
-	muteCount := 0
-	if maxFollows >= 1 {
-		muteCount = rand.Intn(maxMutes)
-	}
-	t2 := measureIterations("generate mutes")
-	for idx := range rand.Perm(len(catalog.Regulars))[:muteCount] {
-		tgt = &catalog.Regulars[idx]
-		if tgt.Auth.Did == acc.Auth.Did {
-			continue
-		}
-		if err := appbsky.GraphMuteActor(context.TODO(), xrpcc, &appbsky.GraphMuteActor_Input{Actor: tgt.Auth.Did}); err != nil {
-			return err
-		}
-	}
-	t2(muteCount)
-	return nil
-}
-
 func genPosts(cctx *cli.Context) error {
-	catalog, err := readAccountCatalog(cctx.String("catalog"))
+	catalog, err := fakedata.ReadAccountCatalog(cctx.String("catalog"))
 	if err != nil {
 		return err
 	}
 
+	pdsHost := cctx.String("pds-host")
 	maxPosts := cctx.Int("max-posts")
 	fracImage := cctx.Float64("frac-image")
 	fracMention := cctx.Float64("frac-mention")
 	jobs := cctx.Int("jobs")
 
-	accChan := make(chan AccountContext, len(catalog.Celebs)+len(catalog.Regulars))
+	accChan := make(chan fakedata.AccountContext, len(catalog.Celebs)+len(catalog.Regulars))
 	eg := new(errgroup.Group)
 	for i := 0; i < jobs; i++ {
 		eg.Go(func() error {
 			for acc := range accChan {
-				xrpcc, err := accountXrpcClient(cctx, &acc)
+				xrpcc, err := fakedata.AccountXrpcClient(pdsHost, &acc)
 				if err != nil {
 					return err
 				}
-				if err = pdsGenPosts(xrpcc, catalog, &acc, maxPosts, fracImage, fracMention); err != nil {
+				if err = fakedata.GenPosts(xrpcc, catalog, &acc, maxPosts, fracImage, fracMention); err != nil {
 					return err
 				}
 			}
@@ -746,57 +345,29 @@ func genPosts(cctx *cli.Context) error {
 }
 
 func genInteractions(cctx *cli.Context) error {
-	catalog, err := readAccountCatalog(cctx.String("catalog"))
+	catalog, err := fakedata.ReadAccountCatalog(cctx.String("catalog"))
 	if err != nil {
 		return err
 	}
 
+	pdsHost := cctx.String("pds-host")
 	fracLike := cctx.Float64("frac-like")
 	fracRepost := cctx.Float64("frac-repost")
 	fracReply := cctx.Float64("frac-reply")
 	jobs := cctx.Int("jobs")
 
-	accChan := make(chan AccountContext, len(catalog.Celebs)+len(catalog.Regulars))
+	accChan := make(chan fakedata.AccountContext, len(catalog.Celebs)+len(catalog.Regulars))
 	eg := new(errgroup.Group)
 	for i := 0; i < jobs; i++ {
 		eg.Go(func() error {
 			for acc := range accChan {
-				xrpcc, err := accountXrpcClient(cctx, &acc)
+				xrpcc, err := fakedata.AccountXrpcClient(pdsHost, &acc)
 				if err != nil {
 					return err
 				}
-				t1 := measureIterations("all interactions")
-				// fetch timeline (up to 100), and iterate over posts
-				maxTimeline := 100
-				resp, err := appbsky.FeedGetTimeline(context.TODO(), xrpcc, "", "", int64(maxTimeline))
-				if err != nil {
+				t1 := fakedata.MeasureIterations("all interactions")
+				if err := fakedata.GenLikesRepostsReplies(xrpcc, &acc, fracLike, fracRepost, fracReply); err != nil {
 					return err
-				}
-				if len(resp.Feed) > maxTimeline {
-					return fmt.Errorf("got too long timeline len=%d", len(resp.Feed))
-				}
-				for _, post := range resp.Feed {
-					// skip account's own posts
-					if post.Post.Author.Did == acc.Auth.Did {
-						continue
-					}
-
-					// generate
-					if fracLike > 0.0 && rand.Float64() < fracLike {
-						if err := pdsCreateLike(xrpcc, post); err != nil {
-							return err
-						}
-					}
-					if fracRepost > 0.0 && rand.Float64() < fracRepost {
-						if err := pdsCreateRepost(xrpcc, post); err != nil {
-							return err
-						}
-					}
-					if fracReply > 0.0 && rand.Float64() < fracReply {
-						if err := pdsCreateReply(xrpcc, post); err != nil {
-							return err
-						}
-					}
 				}
 				t1(1)
 			}
@@ -811,101 +382,25 @@ func genInteractions(cctx *cli.Context) error {
 	return eg.Wait()
 }
 
-func browseAccount(xrpcc *xrpc.Client, acc *AccountContext) error {
-	// fetch notifications
-	maxNotif := 50
-	resp, err := appbsky.NotificationListNotifications(context.TODO(), xrpcc, "", int64(maxNotif))
-	if err != nil {
-		return err
-	}
-	if len(resp.Notifications) > maxNotif {
-		return fmt.Errorf("got too many notifications len=%d", len(resp.Notifications))
-	}
-	t1 := measureIterations("notification interactions")
-	for _, notif := range resp.Notifications {
-		switch notif.Reason {
-		case "vote":
-			fallthrough
-		case "repost":
-			fallthrough
-		case "follow":
-			_, err := appbsky.ActorGetProfile(context.TODO(), xrpcc, notif.Author.Did)
-			if err != nil {
-				return err
-			}
-			_, err = appbsky.FeedGetAuthorFeed(context.TODO(), xrpcc, notif.Author.Did, "", 50)
-			if err != nil {
-				return err
-			}
-		case "mention":
-			fallthrough
-		case "reply":
-			_, err := appbsky.FeedGetPostThread(context.TODO(), xrpcc, 4, notif.Uri)
-			if err != nil {
-				return err
-			}
-		default:
-		}
-	}
-	t1(len(resp.Notifications))
-
-	// fetch timeline (up to 100), and iterate over posts
-	timelineLen := 100
-	timelineResp, err := appbsky.FeedGetTimeline(context.TODO(), xrpcc, "", "", int64(timelineLen))
-	if err != nil {
-		return err
-	}
-	if len(timelineResp.Feed) > timelineLen {
-		return fmt.Errorf("longer than expected timeline len=%d", len(timelineResp.Feed))
-	}
-	t2 := measureIterations("timeline interactions")
-	for _, post := range timelineResp.Feed {
-		// skip account's own posts
-		if post.Post.Author.Did == acc.Auth.Did {
-			continue
-		}
-		// TODO: should we do something different here?
-		if rand.Float64() < 0.25 {
-			_, err = appbsky.FeedGetPostThread(context.TODO(), xrpcc, 4, post.Post.Uri)
-			if err != nil {
-				return err
-			}
-		} else if rand.Float64() < 0.25 {
-			_, err = appbsky.ActorGetProfile(context.TODO(), xrpcc, post.Post.Author.Did)
-			if err != nil {
-				return err
-			}
-			_, err = appbsky.FeedGetAuthorFeed(context.TODO(), xrpcc, post.Post.Author.Did, "", 50)
-			if err != nil {
-				return err
-			}
-		}
-	}
-	t2(len(timelineResp.Feed))
-
-	// notification count for good measure
-	_, err = appbsky.NotificationGetUnreadCount(context.TODO(), xrpcc)
-	return err
-}
-
 func runBrowsing(cctx *cli.Context) error {
-	catalog, err := readAccountCatalog(cctx.String("catalog"))
+	catalog, err := fakedata.ReadAccountCatalog(cctx.String("catalog"))
 	if err != nil {
 		return err
 	}
 
+	pdsHost := cctx.String("pds-host")
 	jobs := cctx.Int("jobs")
 
-	accChan := make(chan AccountContext, len(catalog.Celebs)+len(catalog.Regulars))
+	accChan := make(chan fakedata.AccountContext, len(catalog.Celebs)+len(catalog.Regulars))
 	eg := new(errgroup.Group)
 	for i := 0; i < jobs; i++ {
 		eg.Go(func() error {
 			for acc := range accChan {
-				xrpcc, err := accountXrpcClient(cctx, &acc)
+				xrpcc, err := fakedata.AccountXrpcClient(pdsHost, &acc)
 				if err != nil {
 					return err
 				}
-				if err := browseAccount(xrpcc, &acc); err != nil {
+				if err := fakedata.BrowseAccount(xrpcc, &acc); err != nil {
 					return err
 				}
 			}

--- a/fakedata/accounts.go
+++ b/fakedata/accounts.go
@@ -51,10 +51,13 @@ func ReadAccountCatalog(path string) (*AccountCatalog, error) {
 		if err := decoder.Decode(&usr); err != nil {
 			return nil, fmt.Errorf("parse AccountContext: %w", err)
 		}
-		if usr.AccountType == "celebrity" {
+		switch usr.AccountType {
+		case "celebrity":
 			catalog.Celebs = append(catalog.Celebs, usr)
-		} else {
+		case "regular":
 			catalog.Regulars = append(catalog.Regulars, usr)
+		default:
+			return nil, fmt.Errorf("unhandled account type: %v", usr.AccountType)
 		}
 	}
 	// validate index numbers

--- a/fakedata/accounts.go
+++ b/fakedata/accounts.go
@@ -1,0 +1,95 @@
+package fakedata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
+	"github.com/bluesky-social/indigo/util"
+	"github.com/bluesky-social/indigo/version"
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+type AccountCatalog struct {
+	Celebs   []AccountContext
+	Regulars []AccountContext
+}
+
+func (ac *AccountCatalog) Combined() []AccountContext {
+	var combined []AccountContext
+	for _, c := range ac.Celebs {
+		combined = append(combined, c)
+	}
+	for _, r := range ac.Regulars {
+		combined = append(combined, r)
+	}
+	return combined
+}
+
+type AccountContext struct {
+	// 0-based index; should match index
+	Index       int           `json:"index"`
+	AccountType string        `json:"accountType"`
+	Email       string        `json:"email"`
+	Password    string        `json:"password"`
+	Auth        xrpc.AuthInfo `json:"auth"`
+}
+
+func ReadAccountCatalog(path string) (*AccountCatalog, error) {
+	catalog := &AccountCatalog{}
+	catFile, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer catFile.Close()
+
+	decoder := json.NewDecoder(catFile)
+	for decoder.More() {
+		var usr AccountContext
+		if err := decoder.Decode(&usr); err != nil {
+			return nil, fmt.Errorf("parse AccountContext: %w", err)
+		}
+		if usr.AccountType == "celebrity" {
+			catalog.Celebs = append(catalog.Celebs, usr)
+		} else {
+			catalog.Regulars = append(catalog.Regulars, usr)
+		}
+	}
+	// validate index numbers
+	for i, u := range catalog.Celebs {
+		if i != u.Index {
+			return nil, fmt.Errorf("account index didn't match: %d != %d (%s)", i, u.Index, u.AccountType)
+		}
+	}
+	for i, u := range catalog.Regulars {
+		if i != u.Index {
+			return nil, fmt.Errorf("account index didn't match: %d != %d (%s)", i, u.Index, u.AccountType)
+		}
+	}
+	log.Infof("loaded account catalog: regular=%d celebrity=%d", len(catalog.Regulars), len(catalog.Celebs))
+	return catalog, nil
+}
+
+func AccountXrpcClient(pdsHost string, ac *AccountContext) (*xrpc.Client, error) {
+	httpClient := util.RobustHTTPClient()
+	ua := "IndigoFakerMaker/" + version.Version
+	xrpcc := &xrpc.Client{
+		Client:    httpClient,
+		Host:      pdsHost,
+		Auth:      &ac.Auth,
+		UserAgent: &ua,
+	}
+	// use XRPC client to re-auth using user/pass
+	auth, err := comatproto.ServerCreateSession(context.TODO(), xrpcc, &comatproto.ServerCreateSession_Input{
+		Identifier: &ac.Auth.Handle,
+		Password:   ac.Password,
+	})
+	if err != nil {
+		return nil, err
+	}
+	xrpcc.Auth.AccessJwt = auth.AccessJwt
+	xrpcc.Auth.RefreshJwt = auth.RefreshJwt
+	return xrpcc, nil
+}

--- a/fakedata/generators.go
+++ b/fakedata/generators.go
@@ -326,7 +326,7 @@ func GenFollowsAndMutes(xrpcc *xrpc.Client, catalog *AccountCatalog, acc *Accoun
 
 	// only muting other users, not celebs
 	muteCount := 0
-	if maxFollows >= 1 {
+	if maxFollows >= 1 && maxMutes > 0 {
 		muteCount = rand.Intn(maxMutes)
 	}
 	t2 := MeasureIterations("generate mutes")

--- a/fakedata/generators.go
+++ b/fakedata/generators.go
@@ -1,0 +1,457 @@
+// Helpers for randomly generated app.bsky.* content: accounts, posts, likes,
+// follows, mentions, etc
+
+package fakedata
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
+	appbsky "github.com/bluesky-social/indigo/api/bsky"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
+	"github.com/bluesky-social/indigo/xrpc"
+
+	"github.com/brianvoe/gofakeit/v6"
+	logging "github.com/ipfs/go-log"
+)
+
+var log = logging.Logger("fakedata")
+
+func MeasureIterations(name string) func(int) {
+	start := time.Now()
+	return func(count int) {
+		if count == 0 {
+			return
+		}
+		total := time.Since(start)
+		log.Infof("%s wall runtime: count=%d total=%s mean=%s", name, count, total, total/time.Duration(count))
+	}
+}
+
+func GenAccount(xrpcc *xrpc.Client, index int, accountType string) (*AccountContext, error) {
+	var suffix string
+	if accountType == "celebrity" {
+		suffix = "C"
+	} else {
+		suffix = ""
+	}
+	prefix := gofakeit.Username()
+	if len(prefix) > 10 {
+		prefix = prefix[0:10]
+	}
+	handle := fmt.Sprintf("%s-%s%d.test", prefix, suffix, index)
+	email := gofakeit.Email()
+	password := gofakeit.Password(true, true, true, true, true, 24)
+	ctx := context.TODO()
+	resp, err := comatproto.ServerCreateAccount(ctx, xrpcc, &comatproto.ServerCreateAccount_Input{
+		Email:    email,
+		Handle:   handle,
+		Password: password,
+	})
+	if err != nil {
+		return nil, err
+	}
+	auth := xrpc.AuthInfo{
+		AccessJwt:  resp.AccessJwt,
+		RefreshJwt: resp.RefreshJwt,
+		Handle:     resp.Handle,
+		Did:        resp.Did,
+	}
+	return &AccountContext{
+		Index:       index,
+		AccountType: accountType,
+		Email:       email,
+		Password:    password,
+		Auth:        auth,
+	}, nil
+}
+
+func GenProfile(xrpcc *xrpc.Client, acc *AccountContext, genAvatar, genBanner bool) error {
+
+	desc := gofakeit.HipsterSentence(12)
+	var name string
+	if acc.AccountType == "celebrity" {
+		name = gofakeit.CelebrityActor()
+	} else {
+		name = gofakeit.Name()
+	}
+
+	var avatar *lexutil.LexBlob
+	if genAvatar {
+		img := gofakeit.ImagePng(200, 200)
+		resp, err := comatproto.RepoUploadBlob(context.TODO(), xrpcc, bytes.NewReader(img))
+		if err != nil {
+			return err
+		}
+		avatar = &lexutil.LexBlob{
+			Ref:      resp.Blob.Ref,
+			MimeType: "image/png",
+			Size:     resp.Blob.Size,
+		}
+	}
+	var banner *lexutil.LexBlob
+	if genBanner {
+		img := gofakeit.ImageJpeg(800, 200)
+		resp, err := comatproto.RepoUploadBlob(context.TODO(), xrpcc, bytes.NewReader(img))
+		if err != nil {
+			return err
+		}
+		banner = &lexutil.LexBlob{
+			Ref:      resp.Blob.Ref,
+			MimeType: "image/jpeg",
+			Size:     resp.Blob.Size,
+		}
+	}
+
+	_, err := comatproto.RepoPutRecord(context.TODO(), xrpcc, &comatproto.RepoPutRecord_Input{
+		Repo:       acc.Auth.Did,
+		Collection: "app.bsky.actor.profile",
+		Rkey:       "self",
+		Record: &lexutil.LexiconTypeDecoder{&appbsky.ActorProfile{
+			Description: &desc,
+			DisplayName: &name,
+			Avatar:      avatar,
+			Banner:      banner,
+		}},
+	})
+	return err
+}
+
+func GenPosts(xrpcc *xrpc.Client, catalog *AccountCatalog, acc *AccountContext, maxPosts int, fracImage float64, fracMention float64) error {
+
+	var mention *appbsky.FeedPost_Entity
+	var tgt *AccountContext
+	var text string
+	ctx := context.TODO()
+
+	if maxPosts < 1 {
+		return nil
+	}
+	count := rand.Intn(maxPosts)
+
+	// celebrities make 2x the posts
+	if acc.AccountType == "celebrity" {
+		count = count * 2
+	}
+	t1 := MeasureIterations("generate posts")
+	for i := 0; i < count; i++ {
+		text = gofakeit.Sentence(10)
+		if len(text) > 200 {
+			text = text[0:200]
+		}
+
+		// half the time, mention a celeb
+		tgt = nil
+		mention = nil
+		if fracMention > 0.0 && rand.Float64() < fracMention/2 {
+			tgt = &catalog.Regulars[rand.Intn(len(catalog.Regulars))]
+		} else if fracMention > 0.0 && rand.Float64() < fracMention/2 {
+			tgt = &catalog.Celebs[rand.Intn(len(catalog.Celebs))]
+		}
+		if tgt != nil {
+			text = "@" + tgt.Auth.Handle + " " + text
+			mention = &appbsky.FeedPost_Entity{
+				Type:  "mention",
+				Value: tgt.Auth.Did,
+				Index: &appbsky.FeedPost_TextSlice{
+					Start: 0,
+					End:   int64(len(tgt.Auth.Handle) + 1),
+				},
+			}
+		}
+
+		var images []*appbsky.EmbedImages_Image
+		if fracImage > 0.0 && rand.Float64() < fracImage {
+			img := gofakeit.ImageJpeg(800, 800)
+			resp, err := comatproto.RepoUploadBlob(context.TODO(), xrpcc, bytes.NewReader(img))
+			if err != nil {
+				return err
+			}
+			images = append(images, &appbsky.EmbedImages_Image{
+				Alt: gofakeit.Lunch(),
+				Image: &lexutil.LexBlob{
+					Ref:      resp.Blob.Ref,
+					MimeType: "image/jpeg",
+					Size:     resp.Blob.Size,
+				},
+			})
+		}
+		post := appbsky.FeedPost{
+			Text:      text,
+			CreatedAt: time.Now().Format(time.RFC3339),
+		}
+		if mention != nil {
+			post.Entities = []*appbsky.FeedPost_Entity{mention}
+		}
+		if len(images) > 0 {
+			post.Embed = &appbsky.FeedPost_Embed{
+				EmbedImages: &appbsky.EmbedImages{
+					Images: images,
+				},
+			}
+		}
+		if _, err := comatproto.RepoCreateRecord(ctx, xrpcc, &comatproto.RepoCreateRecord_Input{
+			Collection: "app.bsky.feed.post",
+			Repo:       acc.Auth.Did,
+			Record:     &lexutil.LexiconTypeDecoder{&post},
+		}); err != nil {
+			return err
+		}
+	}
+	t1(count)
+	return nil
+}
+
+func CreateFollow(xrpcc *xrpc.Client, tgt *AccountContext) error {
+	follow := &appbsky.GraphFollow{
+		CreatedAt: time.Now().Format(time.RFC3339),
+		Subject:   tgt.Auth.Did,
+	}
+	_, err := comatproto.RepoCreateRecord(context.TODO(), xrpcc, &comatproto.RepoCreateRecord_Input{
+		Collection: "app.bsky.graph.follow",
+		Repo:       xrpcc.Auth.Did,
+		Record:     &lexutil.LexiconTypeDecoder{follow},
+	})
+	return err
+}
+
+func CreateLike(xrpcc *xrpc.Client, viewPost *appbsky.FeedDefs_FeedViewPost) error {
+	ctx := context.TODO()
+	like := appbsky.FeedLike{
+		Subject: &comatproto.RepoStrongRef{
+			Uri: viewPost.Post.Uri,
+			Cid: viewPost.Post.Cid,
+		},
+		CreatedAt: time.Now().Format(time.RFC3339),
+	}
+	// TODO: may have already like? in that case should ignore error
+	_, err := comatproto.RepoCreateRecord(ctx, xrpcc, &comatproto.RepoCreateRecord_Input{
+		Collection: "app.bsky.feed.like",
+		Repo:       xrpcc.Auth.Did,
+		Record:     &lexutil.LexiconTypeDecoder{&like},
+	})
+	return err
+}
+
+func CreateRepost(xrpcc *xrpc.Client, viewPost *appbsky.FeedDefs_FeedViewPost) error {
+	repost := &appbsky.FeedRepost{
+		CreatedAt: time.Now().Format(time.RFC3339),
+		Subject: &comatproto.RepoStrongRef{
+			Uri: viewPost.Post.Uri,
+			Cid: viewPost.Post.Cid,
+		},
+	}
+	_, err := comatproto.RepoCreateRecord(context.TODO(), xrpcc, &comatproto.RepoCreateRecord_Input{
+		Collection: "app.bsky.feed.repost",
+		Repo:       xrpcc.Auth.Did,
+		Record:     &lexutil.LexiconTypeDecoder{repost},
+	})
+	return err
+}
+
+func CreateReply(xrpcc *xrpc.Client, viewPost *appbsky.FeedDefs_FeedViewPost) error {
+	text := gofakeit.Sentence(10)
+	if len(text) > 200 {
+		text = text[0:200]
+	}
+	parent := &comatproto.RepoStrongRef{
+		Uri: viewPost.Post.Uri,
+		Cid: viewPost.Post.Cid,
+	}
+	root := parent
+	if viewPost.Reply != nil {
+		root = &comatproto.RepoStrongRef{
+			Uri: viewPost.Reply.Root.Uri,
+			Cid: viewPost.Reply.Root.Cid,
+		}
+	}
+	replyPost := &appbsky.FeedPost{
+		CreatedAt: time.Now().Format(time.RFC3339),
+		Text:      text,
+		Reply: &appbsky.FeedPost_ReplyRef{
+			Parent: parent,
+			Root:   root,
+		},
+	}
+	_, err := comatproto.RepoCreateRecord(context.TODO(), xrpcc, &comatproto.RepoCreateRecord_Input{
+		Collection: "app.bsky.feed.post",
+		Repo:       xrpcc.Auth.Did,
+		Record:     &lexutil.LexiconTypeDecoder{replyPost},
+	})
+	return err
+}
+
+func GenFollowsAndMutes(xrpcc *xrpc.Client, catalog *AccountCatalog, acc *AccountContext, maxFollows int, maxMutes int) error {
+
+	// TODO: have a "shape" to likelihood of doing a follow
+	var tgt *AccountContext
+
+	if maxFollows > len(catalog.Regulars) {
+		return fmt.Errorf("not enought regulars to pick maxFollowers from")
+	}
+	if maxMutes > len(catalog.Regulars) {
+		return fmt.Errorf("not enought regulars to pick maxMutes from")
+	}
+
+	regCount := 0
+	celebCount := 0
+	if maxFollows >= 1 {
+		regCount = rand.Intn(maxFollows)
+		celebCount = rand.Intn(len(catalog.Celebs))
+	}
+	t1 := MeasureIterations("generate follows")
+	for idx := range rand.Perm(len(catalog.Celebs))[:celebCount] {
+		tgt = &catalog.Celebs[idx]
+		if tgt.Auth.Did == acc.Auth.Did {
+			continue
+		}
+		if err := CreateFollow(xrpcc, tgt); err != nil {
+			return err
+		}
+	}
+	for idx := range rand.Perm(len(catalog.Regulars))[:regCount] {
+		tgt = &catalog.Regulars[idx]
+		if tgt.Auth.Did == acc.Auth.Did {
+			continue
+		}
+		if err := CreateFollow(xrpcc, tgt); err != nil {
+			return err
+		}
+	}
+	t1(regCount + celebCount)
+
+	// only muting other users, not celebs
+	muteCount := 0
+	if maxFollows >= 1 {
+		muteCount = rand.Intn(maxMutes)
+	}
+	t2 := MeasureIterations("generate mutes")
+	for idx := range rand.Perm(len(catalog.Regulars))[:muteCount] {
+		tgt = &catalog.Regulars[idx]
+		if tgt.Auth.Did == acc.Auth.Did {
+			continue
+		}
+		if err := appbsky.GraphMuteActor(context.TODO(), xrpcc, &appbsky.GraphMuteActor_Input{Actor: tgt.Auth.Did}); err != nil {
+			return err
+		}
+	}
+	t2(muteCount)
+	return nil
+}
+
+func GenLikesRepostsReplies(xrpcc *xrpc.Client, acc *AccountContext, fracLike, fracRepost, fracReply float64) error {
+	// fetch timeline (up to 100), and iterate over posts
+	maxTimeline := 100
+	resp, err := appbsky.FeedGetTimeline(context.TODO(), xrpcc, "", "", int64(maxTimeline))
+	if err != nil {
+		return err
+	}
+	if len(resp.Feed) > maxTimeline {
+		return fmt.Errorf("got too long timeline len=%d", len(resp.Feed))
+	}
+	for _, post := range resp.Feed {
+		// skip account's own posts
+		if post.Post.Author.Did == acc.Auth.Did {
+			continue
+		}
+
+		// generate
+		if fracLike > 0.0 && rand.Float64() < fracLike {
+			if err := CreateLike(xrpcc, post); err != nil {
+				return err
+			}
+		}
+		if fracRepost > 0.0 && rand.Float64() < fracRepost {
+			if err := CreateRepost(xrpcc, post); err != nil {
+				return err
+			}
+		}
+		if fracReply > 0.0 && rand.Float64() < fracReply {
+			if err := CreateReply(xrpcc, post); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func BrowseAccount(xrpcc *xrpc.Client, acc *AccountContext) error {
+	// fetch notifications
+	maxNotif := 50
+	resp, err := appbsky.NotificationListNotifications(context.TODO(), xrpcc, "", int64(maxNotif))
+	if err != nil {
+		return err
+	}
+	if len(resp.Notifications) > maxNotif {
+		return fmt.Errorf("got too many notifications len=%d", len(resp.Notifications))
+	}
+	t1 := MeasureIterations("notification interactions")
+	for _, notif := range resp.Notifications {
+		switch notif.Reason {
+		case "vote":
+			fallthrough
+		case "repost":
+			fallthrough
+		case "follow":
+			_, err := appbsky.ActorGetProfile(context.TODO(), xrpcc, notif.Author.Did)
+			if err != nil {
+				return err
+			}
+			_, err = appbsky.FeedGetAuthorFeed(context.TODO(), xrpcc, notif.Author.Did, "", 50)
+			if err != nil {
+				return err
+			}
+		case "mention":
+			fallthrough
+		case "reply":
+			_, err := appbsky.FeedGetPostThread(context.TODO(), xrpcc, 4, notif.Uri)
+			if err != nil {
+				return err
+			}
+		default:
+		}
+	}
+	t1(len(resp.Notifications))
+
+	// fetch timeline (up to 100), and iterate over posts
+	timelineLen := 100
+	timelineResp, err := appbsky.FeedGetTimeline(context.TODO(), xrpcc, "", "", int64(timelineLen))
+	if err != nil {
+		return err
+	}
+	if len(timelineResp.Feed) > timelineLen {
+		return fmt.Errorf("longer than expected timeline len=%d", len(timelineResp.Feed))
+	}
+	t2 := MeasureIterations("timeline interactions")
+	for _, post := range timelineResp.Feed {
+		// skip account's own posts
+		if post.Post.Author.Did == acc.Auth.Did {
+			continue
+		}
+		// TODO: should we do something different here?
+		if rand.Float64() < 0.25 {
+			_, err = appbsky.FeedGetPostThread(context.TODO(), xrpcc, 4, post.Post.Uri)
+			if err != nil {
+				return err
+			}
+		} else if rand.Float64() < 0.25 {
+			_, err = appbsky.ActorGetProfile(context.TODO(), xrpcc, post.Post.Author.Did)
+			if err != nil {
+				return err
+			}
+			_, err = appbsky.FeedGetAuthorFeed(context.TODO(), xrpcc, post.Post.Author.Did, "", 50)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	t2(len(timelineResp.Feed))
+
+	// notification count for good measure
+	_, err = appbsky.NotificationGetUnreadCount(context.TODO(), xrpcc)
+	return err
+}

--- a/fakedata/localinterop_test.go
+++ b/fakedata/localinterop_test.go
@@ -1,0 +1,91 @@
+//go:build localinterop
+
+package fakedata
+
+import (
+	"testing"
+
+	"github.com/bluesky-social/indigo/util"
+	"github.com/bluesky-social/indigo/xrpc"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	pdsHost       = "http://localhost:2583"
+	adminPassword = "admin"
+	celebCount    = 2
+	regularCount  = 5
+	maxPosts      = 5
+	maxFollows    = 5
+	maxMutes      = 2
+	fracImage     = 0.3
+	fracMention   = 0.3
+)
+
+func genTestCatalog(t *testing.T, pdsHost string) AccountCatalog {
+
+	ap := adminPassword
+	xrpccAdmin := xrpc.Client{
+		Client: util.TestingHTTPClient(),
+		Host:   pdsHost,
+	}
+	xrpccAdmin.AdminToken = &ap
+
+	var catalog AccountCatalog
+	for i := 0; i < celebCount; i++ {
+		usr, err := GenAccount(&xrpccAdmin, i, "celebrity")
+		if err != nil {
+			t.Fatal(err)
+		}
+		catalog.Celebs = append(catalog.Celebs, *usr)
+	}
+	for i := 0; i < regularCount; i++ {
+		usr, err := GenAccount(&xrpccAdmin, i, "regular")
+		if err != nil {
+			t.Fatal(err)
+		}
+		catalog.Regulars = append(catalog.Regulars, *usr)
+	}
+	return catalog
+}
+
+// runs basic fakedata generation against a local PDS process. eg, the
+// typescript implementation, running locally or in docker
+func TestFakedataLocalInterop(t *testing.T) {
+	assert := assert.New(t)
+	_ = assert
+
+	catalog := genTestCatalog(t, pdsHost)
+	combined := catalog.Combined()
+
+	// generate profile, graph, posts
+	for _, acc := range combined {
+		xrpcc, err := AccountXrpcClient(pdsHost, &acc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.NoError(GenProfile(xrpcc, &acc, true, true))
+		assert.NoError(GenFollowsAndMutes(xrpcc, &catalog, &acc, maxFollows, maxMutes))
+		assert.NoError(GenPosts(xrpcc, &catalog, &acc, maxPosts, fracImage, fracMention))
+	}
+
+	// generate interactions (additional posts, etc)
+	for _, acc := range combined {
+		xrpcc, err := AccountXrpcClient(pdsHost, &acc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.NoError(GenFollowsAndMutes(xrpcc, &catalog, &acc, maxFollows, maxMutes))
+		assert.NoError(GenPosts(xrpcc, &catalog, &acc, maxPosts, fracImage, fracMention))
+	}
+
+	// do browsing (read-only)
+	for _, acc := range combined {
+		xrpcc, err := AccountXrpcClient(pdsHost, &acc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.NoError(BrowseAccount(xrpcc, &acc))
+	}
+}

--- a/testing/pds_fakedata_test.go
+++ b/testing/pds_fakedata_test.go
@@ -1,0 +1,106 @@
+package testing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bluesky-social/indigo/fakedata"
+	"github.com/bluesky-social/indigo/util"
+	"github.com/bluesky-social/indigo/xrpc"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	pdsHost       = "http://localhost:5159"
+	adminPassword = "admin"
+	celebCount    = 2
+	regularCount  = 5
+	maxPosts      = 5
+	maxFollows    = 5
+	// TODO: golang PDS does not support putRecord
+	maxMutes    = 0 // 2
+	fracMention = 0.3
+	// TODO: golang PDS does not support images
+	genAvatar = false // true
+	genBanner = false // true
+	fracImage = 0.0   // 0.3
+)
+
+func genTestCatalog(t *testing.T, pdsHost string) fakedata.AccountCatalog {
+
+	ap := adminPassword
+	xrpccAdmin := xrpc.Client{
+		Client: util.TestingHTTPClient(),
+		Host:   pdsHost,
+	}
+	xrpccAdmin.AdminToken = &ap
+
+	var catalog fakedata.AccountCatalog
+	for i := 0; i < celebCount; i++ {
+		usr, err := fakedata.GenAccount(&xrpccAdmin, i, "celebrity")
+		if err != nil {
+			t.Fatal(err)
+		}
+		catalog.Celebs = append(catalog.Celebs, *usr)
+	}
+	for i := 0; i < regularCount; i++ {
+		usr, err := fakedata.GenAccount(&xrpccAdmin, i, "regular")
+		if err != nil {
+			t.Fatal(err)
+		}
+		catalog.Regulars = append(catalog.Regulars, *usr)
+	}
+	return catalog
+}
+
+func TestPDSFakedata(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping PDS+fakedata test in 'short' test mode")
+	}
+	assert := assert.New(t)
+	plcc := testPLC(t)
+	pds := mustSetupPDS(t, "localhost:5159", ".test", plcc)
+	pds.Run(t)
+
+	time.Sleep(time.Millisecond * 50)
+
+	catalog := genTestCatalog(t, pdsHost)
+	combined := catalog.Combined()
+	testClient := util.TestingHTTPClient()
+
+	// generate profile, graph, posts
+	for _, acc := range combined {
+		xrpcc, err := fakedata.AccountXrpcClient(pdsHost, &acc)
+		xrpcc.Client = testClient
+		if err != nil {
+			t.Fatal(err)
+		}
+		// TODO: golang PDS does not support putRecord
+		//assert.NoError(fakedata.GenProfile(xrpcc, &acc, genAvatar, genBanner))
+		assert.NoError(fakedata.GenFollowsAndMutes(xrpcc, &catalog, &acc, maxFollows, maxMutes))
+		assert.NoError(fakedata.GenPosts(xrpcc, &catalog, &acc, maxPosts, fracImage, fracMention))
+	}
+
+	// generate interactions (additional posts, etc)
+	for _, acc := range combined {
+		xrpcc, err := fakedata.AccountXrpcClient(pdsHost, &acc)
+		xrpcc.Client = testClient
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.NoError(fakedata.GenFollowsAndMutes(xrpcc, &catalog, &acc, maxFollows, maxMutes))
+		assert.NoError(fakedata.GenPosts(xrpcc, &catalog, &acc, maxPosts, fracImage, fracMention))
+	}
+
+	// do browsing (read-only)
+	for _, acc := range combined {
+		xrpcc, err := fakedata.AccountXrpcClient(pdsHost, &acc)
+		xrpcc.Client = testClient
+		if err != nil {
+			t.Fatal(err)
+		}
+		// TODO: golang listNotifications broken
+		//assert.NoError(fakedata.BrowseAccount(xrpcc, &acc))
+	}
+}

--- a/util/http.go
+++ b/util/http.go
@@ -55,3 +55,11 @@ func RobustHTTPClient() *http.Client {
 	client.Timeout = 20 * time.Second
 	return client
 }
+
+// For use in local integration tests. Short timeouts, no retries, etc
+func TestingHTTPClient() *http.Client {
+
+	client := http.DefaultClient
+	client.Timeout = 200 * time.Millisecond
+	return client
+}


### PR DESCRIPTION
Refactored fakermaker to move internal methods in to `fakedata/` package.

Then use that to write integration tests.

Some code duplication here, though note that it can be helpful to comment out parts of the complete fakermaker run when pieces are not supported.

The `const` variable under `./testing` will probably need to change.