### PR TITLE
lex: another interop test (unicode, blobs, etc)

### DIFF
--- a/lex/util/cbor_gen_test.go
+++ b/lex/util/cbor_gen_test.go
@@ -25,6 +25,815 @@ func (t *basicSchema) MarshalCBOR(w io.Writer) error {
 	}
 
 	cw := cbg.NewCborWriter(w)
+	fieldCount := 8
+
+	if t.Absent == nil {
+		fieldCount--
+	}
+
+	if _, err := cw.Write(cbg.CborEncodeMajorType(cbg.MajMap, uint64(fieldCount))); err != nil {
+		return err
+	}
+
+	// t.Bool (bool) (bool)
+	if len("bool") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"bool\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("bool"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("bool")); err != nil {
+		return err
+	}
+
+	if err := cbg.WriteBool(w, t.Bool); err != nil {
+		return err
+	}
+
+	// t.Null (string) (string)
+	if len("null") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"null\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("null"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("null")); err != nil {
+		return err
+	}
+
+	if t.Null == nil {
+		if _, err := cw.Write(cbg.CborNull); err != nil {
+			return err
+		}
+	} else {
+		if len(*t.Null) > cbg.MaxLength {
+			return xerrors.Errorf("Value in field t.Null was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.Null))); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(w, string(*t.Null)); err != nil {
+			return err
+		}
+	}
+
+	// t.Array ([]string) (slice)
+	if len("array") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"array\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("array"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("array")); err != nil {
+		return err
+	}
+
+	if len(t.Array) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Array was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Array))); err != nil {
+		return err
+	}
+	for _, v := range t.Array {
+		if len(v) > cbg.MaxLength {
+			return xerrors.Errorf("Value in field v was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(v))); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(w, string(v)); err != nil {
+			return err
+		}
+	}
+
+	// t.Absent (string) (string)
+	if t.Absent != nil {
+
+		if len("absent") > cbg.MaxLength {
+			return xerrors.Errorf("Value in field \"absent\" was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("absent"))); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(w, string("absent")); err != nil {
+			return err
+		}
+
+		if t.Absent == nil {
+			if _, err := cw.Write(cbg.CborNull); err != nil {
+				return err
+			}
+		} else {
+			if len(*t.Absent) > cbg.MaxLength {
+				return xerrors.Errorf("Value in field t.Absent was too long")
+			}
+
+			if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(*t.Absent))); err != nil {
+				return err
+			}
+			if _, err := io.WriteString(w, string(*t.Absent)); err != nil {
+				return err
+			}
+		}
+	}
+
+	// t.Object (util.basicSchemaInner) (struct)
+	if len("object") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"object\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("object"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("object")); err != nil {
+		return err
+	}
+
+	if err := t.Object.MarshalCBOR(cw); err != nil {
+		return err
+	}
+
+	// t.String (string) (string)
+	if len("string") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"string\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("string"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("string")); err != nil {
+		return err
+	}
+
+	if len(t.String) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field t.String was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.String))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string(t.String)); err != nil {
+		return err
+	}
+
+	// t.Integer (int64) (int64)
+	if len("integer") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"integer\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("integer"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("integer")); err != nil {
+		return err
+	}
+
+	if t.Integer >= 0 {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Integer)); err != nil {
+			return err
+		}
+	} else {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Integer-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.Unicode (string) (string)
+	if len("unicode") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"unicode\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("unicode"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("unicode")); err != nil {
+		return err
+	}
+
+	if len(t.Unicode) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field t.Unicode was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Unicode))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string(t.Unicode)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *basicSchema) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = basicSchema{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("basicSchema: map struct too large (%d)", extra)
+	}
+
+	var name string
+	n := extra
+
+	for i := uint64(0); i < n; i++ {
+
+		{
+			sval, err := cbg.ReadString(cr)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
+		}
+
+		switch name {
+		// t.Bool (bool) (bool)
+		case "bool":
+
+			maj, extra, err = cr.ReadHeader()
+			if err != nil {
+				return err
+			}
+			if maj != cbg.MajOther {
+				return fmt.Errorf("booleans must be major type 7")
+			}
+			switch extra {
+			case 20:
+				t.Bool = false
+			case 21:
+				t.Bool = true
+			default:
+				return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+			}
+			// t.Null (string) (string)
+		case "null":
+
+			{
+				b, err := cr.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := cr.UnreadByte(); err != nil {
+						return err
+					}
+
+					sval, err := cbg.ReadString(cr)
+					if err != nil {
+						return err
+					}
+
+					t.Null = (*string)(&sval)
+				}
+			}
+			// t.Array ([]string) (slice)
+		case "array":
+
+			maj, extra, err = cr.ReadHeader()
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.MaxLength {
+				return fmt.Errorf("t.Array: array too large (%d)", extra)
+			}
+
+			if maj != cbg.MajArray {
+				return fmt.Errorf("expected cbor array")
+			}
+
+			if extra > 0 {
+				t.Array = make([]string, extra)
+			}
+
+			for i := 0; i < int(extra); i++ {
+
+				{
+					sval, err := cbg.ReadString(cr)
+					if err != nil {
+						return err
+					}
+
+					t.Array[i] = string(sval)
+				}
+			}
+
+			// t.Absent (string) (string)
+		case "absent":
+
+			{
+				b, err := cr.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := cr.UnreadByte(); err != nil {
+						return err
+					}
+
+					sval, err := cbg.ReadString(cr)
+					if err != nil {
+						return err
+					}
+
+					t.Absent = (*string)(&sval)
+				}
+			}
+			// t.Object (util.basicSchemaInner) (struct)
+		case "object":
+
+			{
+
+				if err := t.Object.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Object: %w", err)
+				}
+
+			}
+			// t.String (string) (string)
+		case "string":
+
+			{
+				sval, err := cbg.ReadString(cr)
+				if err != nil {
+					return err
+				}
+
+				t.String = string(sval)
+			}
+			// t.Integer (int64) (int64)
+		case "integer":
+			{
+				maj, extra, err := cr.ReadHeader()
+				var extraI int64
+				if err != nil {
+					return err
+				}
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative overflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				t.Integer = int64(extraI)
+			}
+			// t.Unicode (string) (string)
+		case "unicode":
+
+			{
+				sval, err := cbg.ReadString(cr)
+				if err != nil {
+					return err
+				}
+
+				t.Unicode = string(sval)
+			}
+
+		default:
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(r, func(cid.Cid) {})
+		}
+	}
+
+	return nil
+}
+func (t *basicSchemaInner) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write([]byte{164}); err != nil {
+		return err
+	}
+
+	// t.Arr ([]string) (slice)
+	if len("arr") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"arr\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("arr"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("arr")); err != nil {
+		return err
+	}
+
+	if len(t.Arr) > cbg.MaxLength {
+		return xerrors.Errorf("Slice value in field t.Arr was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajArray, uint64(len(t.Arr))); err != nil {
+		return err
+	}
+	for _, v := range t.Arr {
+		if len(v) > cbg.MaxLength {
+			return xerrors.Errorf("Value in field v was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(v))); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(w, string(v)); err != nil {
+			return err
+		}
+	}
+
+	// t.Bool (bool) (bool)
+	if len("bool") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"bool\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("bool"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("bool")); err != nil {
+		return err
+	}
+
+	if err := cbg.WriteBool(w, t.Bool); err != nil {
+		return err
+	}
+
+	// t.Number (int64) (int64)
+	if len("number") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"number\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("number"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("number")); err != nil {
+		return err
+	}
+
+	if t.Number >= 0 {
+		if err := cw.WriteMajorTypeHeader(cbg.MajUnsignedInt, uint64(t.Number)); err != nil {
+			return err
+		}
+	} else {
+		if err := cw.WriteMajorTypeHeader(cbg.MajNegativeInt, uint64(-t.Number-1)); err != nil {
+			return err
+		}
+	}
+
+	// t.String (string) (string)
+	if len("string") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"string\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("string"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("string")); err != nil {
+		return err
+	}
+
+	if len(t.String) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field t.String was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.String))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string(t.String)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *basicSchemaInner) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = basicSchemaInner{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("basicSchemaInner: map struct too large (%d)", extra)
+	}
+
+	var name string
+	n := extra
+
+	for i := uint64(0); i < n; i++ {
+
+		{
+			sval, err := cbg.ReadString(cr)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
+		}
+
+		switch name {
+		// t.Arr ([]string) (slice)
+		case "arr":
+
+			maj, extra, err = cr.ReadHeader()
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.MaxLength {
+				return fmt.Errorf("t.Arr: array too large (%d)", extra)
+			}
+
+			if maj != cbg.MajArray {
+				return fmt.Errorf("expected cbor array")
+			}
+
+			if extra > 0 {
+				t.Arr = make([]string, extra)
+			}
+
+			for i := 0; i < int(extra); i++ {
+
+				{
+					sval, err := cbg.ReadString(cr)
+					if err != nil {
+						return err
+					}
+
+					t.Arr[i] = string(sval)
+				}
+			}
+
+			// t.Bool (bool) (bool)
+		case "bool":
+
+			maj, extra, err = cr.ReadHeader()
+			if err != nil {
+				return err
+			}
+			if maj != cbg.MajOther {
+				return fmt.Errorf("booleans must be major type 7")
+			}
+			switch extra {
+			case 20:
+				t.Bool = false
+			case 21:
+				t.Bool = true
+			default:
+				return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+			}
+			// t.Number (int64) (int64)
+		case "number":
+			{
+				maj, extra, err := cr.ReadHeader()
+				var extraI int64
+				if err != nil {
+					return err
+				}
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative overflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				t.Number = int64(extraI)
+			}
+			// t.String (string) (string)
+		case "string":
+
+			{
+				sval, err := cbg.ReadString(cr)
+				if err != nil {
+					return err
+				}
+
+				t.String = string(sval)
+			}
+
+		default:
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(r, func(cid.Cid) {})
+		}
+	}
+
+	return nil
+}
+func (t *ipldSchema) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
+
+	if _, err := cw.Write([]byte{163}); err != nil {
+		return err
+	}
+
+	// t.A (util.LexLink) (struct)
+	if len("a") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"a\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("a"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("a")); err != nil {
+		return err
+	}
+
+	if err := t.A.MarshalCBOR(cw); err != nil {
+		return err
+	}
+
+	// t.B (util.LexBytes) (slice)
+	if len("b") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"b\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("b"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("b")); err != nil {
+		return err
+	}
+
+	if len(t.B) > cbg.ByteArrayMaxLen {
+		return xerrors.Errorf("Byte array in field t.B was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.B))); err != nil {
+		return err
+	}
+
+	if _, err := cw.Write(t.B[:]); err != nil {
+		return err
+	}
+
+	// t.C (util.LexBlob) (struct)
+	if len("c") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"c\" was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("c"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("c")); err != nil {
+		return err
+	}
+
+	if err := t.C.MarshalCBOR(cw); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *ipldSchema) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = ipldSchema{}
+
+	cr := cbg.NewCborReader(r)
+
+	maj, extra, err := cr.ReadHeader()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err == io.EOF {
+			err = io.ErrUnexpectedEOF
+		}
+	}()
+
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
+	}
+
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("ipldSchema: map struct too large (%d)", extra)
+	}
+
+	var name string
+	n := extra
+
+	for i := uint64(0); i < n; i++ {
+
+		{
+			sval, err := cbg.ReadString(cr)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
+		}
+
+		switch name {
+		// t.A (util.LexLink) (struct)
+		case "a":
+
+			{
+
+				if err := t.A.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.A: %w", err)
+				}
+
+			}
+			// t.B (util.LexBytes) (slice)
+		case "b":
+
+			maj, extra, err = cr.ReadHeader()
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.ByteArrayMaxLen {
+				return fmt.Errorf("t.B: byte array too large (%d)", extra)
+			}
+			if maj != cbg.MajByteString {
+				return fmt.Errorf("expected byte array")
+			}
+
+			if extra > 0 {
+				t.B = make([]uint8, extra)
+			}
+
+			if _, err := io.ReadFull(cr, t.B[:]); err != nil {
+				return err
+			}
+			// t.C (util.LexBlob) (struct)
+		case "c":
+
+			{
+
+				if err := t.C.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.C: %w", err)
+				}
+
+			}
+
+		default:
+			// Field doesn't exist on this type, so ignore it
+			cbg.ScanForLinks(r, func(cid.Cid) {})
+		}
+	}
+
+	return nil
+}
+func (t *basicOldSchema) MarshalCBOR(w io.Writer) error {
+	if t == nil {
+		_, err := w.Write(cbg.CborNull)
+		return err
+	}
+
+	cw := cbg.NewCborWriter(w)
 	fieldCount := 7
 
 	if t.D == nil {
@@ -189,7 +998,7 @@ func (t *basicSchema) MarshalCBOR(w io.Writer) error {
 		}
 	}
 
-	// t.G (util.basicSchemaInner) (struct)
+	// t.G (util.basicOldSchemaInner) (struct)
 	if len("g") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"g\" was too long")
 	}
@@ -207,8 +1016,8 @@ func (t *basicSchema) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *basicSchema) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = basicSchema{}
+func (t *basicOldSchema) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = basicOldSchema{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -227,7 +1036,7 @@ func (t *basicSchema) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("basicSchema: map struct too large (%d)", extra)
+		return fmt.Errorf("basicOldSchema: map struct too large (%d)", extra)
 	}
 
 	var name string
@@ -374,7 +1183,7 @@ func (t *basicSchema) UnmarshalCBOR(r io.Reader) (err error) {
 				}
 			}
 
-			// t.G (util.basicSchemaInner) (struct)
+			// t.G (util.basicOldSchemaInner) (struct)
 		case "g":
 
 			{
@@ -393,7 +1202,7 @@ func (t *basicSchema) UnmarshalCBOR(r io.Reader) (err error) {
 
 	return nil
 }
-func (t *basicSchemaInner) MarshalCBOR(w io.Writer) error {
+func (t *basicOldSchemaInner) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -500,8 +1309,8 @@ func (t *basicSchemaInner) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *basicSchemaInner) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = basicSchemaInner{}
+func (t *basicOldSchemaInner) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = basicOldSchemaInner{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -520,7 +1329,7 @@ func (t *basicSchemaInner) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("basicSchemaInner: map struct too large (%d)", extra)
+		return fmt.Errorf("basicOldSchemaInner: map struct too large (%d)", extra)
 	}
 
 	var name string
@@ -633,7 +1442,7 @@ func (t *basicSchemaInner) UnmarshalCBOR(r io.Reader) (err error) {
 
 	return nil
 }
-func (t *ipldSchema) MarshalCBOR(w io.Writer) error {
+func (t *ipldOldSchema) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
@@ -687,8 +1496,8 @@ func (t *ipldSchema) MarshalCBOR(w io.Writer) error {
 	return nil
 }
 
-func (t *ipldSchema) UnmarshalCBOR(r io.Reader) (err error) {
-	*t = ipldSchema{}
+func (t *ipldOldSchema) UnmarshalCBOR(r io.Reader) (err error) {
+	*t = ipldOldSchema{}
 
 	cr := cbg.NewCborReader(r)
 
@@ -707,7 +1516,7 @@ func (t *ipldSchema) UnmarshalCBOR(r io.Reader) (err error) {
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("ipldSchema: map struct too large (%d)", extra)
+		return fmt.Errorf("ipldOldSchema: map struct too large (%d)", extra)
 	}
 
 	var name string

--- a/lex/util/lex_interop_old_test.go
+++ b/lex/util/lex_interop_old_test.go
@@ -1,0 +1,172 @@
+// This file has "old" versions of the interop tests. Might as well keep these
+// around!
+
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/assert"
+)
+
+type basicOldSchema struct {
+	A string              `json:"a" cborgen:"a"`
+	B int64               `json:"b" cborgen:"b"`
+	C bool                `json:"c" cborgen:"c"`
+	D *string             `json:"d,omitempty" cborgen:"d,omitempty"`
+	E *string             `json:"e" cborgen:"e"`
+	F []string            `json:"f" cborgen:"f"`
+	G basicOldSchemaInner `json:"g" cborgen:"g"`
+}
+
+type basicOldSchemaInner struct {
+	H string   `json:"h" cborgen:"h"`
+	I int64    `json:"i" cborgen:"i"`
+	J bool     `json:"j" cborgen:"j"`
+	K []string `json:"k" cborgen:"k"`
+}
+
+type ipldOldSchema struct {
+	A LexLink  `json:"a" cborgen:"a"`
+	B LexBytes `json:"b" cborgen:"b"`
+}
+
+func TestInteropBasicOldSchema(t *testing.T) {
+	assert := assert.New(t)
+	jsonStr := `{
+      "a": "abc",
+      "b": 123,
+      "c": true,
+      "e": null,
+      "f": ["abc", "def", "ghi"],
+      "g": {
+        "h": "abc",
+        "i": 123,
+        "j": true,
+        "k": ["abc", "def", "ghi"]
+      }
+    }`
+	goObj := basicOldSchema{
+		A: "abc",
+		B: 123,
+		C: true,
+		D: nil,
+		E: nil,
+		F: []string{"abc", "def", "ghi"},
+		G: basicOldSchemaInner{
+			H: "abc",
+			I: 123,
+			J: true,
+			K: []string{"abc", "def", "ghi"},
+		},
+	}
+	cborBytes := []byte{166, 97, 97, 99, 97, 98, 99, 97, 98, 24, 123, 97, 99, 245, 97, 101, 246,
+		97, 102, 131, 99, 97, 98, 99, 99, 100, 101, 102, 99, 103, 104, 105, 97,
+		103, 164, 97, 104, 99, 97, 98, 99, 97, 105, 24, 123, 97, 106, 245, 97,
+		107, 131, 99, 97, 98, 99, 99, 100, 101, 102, 99, 103, 104, 105}
+	cidStr := "bafyreiaioukcatdbdltzqznmyqmwgpgmoex62tkwqtdmganxgv3v5bn2o4"
+
+	// easier commenting out of code during development
+	_ = assert
+	_ = jsonStr
+	_ = goObj
+	_ = cidStr
+	_ = bytes.NewReader(cborBytes)
+
+	// basic parsing
+	jsonObj := basicOldSchema{}
+	assert.NoError(json.Unmarshal([]byte(jsonStr), &jsonObj))
+	cborObj := basicOldSchema{}
+	assert.NoError(cborObj.UnmarshalCBOR(bytes.NewReader(cborBytes)))
+
+	// compare parsed against known object
+	assert.Equal(goObj, jsonObj)
+	assert.Equal(goObj, cborObj)
+
+	// reproduce CBOR serialization
+	goCborBytes := new(bytes.Buffer)
+	assert.NoError(goObj.MarshalCBOR(goCborBytes))
+	assert.Equal(cborBytes, goCborBytes.Bytes())
+	// 0x71 = dag-cbor, 0x12 = sha2-256, 0 = default length
+	cidBuilder := cid.V1Builder{0x71, 0x12, 0}
+	goCborCid, err := cidBuilder.Sum(goCborBytes.Bytes())
+	assert.NoError(err)
+	assert.Equal(cidStr, goCborCid.String())
+
+	// reproduce JSON serialization
+	var jsonAll interface{}
+	assert.NoError(json.Unmarshal([]byte(jsonStr), &jsonAll))
+	goJsonBytes, err := json.Marshal(goObj)
+	assert.NoError(err)
+	var goJsonAll interface{}
+	assert.NoError(json.Unmarshal(goJsonBytes, &goJsonAll))
+	assert.Equal(jsonAll, goJsonAll)
+}
+
+func TestInteropIpldOldSchema(t *testing.T) {
+	assert := assert.New(t)
+
+	jsonStr := `{
+      "a": {
+        "$link": "bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a"
+      },
+      "b": {
+        "$bytes": "nFERjvLLiw9qm45JrqH9QTzyC2Lu1Xb4ne6+sBrCzI0"
+      }
+    }`
+	cidOne, err := cid.Decode("bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a")
+	assert.NoError(err)
+	goObj := ipldOldSchema{
+		A: LexLink(cidOne),
+		B: LexBytes([]byte{
+			156, 81, 17, 142, 242, 203, 139, 15, 106, 155, 142, 73, 174, 161, 253,
+			65, 60, 242, 11, 98, 238, 213, 118, 248, 157, 238, 190, 176, 26, 194,
+			204, 141,
+		}),
+	}
+	cborBytes := []byte{162, 97, 97, 216, 42, 88, 37, 0, 1, 113, 18, 32, 101, 6, 42, 90, 90, 0,
+		252, 22, 215, 60, 105, 68, 35, 124, 203, 193, 91, 28, 74, 114, 52, 72,
+		147, 54, 137, 29, 9, 23, 65, 162, 57, 208, 97, 98, 88, 32, 156, 81, 17,
+		142, 242, 203, 139, 15, 106, 155, 142, 73, 174, 161, 253, 65, 60, 242, 11,
+		98, 238, 213, 118, 248, 157, 238, 190, 176, 26, 194, 204, 141}
+	cidStr := "bafyreif37nlcsyb4ckm2i7y3w2ctnebzkib7ekzmv3tvl3mo5og2gxot5y"
+
+	// easier commenting out of code during development
+	_ = assert
+	_ = jsonStr
+	_ = goObj
+	_ = cidStr
+	_ = bytes.NewReader(cborBytes)
+
+	// basic parsing
+	jsonObj := ipldOldSchema{}
+	assert.NoError(json.Unmarshal([]byte(jsonStr), &jsonObj))
+	cborObj := ipldOldSchema{}
+	assert.NoError(cborObj.UnmarshalCBOR(bytes.NewReader(cborBytes)))
+
+	// compare parsed against known object
+	assert.Equal(goObj, jsonObj)
+	assert.Equal(goObj, cborObj)
+
+	// reproduce CBOR serialization
+	goCborBytes := new(bytes.Buffer)
+	assert.NoError(goObj.MarshalCBOR(goCborBytes))
+	assert.Equal(cborBytes, goCborBytes.Bytes())
+	// 0x71 = dag-cbor, 0x12 = sha2-256, 0 = default length
+	cidBuilder := cid.V1Builder{0x71, 0x12, 0}
+	goCborCid, err := cidBuilder.Sum(goCborBytes.Bytes())
+	assert.NoError(err)
+	assert.Equal(cidStr, goCborCid.String())
+
+	// reproduce JSON serialization
+	var jsonAll interface{}
+	assert.NoError(json.Unmarshal([]byte(jsonStr), &jsonAll))
+	goJsonBytes, err := json.Marshal(goObj)
+	assert.NoError(err)
+	var goJsonAll interface{}
+	assert.NoError(json.Unmarshal(goJsonBytes, &goJsonAll))
+	assert.Equal(jsonAll, goJsonAll)
+}

--- a/lex/util/lex_types_test.go
+++ b/lex/util/lex_types_test.go
@@ -1,0 +1,80 @@
+package util
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/assert"
+)
+
+type blobSchema struct {
+	A string  `json:"a" cborgen:"a"`
+	B LexBlob `json:"b" cborgen:"b"`
+}
+
+func TestBlobParse(t *testing.T) {
+	assert := assert.New(t)
+	jsonStr := `{
+		"a": "abc",
+		"b": {
+			"$type": "blob",
+			"ref": {
+				"$link": "bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a"
+		},
+		"mimeType": "image/png",
+		"size": 12345
+		}
+	}`
+	cidOne, err := cid.Decode("bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a")
+	goObj := blobSchema{
+		A: "abc",
+		B: LexBlob{
+			Ref:      LexLink(cidOne),
+			MimeType: "image/png",
+			Size:     12345,
+		},
+	}
+	jsonStrLegacy := `{
+		"a": "abc",
+		"b": {
+			"cid": "bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a",
+			"mimeType": "image/png"
+		}
+    }`
+	goObjLegacy := blobSchema{
+		A: "abc",
+		B: LexBlob{
+			Ref:      LexLink(cidOne),
+			MimeType: "image/png",
+			Size:     -1,
+		},
+	}
+
+	// basic parsing
+	jsonObj := blobSchema{}
+	assert.NoError(json.Unmarshal([]byte(jsonStr), &jsonObj))
+	jsonObjLegacy := blobSchema{}
+	assert.NoError(json.Unmarshal([]byte(jsonStrLegacy), &jsonObjLegacy))
+
+	// compare parsed against known object
+	assert.Equal(goObj, jsonObj)
+	assert.Equal(goObjLegacy, jsonObjLegacy)
+
+	// reproduce JSON serialization
+	var jsonAll interface{}
+	assert.NoError(json.Unmarshal([]byte(jsonStr), &jsonAll))
+	goJsonBytes, err := json.Marshal(goObj)
+	assert.NoError(err)
+	var goJsonAll interface{}
+	assert.NoError(json.Unmarshal(goJsonBytes, &goJsonAll))
+	assert.Equal(jsonAll, goJsonAll)
+
+	var jsonAllLegacy interface{}
+	assert.NoError(json.Unmarshal([]byte(jsonStrLegacy), &jsonAllLegacy))
+	goJsonBytesLegacy, err := json.Marshal(goObjLegacy)
+	assert.NoError(err)
+	var goJsonAllLegacy interface{}
+	assert.NoError(json.Unmarshal(goJsonBytesLegacy, &goJsonAllLegacy))
+	assert.Equal(jsonAllLegacy, goJsonAllLegacy)
+}


### PR DESCRIPTION
This matches up with the test vectors in: https://github.com/bluesky-social/atproto/pull/734

There was a single previous test file that i've renamed and split into interop and generic test cases. I kept the old interop test case versions (which didn't end up merged in `atproto`) around in a separate file.

Note that for golang I declared actual struct types (schemas) for these types, instead of doing generic parsing.

The "array" case (with arrays-of-arrays-of-bytes) does not work with golang cbor-gen currently, so I only have JSON tests for that.

I didn't do the "poorly formatted" test case yet, I wanted to get the basic tests in place quickly for now. It might be helpful to add a blob in that test case as well, to test generic (schema-less / struct-less) blob CID extraction.

