### PR TITLE
docker-compose integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ test-short: ## Run tests, skipping slower integration tests
 
 .PHONY: test-interop
 test-interop: ## Run tests, including local interop (requires services running)
-	go test -tags=localinterop ./...
+	go clean -testcache && go test -tags=localinterop ./...
 
 .PHONY: coverage-html
 coverage-html: ## Generate test coverage report and open in browser

--- a/cmd/fakermaker/README.md
+++ b/cmd/fakermaker/README.md
@@ -1,0 +1,60 @@
+
+## Running `fakermaker`
+
+Configure a `.env` file for use against `atproto` Typescript PDS implementation
+(in development mode, already running locally):
+
+	ATP_PDS_HOST=http://localhost:2583
+	ATP_AUTH_HANDLE="admin.test"
+	ATP_AUTH_PASSWORD="admin"
+	ATP_AUTH_ADMIN_PASSWORD="admin"
+
+or, against `laputa` golang PDS implementation (in this repo; already running
+locally):
+
+	ATP_PDS_HOST=http://localhost:4989
+	ATP_AUTH_HANDLE="admin.test"
+	ATP_AUTH_PASSWORD="admin"
+	ATP_AUTH_ADMIN_PASSWORD="admin"
+
+Then, from the top-level directory, run test commands:
+
+	mkdir -p data/fakermaker
+    export GOLOG_LOG_LEVEL=info
+
+    # setup and create initial accounts; 100 by default
+	go run ./cmd/fakermaker/ gen-accounts > data/fakermaker/accounts.json
+
+    # create or update profiles for all the accounts
+    go run ./cmd/fakermaker/ gen-profiles
+
+    # create follow graph between accounts
+    go run ./cmd/fakermaker/ gen-graph
+
+    # create posts, including mentions and image uploads
+    go run ./cmd/fakermaker/ gen-posts
+
+    # create more interations, such as likes, between accounts
+    go run ./cmd/fakermaker/ gen-interactions
+
+    # lastly, read-only queries, including timelines, notifications, and post threads
+    go run ./cmd/fakermaker/ run-browsing                                                                               
+
+
+## Docker Compose Integration Tests
+
+To run against Typescript services running in Docker, use the docker compose
+file in this directory.
+
+Run all the servics:
+
+    docker-compose up
+
+Then configure and run `fakermaker` using the commands above. To run automated integration tests:
+
+    # from top-level directory of this repo
+    make test-interop
+
+If you need to wipe volumes (all databases):
+
+    docker-compose down -v

--- a/cmd/fakermaker/docker-compose.yaml
+++ b/cmd/fakermaker/docker-compose.yaml
@@ -1,0 +1,125 @@
+version: '3'
+volumes:
+  dbvol:
+    driver: local
+services:
+  db:
+    image: postgres:14.3-alpine
+    restart: always
+    environment:
+      - POSTGRES_USER=bsky
+      - POSTGRES_PASSWORD=yksb
+    # intentionally *not* exposing default postgresql port to host (conflicts with other local dev DBs)
+    command: -p 6543
+    ports:
+      - '6543:6543'
+    expose:
+      - '6543'
+    volumes: 
+      - dbvol:/var/lib/postgresql/docker
+      - ./docker-create-dev-dbs.sql:/docker-entrypoint-initdb.d/create-dev-dbs.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -p 6543 -U bsky"]
+      interval: 3s
+      timeout: 2s
+      retries: 3
+
+  plc:
+    image: ghcr.io/bluesky-social/did-method-plc:plc-79cda64f2e51f0017c75e86b63afe95b100273c2
+    ports:
+      - "2582:2582"
+    expose:
+      - "2582"
+    environment:
+      - ENV=dev
+      - DATABASE_URL=postgres://bsky:yksb@db:6543/plc_dev
+      - PORT=2582
+      - DEBUG_MODE=1
+      - LOG_ENABLED=true
+      - LOG_LEVEL=info
+      - LOG_DESTINATION=1
+    working_dir: /app/packages/server
+    command: yarn run start
+    links:
+      - db
+    depends_on:
+      db:
+        condition: service_healthy
+
+  pds-one:
+    image: ghcr.io/bluesky-social/atproto:pds-c18cb6a25d2d3bb7d1e8bc32f4c4aa617c5d73be
+    ports:
+      - "2583:2583"
+    expose:
+      - "2583"
+    environment:
+      - ENV=dev
+      - DB_POSTGRES_URL=postgres://bsky:yksb@db:6543/pds_dev
+      - AVAILABLE_USER_DOMAINS=.test,.dev.bsky.dev
+      - DID_PLC_URL=http://plc:2582
+      - PORT=2583
+      - DEBUG_MODE=1
+      - LOG_LEVEL=info
+      - LOG_ENABLED=true
+      - LOG_DESTINATION=1
+    working_dir: /app/packages/pds
+    command: yarn run start
+    links:
+      - db
+      - plc
+    depends_on:
+      db:
+        condition: service_healthy
+      plc:
+        condition: service_started
+
+  bgs:
+    # to build/run locally, uncomment this instead
+    #build: ../bigsky/
+    image: ghcr.io/bluesky-social/indigo:bigsky-8c8248dc2d2767532f545fc18c949608a6baf1df
+    ports:
+      - "2470:2470"
+    environment:
+      - ATP_PLC_HOST=http://plc:2582
+      - ATP_PDS_HOST=http://pds-one:2583
+      - GOLOG_LOG_LEVEL=info
+    links:
+      - db
+      - plc
+      - pds-one
+    depends_on:
+      db:
+        condition: service_healthy
+      plc:
+        condition: service_started
+      pds-one:
+        condition: service_started
+
+  appview:
+    image: ghcr.io/bluesky-social/atproto:bsky-af9f11fbde332dfebb8c79e52f009cfd13d08346
+    ports:
+      - "2584:2584"
+    expose:
+      - "2584"
+    environment:
+      - ENV=dev
+      - DB_POSTGRES_URL=postgres://bsky:yksb@db:6543/bsky_dev
+      - DID_PLC_URL=http://plc:2582
+      - PORT=2584
+      - DEBUG_MODE=1
+      - LOG_LEVEL=info
+      - LOG_ENABLED=true
+      - LOG_DESTINATION=1
+    working_dir: /app/packages/bsky
+    command: yarn run start
+    links:
+      - db
+      - plc
+      - bgs
+    depends_on:
+      db:
+        condition: service_healthy
+      plc:
+        condition: service_started
+      bgs:
+        condition: service_started

--- a/cmd/fakermaker/docker-create-dev-dbs.sql
+++ b/cmd/fakermaker/docker-create-dev-dbs.sql
@@ -1,0 +1,5 @@
+
+CREATE DATABASE plc_dev;
+CREATE DATABASE pds_dev;
+CREATE DATABASE bgs_dev;
+CREATE DATABASE bsky_dev;

--- a/util/http.go
+++ b/util/http.go
@@ -60,6 +60,6 @@ func RobustHTTPClient() *http.Client {
 func TestingHTTPClient() *http.Client {
 
 	client := http.DefaultClient
-	client.Timeout = 200 * time.Millisecond
+	client.Timeout = 1 * time.Second
 	return client
 }


### PR DESCRIPTION
These don't run fully-automated yet, but this is a step towards additional end-to-end inter-language tests.

For now there is a single small/simple fakermaker test which runs only against the PDS.

Planned follow-ups:

- actual end-to-end tests: golang test code to talk to BGS or appview in addition to just PDS, checking that events came through
- automation of having the appview connect to BGS, and BGS connect to PDS
- additional PDS instances on separate ports, to test things like account migration
- some solution for DID and handle resolution with fake domains. maybe it will just work with HTTP resolution (vs DNS)?
- PDS configured to proxy requests to the appview