### PR TITLE
add simple auth for new admin routes and basic auth token management

### DIFF
--- a/bgs/admin.go
+++ b/bgs/admin.go
@@ -1,11 +1,36 @@
 package bgs
 
-import "github.com/labstack/echo/v4"
+import (
+	"strconv"
+
+	"github.com/bluesky-social/indigo/util"
+	"github.com/labstack/echo/v4"
+)
 
 func (bgs *BGS) handleAdminDeleteRecord(e echo.Context) error {
+	puri, err := util.ParseAtUri(e.QueryParam("uri"))
+	if err != nil {
+		return err
+	}
+
+	_ = puri
+
 	panic("TODO")
 }
 
 func (bgs *BGS) handleAdminBlockRepoStream(e echo.Context) error {
+	panic("TODO")
+}
+
+func (bgs *BGS) handleAdminDisableNewSlurps(e echo.Context) error {
+	enabled, err := strconv.ParseBool(e.QueryParam("enabled"))
+	if err != nil {
+		return err
+	}
+
+	return bgs.slurper.SetNewSubsDisabled(!enabled)
+}
+
+func (bgs *BGS) handleAdminTakedownRepo(e echo.Context) error {
 	panic("TODO")
 }

--- a/bgs/admin.go
+++ b/bgs/admin.go
@@ -1,0 +1,11 @@
+package bgs
+
+import "github.com/labstack/echo/v4"
+
+func (bgs *BGS) handleAdminDeleteRecord(e echo.Context) error {
+	panic("TODO")
+}
+
+func (bgs *BGS) handleAdminBlockRepoStream(e echo.Context) error {
+	panic("TODO")
+}

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -60,6 +60,7 @@ type BGS struct {
 
 func NewBGS(db *gorm.DB, ix *indexer.Indexer, repoman *repomgr.RepoManager, evtman *events.EventManager, didr plc.DidResolver, blobs blobs.BlobStore, ssl bool) (*BGS, error) {
 	db.AutoMigrate(User{})
+	db.AutoMigrate(AuthToken{})
 	db.AutoMigrate(models.PDS{})
 
 	bgs := &BGS{
@@ -181,7 +182,6 @@ func (bgs *BGS) Start(listen string) error {
 	// TODO: this API is temporary until we formalize what we want here
 
 	e.GET("/xrpc/com.atproto.sync.subscribeRepos", bgs.EventsHandler)
-
 	e.GET("/xrpc/com.atproto.sync.getCheckout", bgs.HandleComAtprotoSyncGetCheckout)
 	e.GET("/xrpc/com.atproto.sync.getCommitPath", bgs.HandleComAtprotoSyncGetCommitPath)
 	e.GET("/xrpc/com.atproto.sync.getHead", bgs.HandleComAtprotoSyncGetHead)
@@ -191,6 +191,9 @@ func (bgs *BGS) Start(listen string) error {
 	e.GET("/xrpc/com.atproto.sync.requestCrawl", bgs.HandleComAtprotoSyncRequestCrawl)
 	e.GET("/xrpc/com.atproto.sync.notifyOfUpdate", bgs.HandleComAtprotoSyncNotifyOfUpdate)
 	e.GET("/xrpc/_health", bgs.HandleHealthCheck)
+
+	admin := e.Group("/admin", bgs.checkAdminAuth)
+	admin.POST("/deleteRecord", bgs.handleAdminDeleteRecord)
 
 	return e.Start(listen)
 }
@@ -206,6 +209,62 @@ func (bgs *BGS) HandleHealthCheck(c echo.Context) error {
 		return c.JSON(500, HealthStatus{Status: "error", Message: "can't connect to database"})
 	} else {
 		return c.JSON(200, HealthStatus{Status: "ok"})
+	}
+}
+
+type AuthToken struct {
+	gorm.Model
+	Token string `gorm:"index"`
+}
+
+func (bgs *BGS) lookupAdminToken(tok string) (bool, error) {
+	var at AuthToken
+	if err := bgs.db.Find(&at, "token = ?", tok).Error; err != nil {
+		return false, err
+	}
+
+	if at.ID == 0 {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (bgs *BGS) CreateAdminToken(tok string) error {
+	exists, err := bgs.lookupAdminToken(tok)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		return nil
+	}
+
+	return bgs.db.Create(&AuthToken{
+		Token: tok,
+	}).Error
+}
+
+func (bgs *BGS) checkAdminAuth(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(e echo.Context) error {
+		authheader := e.Request().Header.Get("Authorization")
+		pref := "Bearer "
+		if !strings.HasPrefix(authheader, pref) {
+			return echo.ErrForbidden
+		}
+
+		token := authheader[len(pref):]
+
+		exists, err := bgs.lookupAdminToken(token)
+		if err != nil {
+			return err
+		}
+
+		if !exists {
+			return echo.ErrForbidden
+		}
+
+		return next(e)
 	}
 }
 

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -74,7 +74,12 @@ func NewBGS(db *gorm.DB, ix *indexer.Indexer, repoman *repomgr.RepoManager, evtm
 	}
 
 	ix.CreateExternalUser = bgs.createExternalUser
-	bgs.slurper = NewSlurper(db, bgs.handleFedEvent, ssl)
+	s, err := NewSlurper(db, bgs.handleFedEvent, ssl)
+	if err != nil {
+		return nil, err
+	}
+
+	bgs.slurper = s
 
 	if err := bgs.slurper.RestartAll(); err != nil {
 		return nil, err

--- a/bgs/fedmgr.go
+++ b/bgs/fedmgr.go
@@ -33,6 +33,7 @@ type Slurper struct {
 }
 
 func NewSlurper(db *gorm.DB, cb IndexCallback, ssl bool) (*Slurper, error) {
+	db.AutoMigrate(&SlurpConfig{})
 	s := &Slurper{
 		cb:     cb,
 		db:     db,

--- a/bgs/fedmgr.go
+++ b/bgs/fedmgr.go
@@ -27,22 +27,69 @@ type Slurper struct {
 	lk     sync.Mutex
 	active map[string]*models.PDS
 
+	newSubsDisabled bool
+
 	ssl bool
 }
 
-func NewSlurper(db *gorm.DB, cb IndexCallback, ssl bool) *Slurper {
-	return &Slurper{
+func NewSlurper(db *gorm.DB, cb IndexCallback, ssl bool) (*Slurper, error) {
+	s := &Slurper{
 		cb:     cb,
 		db:     db,
 		active: make(map[string]*models.PDS),
 		ssl:    ssl,
 	}
+	if err := s.loadConfig(); err != nil {
+		return nil, err
+	}
+
+	return s, nil
 }
+
+func (s *Slurper) loadConfig() error {
+	var sc SlurpConfig
+	if err := s.db.Find(&sc).Error; err != nil {
+		return err
+	}
+
+	if sc.ID == 0 {
+		if err := s.db.Create(&SlurpConfig{}).Error; err != nil {
+			return err
+		}
+	}
+
+	s.newSubsDisabled = sc.NewSubsDisabled
+
+	return nil
+}
+
+type SlurpConfig struct {
+	gorm.Model
+
+	NewSubsDisabled bool
+}
+
+func (s *Slurper) SetNewSubsDisabled(dis bool) error {
+	s.lk.Lock()
+	defer s.lk.Unlock()
+
+	if err := s.db.Model(SlurpConfig{}).Where("id = 1").Update("new_subs_disabled", dis).Error; err != nil {
+		return err
+	}
+
+	s.newSubsDisabled = dis
+	return nil
+}
+
+var ErrNewSubsDisabled = fmt.Errorf("new subscriptions temporarily disabled")
 
 func (s *Slurper) SubscribeToPds(ctx context.Context, host string, reg bool) error {
 	// TODO: for performance, lock on the hostname instead of global
 	s.lk.Lock()
 	defer s.lk.Unlock()
+	if s.newSubsDisabled {
+		return ErrNewSubsDisabled
+	}
 
 	_, ok := s.active[host]
 	if ok {
@@ -87,7 +134,7 @@ func (s *Slurper) RestartAll() error {
 	defer s.lk.Unlock()
 
 	var all []models.PDS
-	if err := s.db.Find(&all).Error; err != nil {
+	if err := s.db.Find(&all, "registered = true").Error; err != nil {
 		return err
 	}
 

--- a/cmd/bigsky/main.go
+++ b/cmd/bigsky/main.go
@@ -103,6 +103,10 @@ func run(args []string) {
 		&cli.StringFlag{
 			Name: "disk-blob-store",
 		},
+		&cli.StringFlag{
+			Name:    "admin-key",
+			EnvVars: []string{"BGS_ADMIN_KEY"},
+		},
 	}
 
 	app.Action = func(cctx *cli.Context) error {
@@ -199,6 +203,12 @@ func run(args []string) {
 		bgs, err := bgs.NewBGS(db, ix, repoman, evtman, cachedidr, blobstore, !cctx.Bool("crawl-insecure-ws"))
 		if err != nil {
 			return err
+		}
+
+		if tok := cctx.String("admin-key"); tok != "" {
+			if err := bgs.CreateAdminToken(tok); err != nil {
+				return fmt.Errorf("failed to set up admin token: %w", err)
+			}
 		}
 
 		// set up pprof endpoint

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
@@ -310,7 +309,7 @@ func (ix *Indexer) handleRecordCreate(ctx context.Context, evt *repomgr.RepoEven
 }
 
 func (ix *Indexer) crawlAtUriRef(ctx context.Context, uri string) error {
-	puri, err := parseAtUri(uri)
+	puri, err := util.ParseAtUri(uri)
 	if err != nil {
 		return err
 	} else {
@@ -538,7 +537,7 @@ func (ix *Indexer) handleRecordUpdate(ctx context.Context, evt *repomgr.RepoEven
 }
 
 func (ix *Indexer) GetPostOrMissing(ctx context.Context, uri string) (*models.FeedPost, error) {
-	puri, err := parseAtUri(uri)
+	puri, err := util.ParseAtUri(uri)
 	if err != nil {
 		return nil, err
 	}
@@ -643,7 +642,7 @@ func (ix *Indexer) GetUserOrMissing(ctx context.Context, did string) (*models.Ac
 	return ix.createMissingUserRecord(ctx, did)
 }
 
-func (ix *Indexer) createMissingPostRecord(ctx context.Context, puri *parsedUri) (*models.FeedPost, error) {
+func (ix *Indexer) createMissingPostRecord(ctx context.Context, puri *util.ParsedUri) (*models.FeedPost, error) {
 	log.Warn("creating missing post record")
 	ai, err := ix.GetUserOrMissing(ctx, puri.Did)
 	if err != nil {
@@ -793,7 +792,7 @@ func isNotFound(err error) bool {
 }
 
 func (ix *Indexer) GetPost(ctx context.Context, uri string) (*models.FeedPost, error) {
-	puri, err := parseAtUri(uri)
+	puri, err := util.ParseAtUri(uri)
 	if err != nil {
 		return nil, err
 	}
@@ -804,30 +803,6 @@ func (ix *Indexer) GetPost(ctx context.Context, uri string) (*models.FeedPost, e
 	}
 
 	return &post, nil
-}
-
-type parsedUri struct {
-	Did        string
-	Collection string
-	Rkey       string
-}
-
-func parseAtUri(uri string) (*parsedUri, error) {
-	if !strings.HasPrefix(uri, "at://") {
-		return nil, fmt.Errorf("AT uris must be prefixed with 'at://'")
-	}
-
-	trimmed := strings.TrimPrefix(uri, "at://")
-	parts := strings.Split(trimmed, "/")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("AT uris must have three parts: did, collection, tid")
-	}
-
-	return &parsedUri{
-		Did:        parts[0],
-		Collection: parts[1],
-		Rkey:       parts[2],
-	}, nil
 }
 
 // TODO: since this function is the only place we depend on the repomanager, i wonder if this should be wired some other way?

--- a/labeler/service.go
+++ b/labeler/service.go
@@ -111,7 +111,10 @@ func NewServer(db *gorm.DB, cs *carstore.CarStore, repoUser RepoConfig, plcURL, 
 		log.Infof("found labelmaker repo: %s", head)
 	}
 
-	slurp := bgs.NewSlurper(db, s.handleBgsRepoEvent, useWss)
+	slurp, err := bgs.NewSlurper(db, s.handleBgsRepoEvent, useWss)
+	if err != nil {
+		return nil, err
+	}
 	s.bgsSlurper = slurp
 
 	go evtmgr.Run()

--- a/util/uri.go
+++ b/util/uri.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ParsedUri struct {
+	Did        string
+	Collection string
+	Rkey       string
+}
+
+func ParseAtUri(uri string) (*ParsedUri, error) {
+	if !strings.HasPrefix(uri, "at://") {
+		return nil, fmt.Errorf("AT uris must be prefixed with 'at://'")
+	}
+
+	trimmed := strings.TrimPrefix(uri, "at://")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("AT uris must have three parts: did, collection, tid")
+	}
+
+	return &ParsedUri{
+		Did:        parts[0],
+		Collection: parts[1],
+		Rkey:       parts[2],
+	}, nil
+}


### PR DESCRIPTION
Adding the scaffolding for a simple admin token auth for control routes. 
Actual routes TBD, but just wanting to land the auth first as a separate thing.