### PR TITLE
gosky: command to output did:key for an input key file

### DIFF
--- a/cmd/gosky/main.go
+++ b/cmd/gosky/main.go
@@ -193,6 +193,7 @@ var didCmd = &cli.Command{
 	Subcommands: []*cli.Command{
 		didGetCmd,
 		didCreateCmd,
+		didKeyCmd,
 	},
 }
 
@@ -247,6 +248,23 @@ var didCreateCmd = &cli.Command{
 		}
 
 		fmt.Println(ndid)
+		return nil
+	},
+}
+
+var didKeyCmd = &cli.Command{
+	Name: "didKey",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name: "keypath",
+		},
+	},
+	Action: func(cctx *cli.Context) error {
+		sigkey, err := cliutil.LoadKeyFromFile(cctx.String("keypath"))
+		if err != nil {
+			return err
+		}
+		fmt.Println(sigkey.Public().DID())
 		return nil
 	},
 }


### PR DESCRIPTION
Small hack that was needed for manually registering a did:plc with a recovery key.