### PR TITLE
mst: remove an alloc in isValidMstKey

### DIFF
--- a/mst/mst_test.go
+++ b/mst/mst_test.go
@@ -502,3 +502,12 @@ func diffOpEq(aa, bb *DiffOp) bool {
 	}
 	return true
 }
+
+func BenchmarkIsValidMstKey(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if !isValidMstKey("foo/foo.bar123") {
+			b.Fatal()
+		}
+	}
+}

--- a/mst/mst_util.go
+++ b/mst/mst_util.go
@@ -193,13 +193,14 @@ var reMstKeyChars = regexp.MustCompile("^[a-zA-Z0-9_:.-]+$")
 
 // Typescript: isValidMstKey(str)
 func isValidMstKey(s string) bool {
-	split := strings.Split(s, "/")
-	return (len(s) <= 256 &&
-		len(split) == 2 &&
-		len(split[0]) > 0 &&
-		len(split[1]) > 1 &&
-		reMstKeyChars.MatchString(split[0]) &&
-		reMstKeyChars.MatchString(split[1]))
+	if len(s) > 256 || strings.Count(s, "/") != 1 {
+		return false
+	}
+	a, b, _ := strings.Cut(s, "/")
+	return len(a) > 0 &&
+		len(b) > 1 &&
+		reMstKeyChars.MatchString(a) &&
+		reMstKeyChars.MatchString(b)
 }
 
 // Typescript: ensureValidMstKey(str)


### PR DESCRIPTION
    goos: darwin
    goarch: arm64
    pkg: github.com/bluesky-social/indigo/mst
                    │   before    │                after                │
                    │   sec/op    │   sec/op     vs base                │
    IsValidMstKey-8   301.1n ± 4%   262.8n ± 4%  -12.69% (p=0.000 n=10)

                    │   before   │               after                │
                    │    B/op    │   B/op     vs base                 │
    IsValidMstKey-8   32.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)

                    │   before   │                after                │
                    │ allocs/op  │ allocs/op   vs base                 │
    IsValidMstKey-8   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)