### PR TITLE
mst: remove alloc in leadingZerosOnHash

### DIFF
--- a/mst/mst.go
+++ b/mst/mst.go
@@ -198,7 +198,7 @@ func entriesFromNodeData(ctx context.Context, nd *NodeData, cst cbor.IpldStore) 
 	if len(nd.Entries) > 0 {
 		// NOTE(bnewbold): can compute the layer on the first KeySuffix, because for the first entry that field is a complete key
 		firstLeaf := nd.Entries[0]
-		layer = leadingZerosOnHash(string(firstLeaf.KeySuffix))
+		layer = leadingZerosOnHashBytes(firstLeaf.KeySuffix)
 	}
 
 	entries, err := deserializeNodeData(ctx, cst, nd, layer)

--- a/mst/mst_test.go
+++ b/mst/mst_test.go
@@ -511,3 +511,27 @@ func BenchmarkIsValidMstKey(b *testing.B) {
 		}
 	}
 }
+
+func TestLeadingZerosOnHashAllocs(t *testing.T) {
+	var sink int
+	const in = "some.key.prefix/key.bar123456789012334556"
+	var inb = []byte(in)
+	if n := int(testing.AllocsPerRun(1000, func() {
+		sink = leadingZerosOnHash(in)
+	})); n != 0 {
+		t.Errorf("allocs (string) = %d; want 0", n)
+	}
+	if n := int(testing.AllocsPerRun(1000, func() {
+		sink = leadingZerosOnHashBytes(inb)
+	})); n != 0 {
+		t.Errorf("allocs (bytes) = %d; want 0", n)
+	}
+	_ = sink
+}
+
+func BenchmarkLeadingZerosOnHash(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = leadingZerosOnHash("some.key.prefix/key.bar123456789012334556")
+	}
+}


### PR DESCRIPTION
    goos: darwin
    goarch: arm64
    pkg: github.com/bluesky-social/indigo/mst
                         │   before    │                after                │
                         │   sec/op    │   sec/op     vs base                │
    LeadingZerosOnHash-8   72.28n ± 3%   58.76n ± 2%  -18.71% (p=0.000 n=10)

                         │   before   │               after                │
                         │    B/op    │   B/op     vs base                 │
    LeadingZerosOnHash-8   48.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)

                         │   before   │                after                │
                         │ allocs/op  │ allocs/op   vs base                 │
    LeadingZerosOnHash-8   1.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)