### PR TITLE
WIP: websocket connection improvements

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -58,7 +58,7 @@ type BGS struct {
 	repoman *repomgr.RepoManager
 }
 
-func NewBGS(db *gorm.DB, ix *indexer.Indexer, repoman *repomgr.RepoManager, evtman *events.EventManager, didr plc.DidResolver, blobs blobs.BlobStore, ssl bool) (*BGS, error) {
+func NewBGS(db *gorm.DB, ix *indexer.Indexer, repoman *repomgr.RepoManager, evtman *events.EventManager, didr plc.DidResolver, blobs blobs.BlobStore) (*BGS, error) {
 	db.AutoMigrate(User{})
 	db.AutoMigrate(models.PDS{})
 
@@ -73,7 +73,7 @@ func NewBGS(db *gorm.DB, ix *indexer.Indexer, repoman *repomgr.RepoManager, evtm
 	}
 
 	ix.CreateExternalUser = bgs.createExternalUser
-	bgs.slurper = NewSlurper(db, bgs.handleFedEvent, ssl)
+	bgs.slurper = NewSlurper(db, bgs.handleFedEvent)
 
 	if err := bgs.slurper.RestartAll(); err != nil {
 		return nil, err

--- a/cmd/beemo/main.go
+++ b/cmd/beemo/main.go
@@ -42,16 +42,16 @@ func run(args []string) error {
 
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
-			Name:    "pds-host",
+			Name:    "pds-url",
 			Usage:   "method, hostname, and port of PDS instance",
 			Value:   "http://localhost:4849",
-			EnvVars: []string{"ATP_PDS_HOST"},
+			EnvVars: []string{"ATP_PDS_URL", "ATP_PDS_HOST"},
 		},
 		&cli.StringFlag{
-			Name:    "redsky-host",
+			Name:    "redsky-url",
 			Usage:   "method, hostname, and port of redsky, for direct links",
 			Value:   "http://localhost:3000",
-			EnvVars: []string{"ATP_REDSKY_HOST"},
+			EnvVars: []string{"ATP_REDSKY_URL", "ATP_REDSKY_HOST"},
 		},
 		&cli.StringFlag{
 			Name:     "handle",
@@ -105,7 +105,7 @@ func pollNewReports(cctx *cli.Context) error {
 	// create a new session
 	xrpcc := &xrpc.Client{
 		Client: util.RobustHTTPClient(),
-		Host:   cctx.String("pds-host"),
+		Host:   cctx.String("pds-url"),
 		Auth:   &xrpc.AuthInfo{Handle: cctx.String("handle")},
 	}
 
@@ -168,9 +168,9 @@ func pollNewReports(cctx *cli.Context) error {
 				msg := fmt.Sprintf("⚠️ New report at `%s` ⚠️\n", report.CreatedAt)
 				msg += fmt.Sprintf("report id: `%d`\t", report.Id)
 				msg += fmt.Sprintf("recent unresolved: `%d`\t", len(mrr.Reports))
-				msg += fmt.Sprintf("instance: `%s`\n", cctx.String("pds-host"))
+				msg += fmt.Sprintf("instance: `%s`\n", cctx.String("pds-url"))
 				msg += fmt.Sprintf("reasonType: `%s`\t", shortType)
-				msg += fmt.Sprintf("Redsky: %s/reports/%d\n", cctx.String("redsky-host"), report.Id)
+				msg += fmt.Sprintf("Redsky: %s/reports/%d\n", cctx.String("redsky-url"), report.Id)
 				//msg += fmt.Sprintf("reportedByDid: `%s`\n", report.ReportedByDid)
 				log.Infof("found new report, notifying slack: %s", report)
 				err := sendSlackMsg(cctx, msg)

--- a/cmd/bigsky/main.go
+++ b/cmd/bigsky/main.go
@@ -85,10 +85,6 @@ func run(args []string) {
 			EnvVars: []string{"ATP_PLC_URL", "ATP_PLC_HOST"},
 		},
 		&cli.BoolFlag{
-			Name:  "crawl-insecure-ws",
-			Usage: "when connecting to PDS instances, use ws:// instead of wss://",
-		},
-		&cli.BoolFlag{
 			Name:  "aggregation",
 			Value: true,
 		},
@@ -196,7 +192,7 @@ func run(args []string) {
 			blobstore = &blobs.DiskBlobStore{bsdir}
 		}
 
-		bgs, err := bgs.NewBGS(db, ix, repoman, evtman, cachedidr, blobstore, !cctx.Bool("crawl-insecure-ws"))
+		bgs, err := bgs.NewBGS(db, ix, repoman, evtman, cachedidr, blobstore)
 		if err != nil {
 			return err
 		}

--- a/cmd/bigsky/main.go
+++ b/cmd/bigsky/main.go
@@ -79,10 +79,10 @@ func run(args []string) {
 			EnvVars: []string{"DATA_DIR"},
 		},
 		&cli.StringFlag{
-			Name:    "plc-host",
+			Name:    "plc-url",
 			Usage:   "method, hostname, and port of PLC registry",
 			Value:   "https://plc.directory",
-			EnvVars: []string{"ATP_PLC_HOST"},
+			EnvVars: []string{"ATP_PLC_URL", "ATP_PLC_HOST"},
 		},
 		&cli.BoolFlag{
 			Name:  "crawl-insecure-ws",
@@ -162,7 +162,7 @@ func run(args []string) {
 			return err
 		}
 
-		didr := &api.PLCServer{Host: cctx.String("plc-host")}
+		didr := &api.PLCServer{Host: cctx.String("plc-url")}
 		cachedidr := plc.NewCachingDidResolver(didr, time.Minute*5, 1000)
 
 		kmgr := indexer.NewKeyManager(cachedidr, nil)

--- a/cmd/fakermaker/main.go
+++ b/cmd/fakermaker/main.go
@@ -34,10 +34,10 @@ func run(args []string) {
 
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
-			Name:    "pds-host",
+			Name:    "pds-url",
 			Usage:   "method, hostname, and port of PDS instance",
 			Value:   "http://localhost:4849",
-			EnvVars: []string{"ATP_PDS_HOST"},
+			EnvVars: []string{"ATP_PDS_URL", "ATP_PDS_HOST"},
 		},
 		&cli.StringFlag{
 			Name:     "admin-password",
@@ -244,7 +244,7 @@ func genProfiles(cctx *cli.Context) error {
 		return err
 	}
 
-	pdsHost := cctx.String("pds-host")
+	pdsHost := cctx.String("pds-url")
 	genAvatar := !cctx.Bool("no-avatars")
 	genBanner := !cctx.Bool("no-banners")
 	jobs := cctx.Int("jobs")
@@ -279,7 +279,7 @@ func genGraph(cctx *cli.Context) error {
 		return err
 	}
 
-	pdsHost := cctx.String("pds-host")
+	pdsHost := cctx.String("pds-url")
 	maxFollows := cctx.Int("max-follows")
 	maxMutes := cctx.Int("max-mutes")
 	jobs := cctx.Int("jobs")
@@ -314,7 +314,7 @@ func genPosts(cctx *cli.Context) error {
 		return err
 	}
 
-	pdsHost := cctx.String("pds-host")
+	pdsHost := cctx.String("pds-url")
 	maxPosts := cctx.Int("max-posts")
 	fracImage := cctx.Float64("frac-image")
 	fracMention := cctx.Float64("frac-mention")
@@ -350,7 +350,7 @@ func genInteractions(cctx *cli.Context) error {
 		return err
 	}
 
-	pdsHost := cctx.String("pds-host")
+	pdsHost := cctx.String("pds-url")
 	fracLike := cctx.Float64("frac-like")
 	fracRepost := cctx.Float64("frac-repost")
 	fracReply := cctx.Float64("frac-reply")
@@ -388,7 +388,7 @@ func runBrowsing(cctx *cli.Context) error {
 		return err
 	}
 
-	pdsHost := cctx.String("pds-host")
+	pdsHost := cctx.String("pds-url")
 	jobs := cctx.Int("jobs")
 
 	accChan := make(chan fakedata.AccountContext, len(catalog.Celebs)+len(catalog.Regulars))

--- a/cmd/gosky/admin.go
+++ b/cmd/gosky/admin.go
@@ -35,7 +35,7 @@ var checkUserCmd = &cli.Command{
 			Name:    "plc",
 			Usage:   "method, hostname, and port of PLC registry",
 			Value:   "https://plc.directory",
-			EnvVars: []string{"ATP_PLC_HOST"},
+			EnvVars: []string{"ATP_PDS_URL", "ATP_PLC_HOST"},
 		},
 		&cli.BoolFlag{
 			Name: "raw",

--- a/cmd/gosky/main.go
+++ b/cmd/gosky/main.go
@@ -54,7 +54,7 @@ func run(args []string) {
 			Name:    "pds-host",
 			Usage:   "method, hostname, and port of PDS instance",
 			Value:   "https://bsky.social",
-			EnvVars: []string{"ATP_PDS_HOST"},
+			EnvVars: []string{"ATP_PDS_URL", "ATP_PDS_HOST"},
 		},
 		&cli.StringFlag{
 			Name:    "auth",
@@ -191,7 +191,7 @@ var didCmd = &cli.Command{
 		&cli.StringFlag{
 			Name:    "plc",
 			Value:   "https://plc.directory",
-			EnvVars: []string{"ATP_PLC_HOST"},
+			EnvVars: []string{"ATP_PDS_URL", "ATP_PLC_HOST"},
 		},
 	},
 	Subcommands: []*cli.Command{

--- a/cmd/gosky/util/util.go
+++ b/cmd/gosky/util/util.go
@@ -86,7 +86,9 @@ func WriteConfig(cfg *CliConfig) error {
 
 func GetXrpcClient(cctx *cli.Context, authreq bool) (*xrpc.Client, error) {
 	h := "http://localhost:4989"
-	if pdsurl := cctx.String("pds-host"); pdsurl != "" {
+	if pdsurl := cctx.String("pds-url"); pdsurl != "" {
+		h = pdsurl
+	} else if pdsurl := cctx.String("pds-host"); pdsurl != "" {
 		h = pdsurl
 	}
 

--- a/cmd/labelmaker/main.go
+++ b/cmd/labelmaker/main.go
@@ -57,10 +57,10 @@ func run(args []string) error {
 			EnvVars: []string{"DATA_DIR"},
 		},
 		&cli.StringFlag{
-			Name:    "bgs-host",
-			Usage:   "hostname and port of BGS to subscribe to",
-			Value:   "localhost:2470",
-			EnvVars: []string{"ATP_BGS_HOST"},
+			Name:    "bgs-url",
+			Usage:   "method, hostname, and port of BGS to subscribe to",
+			Value:   "http://localhost:2470",
+			EnvVars: []string{"ATP_BGS_URL", "ATP_BGS_HOST"},
 		},
 		&cli.StringFlag{
 			Name:    "plc-url",
@@ -74,10 +74,6 @@ func run(args []string) error {
 			Usage:   "method, hostname, and port of PDS instance",
 			Value:   "http://localhost:4849",
 			EnvVars: []string{"ATP_PLC_URL", "ATP_PDS_HOST"},
-		},
-		&cli.BoolFlag{
-			Name:  "subscribe-insecure-ws",
-			Usage: "when connecting to BGS instance, use ws:// instead of wss://",
 		},
 		&cli.StringFlag{
 			Name:    "repo-did",
@@ -194,7 +190,6 @@ func run(args []string) error {
 		bgsURL := cctx.String("bgs-url")
 		plcURL := cctx.String("plc-url")
 		blobPdsURL := cctx.String("pds-url")
-		useWss := !cctx.Bool("subscribe-insecure-ws")
 		repoDid := cctx.String("repo-did")
 		repoHandle := cctx.String("repo-handle")
 		repoPassword := cctx.String("repo-password")
@@ -231,7 +226,7 @@ func run(args []string) error {
 			UserId:     1,
 		}
 
-		srv, err := labeler.NewServer(db, cstore, repoUser, plcURL, blobPdsURL, xrpcProxyURL, xrpcProxyAdminPassword, useWss)
+		srv, err := labeler.NewServer(db, cstore, repoUser, plcURL, blobPdsURL, xrpcProxyURL, xrpcProxyAdminPassword)
 		if err != nil {
 			return err
 		}
@@ -252,7 +247,7 @@ func run(args []string) error {
 			srv.AddSQRLLabeler(sqrlURL)
 		}
 
-		srv.SubscribeBGS(context.TODO(), bgsURL, useWss)
+		srv.SubscribeBGS(context.TODO(), bgsURL)
 		return srv.RunAPI(bind)
 	}
 

--- a/cmd/labelmaker/main.go
+++ b/cmd/labelmaker/main.go
@@ -63,17 +63,17 @@ func run(args []string) error {
 			EnvVars: []string{"ATP_BGS_HOST"},
 		},
 		&cli.StringFlag{
-			Name:    "plc-host",
+			Name:    "plc-url",
 			Usage:   "method, hostname, and port of PLC registry",
 			Value:   "https://plc.directory",
-			EnvVars: []string{"ATP_PLC_HOST"},
+			EnvVars: []string{"ATP_PLC_URL", "ATP_PLC_HOST"},
 		},
 		// TODO(bnewbold): this is a temporary hack to fetch our own blobs
 		&cli.StringFlag{
-			Name:    "pds-host",
+			Name:    "pds-url",
 			Usage:   "method, hostname, and port of PDS instance",
 			Value:   "http://localhost:4849",
-			EnvVars: []string{"ATP_PDS_HOST"},
+			EnvVars: []string{"ATP_PLC_URL", "ATP_PDS_HOST"},
 		},
 		&cli.BoolFlag{
 			Name:  "subscribe-insecure-ws",
@@ -191,9 +191,9 @@ func run(args []string) error {
 			kwl = append(kwl, labeler.KeywordLabeler{Value: "definite-article", Keywords: []string{"the"}})
 		}
 
-		bgsURL := cctx.String("bgs-host")
-		plcURL := cctx.String("plc-host")
-		blobPdsURL := cctx.String("pds-host")
+		bgsURL := cctx.String("bgs-url")
+		plcURL := cctx.String("plc-url")
+		blobPdsURL := cctx.String("pds-url")
 		useWss := !cctx.Bool("subscribe-insecure-ws")
 		repoDid := cctx.String("repo-did")
 		repoHandle := cctx.String("repo-handle")

--- a/cmd/laputa/main.go
+++ b/cmd/laputa/main.go
@@ -61,10 +61,10 @@ func run(args []string) {
 			Value: "localhost:4989",
 		},
 		&cli.StringFlag{
-			Name:    "plc-host",
+			Name:    "plc-url",
 			Usage:   "method, hostname, and port of PLC registry",
 			Value:   "https://plc.directory",
-			EnvVars: []string{"ATP_PLC_HOST"},
+			EnvVars: []string{"ATP_PLC_URL", "ATP_PLC_HOST"},
 		},
 		&cli.StringFlag{
 			Name:    "data-dir",
@@ -153,7 +153,7 @@ func run(args []string) {
 		}
 
 		var didr plc.PLCClient
-		if plchost := cctx.String("plc-host"); plchost != "" {
+		if plchost := cctx.String("plc-url"); plchost != "" {
 			didr = &api.PLCServer{Host: plchost}
 		} else {
 			didr = plc.NewFakeDid(db)

--- a/cmd/stress/main.go
+++ b/cmd/stress/main.go
@@ -70,7 +70,7 @@ var postingCmd = &cli.Command{
 			Name:    "pds-host",
 			Usage:   "method, hostname, and port of PDS instance",
 			Value:   "http://localhost:4849",
-			EnvVars: []string{"ATP_PDS_HOST"},
+			EnvVars: []string{"ATP_PDS_URL", "ATP_PDS_HOST"},
 		},
 		&cli.StringFlag{
 			Name: "invite",
@@ -167,7 +167,7 @@ var genRepoCmd = &cli.Command{
 			Name:    "pds-host",
 			Usage:   "method, hostname, and port of PDS instance",
 			Value:   "http://localhost:4849",
-			EnvVars: []string{"ATP_PDS_HOST"},
+			EnvVars: []string{"ATP_PDS_URL", "ATP_PDS_HOST"},
 		},
 	},
 	Action: func(cctx *cli.Context) error {

--- a/labeler/service.go
+++ b/labeler/service.go
@@ -62,8 +62,7 @@ type RepoConfig struct {
 }
 
 // In addition to configuring the service, will connect to upstream BGS and start processing events. Won't handle HTTP or WebSocket endpoints until RunAPI() is called.
-// 'useWss' is a flag to use SSL for outbound WebSocket connections
-func NewServer(db *gorm.DB, cs *carstore.CarStore, repoUser RepoConfig, plcURL, blobPdsURL, xrpcProxyURL, xrpcProxyAdminPassword string, useWss bool) (*Server, error) {
+func NewServer(db *gorm.DB, cs *carstore.CarStore, repoUser RepoConfig, plcURL, blobPdsURL, xrpcProxyURL, xrpcProxyAdminPassword string) (*Server, error) {
 
 	db.AutoMigrate(models.PDS{})
 	db.AutoMigrate(models.Label{})
@@ -111,7 +110,7 @@ func NewServer(db *gorm.DB, cs *carstore.CarStore, repoUser RepoConfig, plcURL, 
 		log.Infof("found labelmaker repo: %s", head)
 	}
 
-	slurp := bgs.NewSlurper(db, s.handleBgsRepoEvent, useWss)
+	slurp := bgs.NewSlurper(db, s.handleBgsRepoEvent)
 	s.bgsSlurper = slurp
 
 	go evtmgr.Run()
@@ -143,10 +142,10 @@ func (s *Server) AddSQRLLabeler(url string) {
 }
 
 // call this *after* all the labelers are configured
-func (s *Server) SubscribeBGS(ctx context.Context, bgsURL string, useWss bool) {
+func (s *Server) SubscribeBGS(ctx context.Context, bgsURL string) {
 	// subscribe our RepoEvent slurper to the BGS, to receive incoming records for labeler
-	log.Infof("subscribing to BGS: %s (SSL=%v)", bgsURL, useWss)
-	s.bgsSlurper.SubscribeToPds(ctx, bgsURL, useWss)
+	log.Infof("subscribing to BGS: %s", bgsURL)
+	s.bgsSlurper.SubscribeToPds(ctx, bgsURL, true)
 }
 
 // efficiency predicate to quickly discard events we know that we shouldn't even bother parsing

--- a/labeler/service_test.go
+++ b/labeler/service_test.go
@@ -49,7 +49,7 @@ func testLabelMaker(t *testing.T) *Server {
 		UserId:     1,
 	}
 
-	lm, err := NewServer(db, cs, repoUser, plcURL, blobPdsURL, xrpcProxyURL, xrpcProxyAdminPassword, false)
+	lm, err := NewServer(db, cs, repoUser, plcURL, blobPdsURL, xrpcProxyURL, xrpcProxyAdminPassword)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testing/labelmaker_fakedata_test.go
+++ b/testing/labelmaker_fakedata_test.go
@@ -62,7 +62,7 @@ func testLabelMaker(t *testing.T) *labeler.Server {
 	xrpcProxyURL := "http://proxy-test.dummy"
 	xrpcProxyAdminPassword := "test-dummy-password"
 
-	lm, err := labeler.NewServer(db, cs, repoUser, plcURL, blobPdsURL, xrpcProxyURL, xrpcProxyAdminPassword, false)
+	lm, err := labeler.NewServer(db, cs, repoUser, plcURL, blobPdsURL, xrpcProxyURL, xrpcProxyAdminPassword)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -392,7 +392,7 @@ func SetupBGS(host string, didr plc.PLCClient) (*testBGS, error) {
 		}
 	})
 
-	b, err := bgs.NewBGS(maindb, ix, repoman, evtman, didr, nil, false)
+	b, err := bgs.NewBGS(maindb, ix, repoman, evtman, didr, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/util/websocket.go
+++ b/util/websocket.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"strings"
+)
+
+// Takes a "host" string and returns an appropriate websocket URL. Defaults to
+// wss://, except for localhost. Tries to convert http/https to wss/ws.
+func WebsocketUrlForHost(host string) string {
+	if host == "" {
+		return ""
+	}
+	if strings.HasPrefix(host, "wss://") || strings.HasPrefix(host, "ws://") {
+		return host
+	}
+	if strings.HasPrefix(host, "https://") {
+		return "wss://" + strings.TrimPrefix(host, "https://")
+	}
+	if strings.HasPrefix(host, "http://") {
+		return "ws://" + strings.TrimPrefix(host, "http://")
+	}
+	if strings.Contains(host, "://") {
+		// don't mess with unexpected methods
+		return host
+	}
+	if strings.HasPrefix(host, "127.0.0.") || strings.HasPrefix(host, "[::1]") {
+		return "ws://" + host
+	}
+	hostname := strings.SplitN(host, ":", 2)[0]
+	if hostname == "localhost" {
+		return "ws://" + host
+	}
+	return "wss://" + host
+}

--- a/util/websocket_test.go
+++ b/util/websocket_test.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebsocketUrlForHost(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		host     string
+		expected string
+	}{
+		{"localhost", "ws://localhost"},
+		{"127.0.0.1", "ws://127.0.0.1"},
+		{"[::1]", "ws://[::1]"},
+		{"wss://127.0.0.1:443", "wss://127.0.0.1:443"},
+		{"example.com", "wss://example.com"},
+		{"ws://example.com", "ws://example.com"},
+		{"wss://example.com", "wss://example.com"},
+		{"http://example.com", "ws://example.com"},
+		{"https://example.com", "wss://example.com"},
+		{"http://example.com:123", "ws://example.com:123"},
+		{"ftp://example.com", "ftp://example.com"},
+		{"", ""},
+		{"a", "wss://a"},
+	}
+
+	for _, c := range testCases {
+		assert.Equal(c.expected, WebsocketUrlForHost(c.host))
+	}
+}


### PR DESCRIPTION
I stalled out on this SSL, `wss://`, `https://` cleanup attempt. Wanted to standardize on storing URLs for each crawl target, with http/https being stored and ws/wss getting inferred. But was more complex than expected.

Posting in case we want to harvest some of the changes out, or to come back to later.