### PR TITLE
fix loop closure issue

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -152,6 +152,16 @@ func (bgs *BGS) StartDebug(listen string) error {
 	})
 	http.Handle("/prometheus", prometheusHandler())
 
+	http.HandleFunc("/feddbg/conns", func(w http.ResponseWriter, r *http.Request) {
+		b, err := json.Marshal(bgs.slurper.GetActiveList())
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		w.Write(b)
+	})
+
 	return http.ListenAndServe(listen, nil)
 }
 

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -152,7 +152,7 @@ func (bgs *BGS) StartDebug(listen string) error {
 	})
 	http.Handle("/prometheus", prometheusHandler())
 
-	http.HandleFunc("/feddbg/conns", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/debug/upstream-conns", func(w http.ResponseWriter, r *http.Request) {
 		b, err := json.Marshal(bgs.slurper.GetActiveList())
 		if err != nil {
 			http.Error(w, err.Error(), 500)


### PR DESCRIPTION
I thought that our linter would have caught this, but apparently it only catches certain shapes of this bug.
Probably worth auditing the rest of the codebase for this problem at some point (or just wait for the go team to fix it like jake said they might)