### PR TITLE
Join string slices in makeParams to fix broken urlencodes

### DIFF
--- a/xrpc/xrpc.go
+++ b/xrpc/xrpc.go
@@ -45,16 +45,16 @@ const (
 )
 
 func makeParams(p map[string]interface{}) string {
-	var parts []string
+	params := url.Values{}
 	for k, v := range p {
 		if s, ok := v.([]string); ok {
-			parts = append(parts, fmt.Sprintf("%s=%s", k, url.QueryEscape(strings.Join(s, ","))))
+			params.Add(k, strings.Join(s, ","))
 		} else {
-			parts = append(parts, fmt.Sprintf("%s=%s", k, url.QueryEscape(fmt.Sprint(v))))
+			params.Add(k, fmt.Sprint(v))
 		}
 	}
 
-	return strings.Join(parts, "&")
+	return params.Encode()
 }
 
 func (c *Client) Do(ctx context.Context, kind XRPCRequestType, inpenc string, method string, params map[string]interface{}, bodyobj interface{}, out interface{}) error {

--- a/xrpc/xrpc.go
+++ b/xrpc/xrpc.go
@@ -44,7 +44,9 @@ const (
 	Procedure
 )
 
-func makeParams(p map[string]interface{}) string {
+// makeParams converts a map of string keys and any values into a URL-encoded string.
+// If a value is a slice of strings, it will be joined with commas.
+func makeParams(p map[string]any) string {
 	params := url.Values{}
 	for k, v := range p {
 		if s, ok := v.([]string); ok {

--- a/xrpc/xrpc.go
+++ b/xrpc/xrpc.go
@@ -46,6 +46,7 @@ const (
 
 // makeParams converts a map of string keys and any values into a URL-encoded string.
 // If a value is a slice of strings, it will be joined with commas.
+// Generally the values will be strings, numbers, booleans, or slices of strings
 func makeParams(p map[string]any) string {
 	params := url.Values{}
 	for k, v := range p {

--- a/xrpc/xrpc.go
+++ b/xrpc/xrpc.go
@@ -47,7 +47,11 @@ const (
 func makeParams(p map[string]interface{}) string {
 	var parts []string
 	for k, v := range p {
-		parts = append(parts, fmt.Sprintf("%s=%s", k, url.QueryEscape(fmt.Sprint(v))))
+		if s, ok := v.([]string); ok {
+			parts = append(parts, fmt.Sprintf("%s=%s", k, url.QueryEscape(strings.Join(s, ","))))
+		} else {
+			parts = append(parts, fmt.Sprintf("%s=%s", k, url.QueryEscape(fmt.Sprint(v))))
+		}
 	}
 
 	return strings.Join(parts, "&")

--- a/xrpc/xrpc_test.go
+++ b/xrpc/xrpc_test.go
@@ -52,13 +52,8 @@ func TestMakeParams(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			result := makeParams(tc.input)
 			if result != tc.expected {
-				t.Errorf("Expected '%s', got '%s'", tc.expected, result)
+				t.Errorf("got '%q', want '%q'", result, tc.expected)
 			}
 		})
 	}
-}
-
-func TestXRPC(t *testing.T) {
-	// Run the tests
-	TestMakeParams(t)
 }

--- a/xrpc/xrpc_test.go
+++ b/xrpc/xrpc_test.go
@@ -1,0 +1,64 @@
+package xrpc
+
+import (
+	"testing"
+)
+
+// TestMakeParams tests the makeParams function.
+func TestMakeParams(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "Empty input",
+			input:    map[string]interface{}{},
+			expected: "",
+		},
+		{
+			name: "Single value",
+			input: map[string]interface{}{
+				"key": "value",
+			},
+			expected: "key=value",
+		},
+		{
+			name: "Multiple values",
+			input: map[string]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expected: "key1=value1&key2=value2",
+		},
+		{
+			name: "Slice of strings",
+			input: map[string]interface{}{
+				"key": []string{"value1", "value2", "value3"},
+			},
+			expected: "key=value1%2Cvalue2%2Cvalue3",
+		},
+		{
+			name: "Mixed values",
+			input: map[string]interface{}{
+				"key1": "value1",
+				"key2": []string{"value2", "value3"},
+			},
+			expected: "key1=value1&key2=value2%2Cvalue3",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := makeParams(tc.input)
+			if result != tc.expected {
+				t.Errorf("Expected '%s', got '%s'", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestXRPC(t *testing.T) {
+	// Run the tests
+	TestMakeParams(t)
+}


### PR DESCRIPTION
Currently the `makeParams` function will take a string slice and URL encode it as `[hello+world]` instead of `hello,world` which makes the XRPC API upset (HTTP:400 errors) since it wants a comma separated list of strings. This change tries to cast the params interface into a string slice, and if it matches, it does a join instead of just printing the debug value string into the query params.

Tested in the [GraphBuilder](https://github.com/ericvolp12/bsky-experiments/blob/main/pkg/events/helpers.go#L20) and hasn't broken anything, not sure if/what the testing plan is here.

That function previously threw 400s trying to talk to the XRPC API.

That project is using a [module replace](https://github.com/ericvolp12/bsky-experiments/blob/main/go.mod#L107) to test my commit in place of the upstream indigo package.