### PR TITLE
small test coverage improvements

### DIFF
--- a/lex/util/decoder_test.go
+++ b/lex/util/decoder_test.go
@@ -20,3 +20,20 @@ func TestLTDMarshal(t *testing.T) {
 		t.Fatal("expected an error marshalling a nil (but not a panic)")
 	}
 }
+
+func TestNewFromType(t *testing.T) {
+
+	raw, err := NewFromType("blob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob := raw.(*LexBlob)
+	if blob.Size != 0 {
+		t.Fatal("expect default/nil LexBlob")
+	}
+
+	_, err = NewFromType("bogus.type")
+	if err == nil {
+		t.Fatal("expect bogus generation to fail")
+	}
+}

--- a/mst/diff.go
+++ b/mst/diff.go
@@ -3,7 +3,6 @@ package mst
 import (
 	"context"
 	"fmt"
-	"sort"
 
 	"github.com/bluesky-social/indigo/util"
 	cid "github.com/ipfs/go-cid"
@@ -16,14 +15,6 @@ type DiffOp struct {
 	Rpath  string
 	OldCid cid.Cid
 	NewCid cid.Cid
-}
-
-func checkDiffSort(diffs []*DiffOp) {
-	if !sort.SliceIsSorted(diffs, func(i, j int) bool {
-		return diffs[i].Rpath < diffs[j].Rpath
-	}) {
-		panic(fmt.Sprintf("diff results not properly sorted! %d", len(diffs)))
-	}
 }
 
 // TODO: this code isn't great, should be rewritten on top of the baseline datastructures once functional and correct

--- a/mst/mst_test.go
+++ b/mst/mst_test.go
@@ -59,13 +59,32 @@ func TestBasicMst(t *testing.T) {
 		t.Fatal("mst generation changed", ncid.String())
 	}
 
+	// delete a key
 	nmst, err := mst.Delete(ctx, "dogs/dogs")
 	if err != nil {
 		t.Fatal(err)
 	}
 	delete(vals, "dogs/dogs")
-
 	assertValues(t, nmst, vals)
+
+	// update a key
+	newCid := randCid()
+	vals["cats/cats"] = newCid
+	nmst, err = nmst.Update(ctx, "cats/cats", newCid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertValues(t, nmst, vals)
+
+	// update deleted key should fail
+	_, err = nmst.Delete(ctx, "dogs/dogs")
+	if err == nil {
+		t.Fatal("can't delete a removed key")
+	}
+	_, err = nmst.Update(ctx, "dogs/dogs", newCid)
+	if err == nil {
+		t.Fatal("can't update a removed key")
+	}
 }
 
 func assertValues(t *testing.T, mst *MerkleSearchTree, vals map[string]cid.Cid) {


### PR DESCRIPTION
Small leftover review things from the weekend.

I assume the deleted function was used in a test or defensive programming previously, but it is unused and I think best to just remove it.

The `TestNewFromType` function is also never used and could just be deleted instead of tested.