### PR TITLE
lexgen: typed identifiers

### DIFF
--- a/api/atproto/admindefs.go
+++ b/api/atproto/admindefs.go
@@ -13,9 +13,9 @@ import (
 
 // AdminDefs_ActionReversal is a "actionReversal" in the com.atproto.admin.defs schema.
 type AdminDefs_ActionReversal struct {
-	CreatedAt string `json:"createdAt" cborgen:"createdAt"`
-	CreatedBy string `json:"createdBy" cborgen:"createdBy"`
-	Reason    string `json:"reason" cborgen:"reason"`
+	CreatedAt string         `json:"createdAt" cborgen:"createdAt"`
+	CreatedBy util.FormatDID `json:"createdBy" cborgen:"createdBy"`
+	Reason    string         `json:"reason" cborgen:"reason"`
 }
 
 // AdminDefs_ActionView is a "actionView" in the com.atproto.admin.defs schema.
@@ -23,7 +23,7 @@ type AdminDefs_ActionView struct {
 	Action            *string                       `json:"action" cborgen:"action"`
 	CreateLabelVals   []string                      `json:"createLabelVals,omitempty" cborgen:"createLabelVals,omitempty"`
 	CreatedAt         string                        `json:"createdAt" cborgen:"createdAt"`
-	CreatedBy         string                        `json:"createdBy" cborgen:"createdBy"`
+	CreatedBy         util.FormatDID                `json:"createdBy" cborgen:"createdBy"`
 	Id                int64                         `json:"id" cborgen:"id"`
 	NegateLabelVals   []string                      `json:"negateLabelVals,omitempty" cborgen:"negateLabelVals,omitempty"`
 	Reason            string                        `json:"reason" cborgen:"reason"`
@@ -44,7 +44,7 @@ type AdminDefs_ActionViewDetail struct {
 	Action          *string                             `json:"action" cborgen:"action"`
 	CreateLabelVals []string                            `json:"createLabelVals,omitempty" cborgen:"createLabelVals,omitempty"`
 	CreatedAt       string                              `json:"createdAt" cborgen:"createdAt"`
-	CreatedBy       string                              `json:"createdBy" cborgen:"createdBy"`
+	CreatedBy       util.FormatDID                      `json:"createdBy" cborgen:"createdBy"`
 	Id              int64                               `json:"id" cborgen:"id"`
 	NegateLabelVals []string                            `json:"negateLabelVals,omitempty" cborgen:"negateLabelVals,omitempty"`
 	Reason          string                              `json:"reason" cborgen:"reason"`
@@ -126,7 +126,7 @@ func (t *AdminDefs_ActionView_Subject) UnmarshalJSON(b []byte) error {
 
 // AdminDefs_BlobView is a "blobView" in the com.atproto.admin.defs schema.
 type AdminDefs_BlobView struct {
-	Cid        string                      `json:"cid" cborgen:"cid"`
+	Cid        util.FormatCID              `json:"cid" cborgen:"cid"`
 	CreatedAt  string                      `json:"createdAt" cborgen:"createdAt"`
 	Details    *AdminDefs_BlobView_Details `json:"details,omitempty" cborgen:"details,omitempty"`
 	MimeType   string                      `json:"mimeType" cborgen:"mimeType"`
@@ -195,24 +195,24 @@ type AdminDefs_ModerationDetail struct {
 // RECORDTYPE: AdminDefs_RecordView
 type AdminDefs_RecordView struct {
 	LexiconTypeID string                   `json:"$type,const=com.atproto.admin.defs" cborgen:"$type,const=com.atproto.admin.defs"`
-	BlobCids      []string                 `json:"blobCids" cborgen:"blobCids"`
-	Cid           string                   `json:"cid" cborgen:"cid"`
+	BlobCids      []util.FormatCID         `json:"blobCids" cborgen:"blobCids"`
+	Cid           util.FormatCID           `json:"cid" cborgen:"cid"`
 	IndexedAt     string                   `json:"indexedAt" cborgen:"indexedAt"`
 	Moderation    *AdminDefs_Moderation    `json:"moderation" cborgen:"moderation"`
 	Repo          *AdminDefs_RepoView      `json:"repo" cborgen:"repo"`
-	Uri           string                   `json:"uri" cborgen:"uri"`
+	Uri           util.FormatAtURI         `json:"uri" cborgen:"uri"`
 	Value         *util.LexiconTypeDecoder `json:"value" cborgen:"value"`
 }
 
 // AdminDefs_RecordViewDetail is a "recordViewDetail" in the com.atproto.admin.defs schema.
 type AdminDefs_RecordViewDetail struct {
 	Blobs      []*AdminDefs_BlobView       `json:"blobs" cborgen:"blobs"`
-	Cid        string                      `json:"cid" cborgen:"cid"`
+	Cid        util.FormatCID              `json:"cid" cborgen:"cid"`
 	IndexedAt  string                      `json:"indexedAt" cborgen:"indexedAt"`
 	Labels     []*LabelDefs_Label          `json:"labels,omitempty" cborgen:"labels,omitempty"`
 	Moderation *AdminDefs_ModerationDetail `json:"moderation" cborgen:"moderation"`
 	Repo       *AdminDefs_RepoView         `json:"repo" cborgen:"repo"`
-	Uri        string                      `json:"uri" cborgen:"uri"`
+	Uri        util.FormatAtURI            `json:"uri" cborgen:"uri"`
 	Value      *util.LexiconTypeDecoder    `json:"value" cborgen:"value"`
 }
 
@@ -220,8 +220,8 @@ type AdminDefs_RecordViewDetail struct {
 //
 // RECORDTYPE: AdminDefs_RepoRef
 type AdminDefs_RepoRef struct {
-	LexiconTypeID string `json:"$type,const=com.atproto.admin.defs" cborgen:"$type,const=com.atproto.admin.defs"`
-	Did           string `json:"did" cborgen:"did"`
+	LexiconTypeID string         `json:"$type,const=com.atproto.admin.defs" cborgen:"$type,const=com.atproto.admin.defs"`
+	Did           util.FormatDID `json:"did" cborgen:"did"`
 }
 
 // AdminDefs_RepoView is a "repoView" in the com.atproto.admin.defs schema.
@@ -229,9 +229,9 @@ type AdminDefs_RepoRef struct {
 // RECORDTYPE: AdminDefs_RepoView
 type AdminDefs_RepoView struct {
 	LexiconTypeID  string                     `json:"$type,const=com.atproto.admin.defs" cborgen:"$type,const=com.atproto.admin.defs"`
-	Did            string                     `json:"did" cborgen:"did"`
+	Did            util.FormatDID             `json:"did" cborgen:"did"`
 	Email          *string                    `json:"email,omitempty" cborgen:"email,omitempty"`
-	Handle         string                     `json:"handle" cborgen:"handle"`
+	Handle         util.FormatHandle          `json:"handle" cborgen:"handle"`
 	IndexedAt      string                     `json:"indexedAt" cborgen:"indexedAt"`
 	InvitedBy      *ServerDefs_InviteCode     `json:"invitedBy,omitempty" cborgen:"invitedBy,omitempty"`
 	Moderation     *AdminDefs_Moderation      `json:"moderation" cborgen:"moderation"`
@@ -240,9 +240,9 @@ type AdminDefs_RepoView struct {
 
 // AdminDefs_RepoViewDetail is a "repoViewDetail" in the com.atproto.admin.defs schema.
 type AdminDefs_RepoViewDetail struct {
-	Did            string                      `json:"did" cborgen:"did"`
+	Did            util.FormatDID              `json:"did" cborgen:"did"`
 	Email          *string                     `json:"email,omitempty" cborgen:"email,omitempty"`
-	Handle         string                      `json:"handle" cborgen:"handle"`
+	Handle         util.FormatHandle           `json:"handle" cborgen:"handle"`
 	IndexedAt      string                      `json:"indexedAt" cborgen:"indexedAt"`
 	InvitedBy      *ServerDefs_InviteCode      `json:"invitedBy,omitempty" cborgen:"invitedBy,omitempty"`
 	Invites        []*ServerDefs_InviteCode    `json:"invites,omitempty" cborgen:"invites,omitempty"`
@@ -257,7 +257,7 @@ type AdminDefs_ReportView struct {
 	Id                  int64                         `json:"id" cborgen:"id"`
 	Reason              *string                       `json:"reason,omitempty" cborgen:"reason,omitempty"`
 	ReasonType          *string                       `json:"reasonType" cborgen:"reasonType"`
-	ReportedBy          string                        `json:"reportedBy" cborgen:"reportedBy"`
+	ReportedBy          util.FormatDID                `json:"reportedBy" cborgen:"reportedBy"`
 	ResolvedByActionIds []int64                       `json:"resolvedByActionIds" cborgen:"resolvedByActionIds"`
 	Subject             *AdminDefs_ReportView_Subject `json:"subject" cborgen:"subject"`
 }
@@ -268,7 +268,7 @@ type AdminDefs_ReportViewDetail struct {
 	Id                int64                               `json:"id" cborgen:"id"`
 	Reason            *string                             `json:"reason,omitempty" cborgen:"reason,omitempty"`
 	ReasonType        *string                             `json:"reasonType" cborgen:"reasonType"`
-	ReportedBy        string                              `json:"reportedBy" cborgen:"reportedBy"`
+	ReportedBy        util.FormatDID                      `json:"reportedBy" cborgen:"reportedBy"`
 	ResolvedByActions []*AdminDefs_ActionView             `json:"resolvedByActions" cborgen:"resolvedByActions"`
 	Subject           *AdminDefs_ReportViewDetail_Subject `json:"subject" cborgen:"subject"`
 }

--- a/api/atproto/admingetRecord.go
+++ b/api/atproto/admingetRecord.go
@@ -7,11 +7,12 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // AdminGetRecord calls the XRPC method "com.atproto.admin.getRecord".
-func AdminGetRecord(ctx context.Context, c *xrpc.Client, cid string, uri string) (*AdminDefs_RecordViewDetail, error) {
+func AdminGetRecord(ctx context.Context, c *xrpc.Client, cid util.FormatCID, uri util.FormatAtURI) (*AdminDefs_RecordViewDetail, error) {
 	var out AdminDefs_RecordViewDetail
 
 	params := map[string]interface{}{

--- a/api/atproto/admingetRepo.go
+++ b/api/atproto/admingetRepo.go
@@ -7,11 +7,12 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // AdminGetRepo calls the XRPC method "com.atproto.admin.getRepo".
-func AdminGetRepo(ctx context.Context, c *xrpc.Client, did string) (*AdminDefs_RepoViewDetail, error) {
+func AdminGetRepo(ctx context.Context, c *xrpc.Client, did util.FormatDID) (*AdminDefs_RepoViewDetail, error) {
 	var out AdminDefs_RepoViewDetail
 
 	params := map[string]interface{}{

--- a/api/atproto/adminresolveModerationReports.go
+++ b/api/atproto/adminresolveModerationReports.go
@@ -7,14 +7,15 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // AdminResolveModerationReports_Input is the input argument to a com.atproto.admin.resolveModerationReports call.
 type AdminResolveModerationReports_Input struct {
-	ActionId  int64   `json:"actionId" cborgen:"actionId"`
-	CreatedBy string  `json:"createdBy" cborgen:"createdBy"`
-	ReportIds []int64 `json:"reportIds" cborgen:"reportIds"`
+	ActionId  int64          `json:"actionId" cborgen:"actionId"`
+	CreatedBy util.FormatDID `json:"createdBy" cborgen:"createdBy"`
+	ReportIds []int64        `json:"reportIds" cborgen:"reportIds"`
 }
 
 // AdminResolveModerationReports calls the XRPC method "com.atproto.admin.resolveModerationReports".

--- a/api/atproto/adminreverseModerationAction.go
+++ b/api/atproto/adminreverseModerationAction.go
@@ -7,14 +7,15 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // AdminReverseModerationAction_Input is the input argument to a com.atproto.admin.reverseModerationAction call.
 type AdminReverseModerationAction_Input struct {
-	CreatedBy string `json:"createdBy" cborgen:"createdBy"`
-	Id        int64  `json:"id" cborgen:"id"`
-	Reason    string `json:"reason" cborgen:"reason"`
+	CreatedBy util.FormatDID `json:"createdBy" cborgen:"createdBy"`
+	Id        int64          `json:"id" cborgen:"id"`
+	Reason    string         `json:"reason" cborgen:"reason"`
 }
 
 // AdminReverseModerationAction calls the XRPC method "com.atproto.admin.reverseModerationAction".

--- a/api/atproto/admintakeModerationAction.go
+++ b/api/atproto/admintakeModerationAction.go
@@ -17,11 +17,11 @@ import (
 type AdminTakeModerationAction_Input struct {
 	Action          string                                   `json:"action" cborgen:"action"`
 	CreateLabelVals []string                                 `json:"createLabelVals,omitempty" cborgen:"createLabelVals,omitempty"`
-	CreatedBy       string                                   `json:"createdBy" cborgen:"createdBy"`
+	CreatedBy       util.FormatDID                           `json:"createdBy" cborgen:"createdBy"`
 	NegateLabelVals []string                                 `json:"negateLabelVals,omitempty" cborgen:"negateLabelVals,omitempty"`
 	Reason          string                                   `json:"reason" cborgen:"reason"`
 	Subject         *AdminTakeModerationAction_Input_Subject `json:"subject" cborgen:"subject"`
-	SubjectBlobCids []string                                 `json:"subjectBlobCids,omitempty" cborgen:"subjectBlobCids,omitempty"`
+	SubjectBlobCids []util.FormatCID                         `json:"subjectBlobCids,omitempty" cborgen:"subjectBlobCids,omitempty"`
 }
 
 type AdminTakeModerationAction_Input_Subject struct {

--- a/api/atproto/adminupdateAccountEmail.go
+++ b/api/atproto/adminupdateAccountEmail.go
@@ -7,14 +7,15 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // AdminUpdateAccountEmail_Input is the input argument to a com.atproto.admin.updateAccountEmail call.
 type AdminUpdateAccountEmail_Input struct {
 	// account: The handle or DID of the repo.
-	Account string `json:"account" cborgen:"account"`
-	Email   string `json:"email" cborgen:"email"`
+	Account util.FormatAtIdentifier `json:"account" cborgen:"account"`
+	Email   string                  `json:"email" cborgen:"email"`
 }
 
 // AdminUpdateAccountEmail calls the XRPC method "com.atproto.admin.updateAccountEmail".

--- a/api/atproto/adminupdateAccountHandle.go
+++ b/api/atproto/adminupdateAccountHandle.go
@@ -7,13 +7,14 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // AdminUpdateAccountHandle_Input is the input argument to a com.atproto.admin.updateAccountHandle call.
 type AdminUpdateAccountHandle_Input struct {
-	Did    string `json:"did" cborgen:"did"`
-	Handle string `json:"handle" cborgen:"handle"`
+	Did    util.FormatDID    `json:"did" cborgen:"did"`
+	Handle util.FormatHandle `json:"handle" cborgen:"handle"`
 }
 
 // AdminUpdateAccountHandle calls the XRPC method "com.atproto.admin.updateAccountHandle".

--- a/api/atproto/cbor_gen.go
+++ b/api/atproto/cbor_gen.go
@@ -36,7 +36,7 @@ func (t *RepoStrongRef) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Cid (string) (string)
+	// t.Cid (util.FormatCID) (struct)
 	if len("cid") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"cid\" was too long")
 	}
@@ -48,18 +48,11 @@ func (t *RepoStrongRef) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if len(t.Cid) > cbg.MaxLength {
-		return xerrors.Errorf("Value in field t.Cid was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Cid))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string(t.Cid)); err != nil {
+	if err := t.Cid.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
-	// t.Uri (string) (string)
+	// t.Uri (util.FormatAtURI) (struct)
 	if len("uri") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"uri\" was too long")
 	}
@@ -71,14 +64,7 @@ func (t *RepoStrongRef) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if len(t.Uri) > cbg.MaxLength {
-		return xerrors.Errorf("Value in field t.Uri was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Uri))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string(t.Uri)); err != nil {
+	if err := t.Uri.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -144,27 +130,25 @@ func (t *RepoStrongRef) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 		switch name {
-		// t.Cid (string) (string)
+		// t.Cid (util.FormatCID) (struct)
 		case "cid":
 
 			{
-				sval, err := cbg.ReadString(cr)
-				if err != nil {
-					return err
+
+				if err := t.Cid.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Cid: %w", err)
 				}
 
-				t.Cid = string(sval)
 			}
-			// t.Uri (string) (string)
+			// t.Uri (util.FormatAtURI) (struct)
 		case "uri":
 
 			{
-				sval, err := cbg.ReadString(cr)
-				if err != nil {
-					return err
+
+				if err := t.Uri.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Uri: %w", err)
 				}
 
-				t.Uri = string(sval)
 			}
 			// t.LexiconTypeID (string) (string)
 		case "$type":
@@ -261,7 +245,7 @@ func (t *SyncSubscribeRepos_Commit) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Repo (string) (string)
+	// t.Repo (util.FormatDID) (struct)
 	if len("repo") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"repo\" was too long")
 	}
@@ -273,14 +257,7 @@ func (t *SyncSubscribeRepos_Commit) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if len(t.Repo) > cbg.MaxLength {
-		return xerrors.Errorf("Value in field t.Repo was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Repo))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string(t.Repo)); err != nil {
+	if err := t.Repo.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -520,16 +497,15 @@ func (t *SyncSubscribeRepos_Commit) UnmarshalCBOR(r io.Reader) (err error) {
 				}
 
 			}
-			// t.Repo (string) (string)
+			// t.Repo (util.FormatDID) (struct)
 		case "repo":
 
 			{
-				sval, err := cbg.ReadString(cr)
-				if err != nil {
-					return err
+
+				if err := t.Repo.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Repo: %w", err)
 				}
 
-				t.Repo = string(sval)
 			}
 			// t.Time (string) (string)
 		case "time":
@@ -661,7 +637,7 @@ func (t *SyncSubscribeRepos_Handle) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Did (string) (string)
+	// t.Did (util.FormatDID) (struct)
 	if len("did") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"did\" was too long")
 	}
@@ -673,14 +649,7 @@ func (t *SyncSubscribeRepos_Handle) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if len(t.Did) > cbg.MaxLength {
-		return xerrors.Errorf("Value in field t.Did was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Did))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string(t.Did)); err != nil {
+	if err := t.Did.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -729,7 +698,7 @@ func (t *SyncSubscribeRepos_Handle) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Handle (string) (string)
+	// t.Handle (util.FormatHandle) (struct)
 	if len("handle") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"handle\" was too long")
 	}
@@ -741,14 +710,7 @@ func (t *SyncSubscribeRepos_Handle) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if len(t.Handle) > cbg.MaxLength {
-		return xerrors.Errorf("Value in field t.Handle was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Handle))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string(t.Handle)); err != nil {
+	if err := t.Handle.MarshalCBOR(cw); err != nil {
 		return err
 	}
 	return nil
@@ -792,16 +754,15 @@ func (t *SyncSubscribeRepos_Handle) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 		switch name {
-		// t.Did (string) (string)
+		// t.Did (util.FormatDID) (struct)
 		case "did":
 
 			{
-				sval, err := cbg.ReadString(cr)
-				if err != nil {
-					return err
+
+				if err := t.Did.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Did: %w", err)
 				}
 
-				t.Did = string(sval)
 			}
 			// t.Seq (int64) (int64)
 		case "seq":
@@ -840,16 +801,15 @@ func (t *SyncSubscribeRepos_Handle) UnmarshalCBOR(r io.Reader) (err error) {
 
 				t.Time = string(sval)
 			}
-			// t.Handle (string) (string)
+			// t.Handle (util.FormatHandle) (struct)
 		case "handle":
 
 			{
-				sval, err := cbg.ReadString(cr)
-				if err != nil {
-					return err
+
+				if err := t.Handle.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Handle: %w", err)
 				}
 
-				t.Handle = string(sval)
 			}
 
 		default:
@@ -1025,7 +985,7 @@ func (t *SyncSubscribeRepos_Migrate) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Did (string) (string)
+	// t.Did (util.FormatDID) (struct)
 	if len("did") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"did\" was too long")
 	}
@@ -1037,14 +997,7 @@ func (t *SyncSubscribeRepos_Migrate) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if len(t.Did) > cbg.MaxLength {
-		return xerrors.Errorf("Value in field t.Did was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Did))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string(t.Did)); err != nil {
+	if err := t.Did.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -1162,16 +1115,15 @@ func (t *SyncSubscribeRepos_Migrate) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 		switch name {
-		// t.Did (string) (string)
+		// t.Did (util.FormatDID) (struct)
 		case "did":
 
 			{
-				sval, err := cbg.ReadString(cr)
-				if err != nil {
-					return err
+
+				if err := t.Did.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Did: %w", err)
 				}
 
-				t.Did = string(sval)
 			}
 			// t.Seq (int64) (int64)
 		case "seq":
@@ -1417,7 +1369,7 @@ func (t *SyncSubscribeRepos_Tombstone) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Did (string) (string)
+	// t.Did (util.FormatDID) (struct)
 	if len("did") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"did\" was too long")
 	}
@@ -1429,14 +1381,7 @@ func (t *SyncSubscribeRepos_Tombstone) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if len(t.Did) > cbg.MaxLength {
-		return xerrors.Errorf("Value in field t.Did was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Did))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string(t.Did)); err != nil {
+	if err := t.Did.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -1525,16 +1470,15 @@ func (t *SyncSubscribeRepos_Tombstone) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 		switch name {
-		// t.Did (string) (string)
+		// t.Did (util.FormatDID) (struct)
 		case "did":
 
 			{
-				sval, err := cbg.ReadString(cr)
-				if err != nil {
-					return err
+
+				if err := t.Did.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Did: %w", err)
 				}
 
-				t.Did = string(sval)
 			}
 			// t.Seq (int64) (int64)
 		case "seq":

--- a/api/atproto/identityresolveHandle.go
+++ b/api/atproto/identityresolveHandle.go
@@ -7,18 +7,19 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // IdentityResolveHandle_Output is the output of a com.atproto.identity.resolveHandle call.
 type IdentityResolveHandle_Output struct {
-	Did string `json:"did" cborgen:"did"`
+	Did util.FormatDID `json:"did" cborgen:"did"`
 }
 
 // IdentityResolveHandle calls the XRPC method "com.atproto.identity.resolveHandle".
 //
 // handle: The handle to resolve. If not supplied, will resolve the host's own handle.
-func IdentityResolveHandle(ctx context.Context, c *xrpc.Client, handle string) (*IdentityResolveHandle_Output, error) {
+func IdentityResolveHandle(ctx context.Context, c *xrpc.Client, handle util.FormatHandle) (*IdentityResolveHandle_Output, error) {
 	var out IdentityResolveHandle_Output
 
 	params := map[string]interface{}{

--- a/api/atproto/identityupdateHandle.go
+++ b/api/atproto/identityupdateHandle.go
@@ -7,12 +7,13 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // IdentityUpdateHandle_Input is the input argument to a com.atproto.identity.updateHandle call.
 type IdentityUpdateHandle_Input struct {
-	Handle string `json:"handle" cborgen:"handle"`
+	Handle util.FormatHandle `json:"handle" cborgen:"handle"`
 }
 
 // IdentityUpdateHandle calls the XRPC method "com.atproto.identity.updateHandle".

--- a/api/atproto/labeldefs.go
+++ b/api/atproto/labeldefs.go
@@ -4,20 +4,24 @@ package atproto
 
 // schema: com.atproto.label.defs
 
+import (
+	"github.com/bluesky-social/indigo/lex/util"
+)
+
 // LabelDefs_Label is a "label" in the com.atproto.label.defs schema.
 //
 // Metadata tag on an atproto resource (eg, repo or record)
 type LabelDefs_Label struct {
 	// cid: optionally, CID specifying the specific version of 'uri' resource this label applies to
-	Cid *string `json:"cid,omitempty" cborgen:"cid,omitempty"`
+	Cid *util.FormatCID `json:"cid,omitempty" cborgen:"cid,omitempty"`
 	// cts: timestamp when this label was created
 	Cts string `json:"cts" cborgen:"cts"`
 	// neg: if true, this is a negation label, overwriting a previous label
 	Neg *bool `json:"neg,omitempty" cborgen:"neg,omitempty"`
 	// src: DID of the actor who created this label
-	Src string `json:"src" cborgen:"src"`
+	Src util.FormatDID `json:"src" cborgen:"src"`
 	// uri: AT URI of the record, repository (account), or other resource which this label applies to
-	Uri string `json:"uri" cborgen:"uri"`
+	Uri util.FormatURI `json:"uri" cborgen:"uri"`
 	// val: the short string name of the value or type of this label
 	Val string `json:"val" cborgen:"val"`
 }

--- a/api/atproto/labelqueryLabels.go
+++ b/api/atproto/labelqueryLabels.go
@@ -7,6 +7,7 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -20,7 +21,7 @@ type LabelQueryLabels_Output struct {
 //
 // sources: Optional list of label sources (DIDs) to filter on
 // uriPatterns: List of AT URI patterns to match (boolean 'OR'). Each may be a prefix (ending with '*'; will match inclusive of the string leading to '*'), or a full URI
-func LabelQueryLabels(ctx context.Context, c *xrpc.Client, cursor string, limit int64, sources []string, uriPatterns []string) (*LabelQueryLabels_Output, error) {
+func LabelQueryLabels(ctx context.Context, c *xrpc.Client, cursor string, limit int64, sources []util.FormatDID, uriPatterns []string) (*LabelQueryLabels_Output, error) {
 	var out LabelQueryLabels_Output
 
 	params := map[string]interface{}{

--- a/api/atproto/moderationcreateReport.go
+++ b/api/atproto/moderationcreateReport.go
@@ -61,7 +61,7 @@ type ModerationCreateReport_Output struct {
 	Id         int64                                  `json:"id" cborgen:"id"`
 	Reason     *string                                `json:"reason,omitempty" cborgen:"reason,omitempty"`
 	ReasonType *string                                `json:"reasonType" cborgen:"reasonType"`
-	ReportedBy string                                 `json:"reportedBy" cborgen:"reportedBy"`
+	ReportedBy util.FormatDID                         `json:"reportedBy" cborgen:"reportedBy"`
 	Subject    *ModerationCreateReport_Output_Subject `json:"subject" cborgen:"subject"`
 }
 

--- a/api/atproto/repoapplyWrites.go
+++ b/api/atproto/repoapplyWrites.go
@@ -20,7 +20,7 @@ import (
 // RECORDTYPE: RepoApplyWrites_Create
 type RepoApplyWrites_Create struct {
 	LexiconTypeID string                   `json:"$type,const=com.atproto.repo.applyWrites" cborgen:"$type,const=com.atproto.repo.applyWrites"`
-	Collection    string                   `json:"collection" cborgen:"collection"`
+	Collection    util.FormatNSID          `json:"collection" cborgen:"collection"`
 	Rkey          *string                  `json:"rkey,omitempty" cborgen:"rkey,omitempty"`
 	Value         *util.LexiconTypeDecoder `json:"value" cborgen:"value"`
 }
@@ -31,16 +31,16 @@ type RepoApplyWrites_Create struct {
 //
 // RECORDTYPE: RepoApplyWrites_Delete
 type RepoApplyWrites_Delete struct {
-	LexiconTypeID string `json:"$type,const=com.atproto.repo.applyWrites" cborgen:"$type,const=com.atproto.repo.applyWrites"`
-	Collection    string `json:"collection" cborgen:"collection"`
-	Rkey          string `json:"rkey" cborgen:"rkey"`
+	LexiconTypeID string          `json:"$type,const=com.atproto.repo.applyWrites" cborgen:"$type,const=com.atproto.repo.applyWrites"`
+	Collection    util.FormatNSID `json:"collection" cborgen:"collection"`
+	Rkey          string          `json:"rkey" cborgen:"rkey"`
 }
 
 // RepoApplyWrites_Input is the input argument to a com.atproto.repo.applyWrites call.
 type RepoApplyWrites_Input struct {
 	// repo: The handle or DID of the repo.
-	Repo       string  `json:"repo" cborgen:"repo"`
-	SwapCommit *string `json:"swapCommit,omitempty" cborgen:"swapCommit,omitempty"`
+	Repo       util.FormatAtIdentifier `json:"repo" cborgen:"repo"`
+	SwapCommit *util.FormatCID         `json:"swapCommit,omitempty" cborgen:"swapCommit,omitempty"`
 	// validate: Validate the records?
 	Validate *bool                                `json:"validate,omitempty" cborgen:"validate,omitempty"`
 	Writes   []*RepoApplyWrites_Input_Writes_Elem `json:"writes" cborgen:"writes"`
@@ -96,7 +96,7 @@ func (t *RepoApplyWrites_Input_Writes_Elem) UnmarshalJSON(b []byte) error {
 // RECORDTYPE: RepoApplyWrites_Update
 type RepoApplyWrites_Update struct {
 	LexiconTypeID string                   `json:"$type,const=com.atproto.repo.applyWrites" cborgen:"$type,const=com.atproto.repo.applyWrites"`
-	Collection    string                   `json:"collection" cborgen:"collection"`
+	Collection    util.FormatNSID          `json:"collection" cborgen:"collection"`
 	Rkey          string                   `json:"rkey" cborgen:"rkey"`
 	Value         *util.LexiconTypeDecoder `json:"value" cborgen:"value"`
 }

--- a/api/atproto/repocreateRecord.go
+++ b/api/atproto/repocreateRecord.go
@@ -14,23 +14,23 @@ import (
 // RepoCreateRecord_Input is the input argument to a com.atproto.repo.createRecord call.
 type RepoCreateRecord_Input struct {
 	// collection: The NSID of the record collection.
-	Collection string `json:"collection" cborgen:"collection"`
+	Collection util.FormatNSID `json:"collection" cborgen:"collection"`
 	// record: The record to create.
 	Record *util.LexiconTypeDecoder `json:"record" cborgen:"record"`
 	// repo: The handle or DID of the repo.
-	Repo string `json:"repo" cborgen:"repo"`
+	Repo util.FormatAtIdentifier `json:"repo" cborgen:"repo"`
 	// rkey: The key of the record.
 	Rkey *string `json:"rkey,omitempty" cborgen:"rkey,omitempty"`
 	// swapCommit: Compare and swap with the previous commit by cid.
-	SwapCommit *string `json:"swapCommit,omitempty" cborgen:"swapCommit,omitempty"`
+	SwapCommit *util.FormatCID `json:"swapCommit,omitempty" cborgen:"swapCommit,omitempty"`
 	// validate: Validate the record?
 	Validate *bool `json:"validate,omitempty" cborgen:"validate,omitempty"`
 }
 
 // RepoCreateRecord_Output is the output of a com.atproto.repo.createRecord call.
 type RepoCreateRecord_Output struct {
-	Cid string `json:"cid" cborgen:"cid"`
-	Uri string `json:"uri" cborgen:"uri"`
+	Cid util.FormatCID   `json:"cid" cborgen:"cid"`
+	Uri util.FormatAtURI `json:"uri" cborgen:"uri"`
 }
 
 // RepoCreateRecord calls the XRPC method "com.atproto.repo.createRecord".

--- a/api/atproto/repodeleteRecord.go
+++ b/api/atproto/repodeleteRecord.go
@@ -7,21 +7,22 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // RepoDeleteRecord_Input is the input argument to a com.atproto.repo.deleteRecord call.
 type RepoDeleteRecord_Input struct {
 	// collection: The NSID of the record collection.
-	Collection string `json:"collection" cborgen:"collection"`
+	Collection util.FormatNSID `json:"collection" cborgen:"collection"`
 	// repo: The handle or DID of the repo.
-	Repo string `json:"repo" cborgen:"repo"`
+	Repo util.FormatAtIdentifier `json:"repo" cborgen:"repo"`
 	// rkey: The key of the record.
 	Rkey string `json:"rkey" cborgen:"rkey"`
 	// swapCommit: Compare and swap with the previous commit by cid.
-	SwapCommit *string `json:"swapCommit,omitempty" cborgen:"swapCommit,omitempty"`
+	SwapCommit *util.FormatCID `json:"swapCommit,omitempty" cborgen:"swapCommit,omitempty"`
 	// swapRecord: Compare and swap with the previous record by cid.
-	SwapRecord *string `json:"swapRecord,omitempty" cborgen:"swapRecord,omitempty"`
+	SwapRecord *util.FormatCID `json:"swapRecord,omitempty" cborgen:"swapRecord,omitempty"`
 }
 
 // RepoDeleteRecord calls the XRPC method "com.atproto.repo.deleteRecord".

--- a/api/atproto/repodescribeRepo.go
+++ b/api/atproto/repodescribeRepo.go
@@ -13,17 +13,17 @@ import (
 
 // RepoDescribeRepo_Output is the output of a com.atproto.repo.describeRepo call.
 type RepoDescribeRepo_Output struct {
-	Collections     []string                 `json:"collections" cborgen:"collections"`
-	Did             string                   `json:"did" cborgen:"did"`
+	Collections     []util.FormatNSID        `json:"collections" cborgen:"collections"`
+	Did             util.FormatDID           `json:"did" cborgen:"did"`
 	DidDoc          *util.LexiconTypeDecoder `json:"didDoc" cborgen:"didDoc"`
-	Handle          string                   `json:"handle" cborgen:"handle"`
+	Handle          util.FormatHandle        `json:"handle" cborgen:"handle"`
 	HandleIsCorrect bool                     `json:"handleIsCorrect" cborgen:"handleIsCorrect"`
 }
 
 // RepoDescribeRepo calls the XRPC method "com.atproto.repo.describeRepo".
 //
 // repo: The handle or DID of the repo.
-func RepoDescribeRepo(ctx context.Context, c *xrpc.Client, repo string) (*RepoDescribeRepo_Output, error) {
+func RepoDescribeRepo(ctx context.Context, c *xrpc.Client, repo util.FormatAtIdentifier) (*RepoDescribeRepo_Output, error) {
 	var out RepoDescribeRepo_Output
 
 	params := map[string]interface{}{

--- a/api/atproto/repogetRecord.go
+++ b/api/atproto/repogetRecord.go
@@ -13,8 +13,8 @@ import (
 
 // RepoGetRecord_Output is the output of a com.atproto.repo.getRecord call.
 type RepoGetRecord_Output struct {
-	Cid   *string                  `json:"cid,omitempty" cborgen:"cid,omitempty"`
-	Uri   string                   `json:"uri" cborgen:"uri"`
+	Cid   *util.FormatCID          `json:"cid,omitempty" cborgen:"cid,omitempty"`
+	Uri   util.FormatAtURI         `json:"uri" cborgen:"uri"`
 	Value *util.LexiconTypeDecoder `json:"value" cborgen:"value"`
 }
 
@@ -24,7 +24,7 @@ type RepoGetRecord_Output struct {
 // collection: The NSID of the record collection.
 // repo: The handle or DID of the repo.
 // rkey: The key of the record.
-func RepoGetRecord(ctx context.Context, c *xrpc.Client, cid string, collection string, repo string, rkey string) (*RepoGetRecord_Output, error) {
+func RepoGetRecord(ctx context.Context, c *xrpc.Client, cid util.FormatCID, collection util.FormatNSID, repo util.FormatAtIdentifier, rkey string) (*RepoGetRecord_Output, error) {
 	var out RepoGetRecord_Output
 
 	params := map[string]interface{}{

--- a/api/atproto/repolistRecords.go
+++ b/api/atproto/repolistRecords.go
@@ -19,8 +19,8 @@ type RepoListRecords_Output struct {
 
 // RepoListRecords_Record is a "record" in the com.atproto.repo.listRecords schema.
 type RepoListRecords_Record struct {
-	Cid   string                   `json:"cid" cborgen:"cid"`
-	Uri   string                   `json:"uri" cborgen:"uri"`
+	Cid   util.FormatCID           `json:"cid" cborgen:"cid"`
+	Uri   util.FormatAtURI         `json:"uri" cborgen:"uri"`
 	Value *util.LexiconTypeDecoder `json:"value" cborgen:"value"`
 }
 
@@ -32,7 +32,7 @@ type RepoListRecords_Record struct {
 // reverse: Reverse the order of the returned records?
 // rkeyEnd: DEPRECATED: The highest sort-ordered rkey to stop at (exclusive)
 // rkeyStart: DEPRECATED: The lowest sort-ordered rkey to start from (exclusive)
-func RepoListRecords(ctx context.Context, c *xrpc.Client, collection string, cursor string, limit int64, repo string, reverse bool, rkeyEnd string, rkeyStart string) (*RepoListRecords_Output, error) {
+func RepoListRecords(ctx context.Context, c *xrpc.Client, collection util.FormatNSID, cursor string, limit int64, repo util.FormatAtIdentifier, reverse bool, rkeyEnd string, rkeyStart string) (*RepoListRecords_Output, error) {
 	var out RepoListRecords_Output
 
 	params := map[string]interface{}{

--- a/api/atproto/repoputRecord.go
+++ b/api/atproto/repoputRecord.go
@@ -14,25 +14,25 @@ import (
 // RepoPutRecord_Input is the input argument to a com.atproto.repo.putRecord call.
 type RepoPutRecord_Input struct {
 	// collection: The NSID of the record collection.
-	Collection string `json:"collection" cborgen:"collection"`
+	Collection util.FormatNSID `json:"collection" cborgen:"collection"`
 	// record: The record to write.
 	Record *util.LexiconTypeDecoder `json:"record" cborgen:"record"`
 	// repo: The handle or DID of the repo.
-	Repo string `json:"repo" cborgen:"repo"`
+	Repo util.FormatAtIdentifier `json:"repo" cborgen:"repo"`
 	// rkey: The key of the record.
 	Rkey string `json:"rkey" cborgen:"rkey"`
 	// swapCommit: Compare and swap with the previous commit by cid.
-	SwapCommit *string `json:"swapCommit,omitempty" cborgen:"swapCommit,omitempty"`
+	SwapCommit *util.FormatCID `json:"swapCommit,omitempty" cborgen:"swapCommit,omitempty"`
 	// swapRecord: Compare and swap with the previous record by cid.
-	SwapRecord *string `json:"swapRecord" cborgen:"swapRecord"`
+	SwapRecord *util.FormatCID `json:"swapRecord" cborgen:"swapRecord"`
 	// validate: Validate the record?
 	Validate *bool `json:"validate,omitempty" cborgen:"validate,omitempty"`
 }
 
 // RepoPutRecord_Output is the output of a com.atproto.repo.putRecord call.
 type RepoPutRecord_Output struct {
-	Cid string `json:"cid" cborgen:"cid"`
-	Uri string `json:"uri" cborgen:"uri"`
+	Cid util.FormatCID   `json:"cid" cborgen:"cid"`
+	Uri util.FormatAtURI `json:"uri" cborgen:"uri"`
 }
 
 // RepoPutRecord calls the XRPC method "com.atproto.repo.putRecord".

--- a/api/atproto/repostrongRef.go
+++ b/api/atproto/repostrongRef.go
@@ -13,7 +13,7 @@ func init() {
 } // RepoStrongRef is a "main" in the com.atproto.repo.strongRef schema.
 // RECORDTYPE: RepoStrongRef
 type RepoStrongRef struct {
-	LexiconTypeID string `json:"$type,const=com.atproto.repo.strongRef,omitempty" cborgen:"$type,const=com.atproto.repo.strongRef,omitempty"`
-	Cid           string `json:"cid" cborgen:"cid"`
-	Uri           string `json:"uri" cborgen:"uri"`
+	LexiconTypeID string           `json:"$type,const=com.atproto.repo.strongRef,omitempty" cborgen:"$type,const=com.atproto.repo.strongRef,omitempty"`
+	Cid           util.FormatCID   `json:"cid" cborgen:"cid"`
+	Uri           util.FormatAtURI `json:"uri" cborgen:"uri"`
 }

--- a/api/atproto/servercreateAccount.go
+++ b/api/atproto/servercreateAccount.go
@@ -7,24 +7,25 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // ServerCreateAccount_Input is the input argument to a com.atproto.server.createAccount call.
 type ServerCreateAccount_Input struct {
-	Email       string  `json:"email" cborgen:"email"`
-	Handle      string  `json:"handle" cborgen:"handle"`
-	InviteCode  *string `json:"inviteCode,omitempty" cborgen:"inviteCode,omitempty"`
-	Password    string  `json:"password" cborgen:"password"`
-	RecoveryKey *string `json:"recoveryKey,omitempty" cborgen:"recoveryKey,omitempty"`
+	Email       string            `json:"email" cborgen:"email"`
+	Handle      util.FormatHandle `json:"handle" cborgen:"handle"`
+	InviteCode  *string           `json:"inviteCode,omitempty" cborgen:"inviteCode,omitempty"`
+	Password    string            `json:"password" cborgen:"password"`
+	RecoveryKey *string           `json:"recoveryKey,omitempty" cborgen:"recoveryKey,omitempty"`
 }
 
 // ServerCreateAccount_Output is the output of a com.atproto.server.createAccount call.
 type ServerCreateAccount_Output struct {
-	AccessJwt  string `json:"accessJwt" cborgen:"accessJwt"`
-	Did        string `json:"did" cborgen:"did"`
-	Handle     string `json:"handle" cborgen:"handle"`
-	RefreshJwt string `json:"refreshJwt" cborgen:"refreshJwt"`
+	AccessJwt  string            `json:"accessJwt" cborgen:"accessJwt"`
+	Did        util.FormatDID    `json:"did" cborgen:"did"`
+	Handle     util.FormatHandle `json:"handle" cborgen:"handle"`
+	RefreshJwt string            `json:"refreshJwt" cborgen:"refreshJwt"`
 }
 
 // ServerCreateAccount calls the XRPC method "com.atproto.server.createAccount".

--- a/api/atproto/servercreateInviteCode.go
+++ b/api/atproto/servercreateInviteCode.go
@@ -7,13 +7,14 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // ServerCreateInviteCode_Input is the input argument to a com.atproto.server.createInviteCode call.
 type ServerCreateInviteCode_Input struct {
-	ForAccount *string `json:"forAccount,omitempty" cborgen:"forAccount,omitempty"`
-	UseCount   int64   `json:"useCount" cborgen:"useCount"`
+	ForAccount *util.FormatDID `json:"forAccount,omitempty" cborgen:"forAccount,omitempty"`
+	UseCount   int64           `json:"useCount" cborgen:"useCount"`
 }
 
 // ServerCreateInviteCode_Output is the output of a com.atproto.server.createInviteCode call.

--- a/api/atproto/servercreateInviteCodes.go
+++ b/api/atproto/servercreateInviteCodes.go
@@ -7,6 +7,7 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -18,9 +19,9 @@ type ServerCreateInviteCodes_AccountCodes struct {
 
 // ServerCreateInviteCodes_Input is the input argument to a com.atproto.server.createInviteCodes call.
 type ServerCreateInviteCodes_Input struct {
-	CodeCount   int64    `json:"codeCount" cborgen:"codeCount"`
-	ForAccounts []string `json:"forAccounts,omitempty" cborgen:"forAccounts,omitempty"`
-	UseCount    int64    `json:"useCount" cborgen:"useCount"`
+	CodeCount   int64            `json:"codeCount" cborgen:"codeCount"`
+	ForAccounts []util.FormatDID `json:"forAccounts,omitempty" cborgen:"forAccounts,omitempty"`
+	UseCount    int64            `json:"useCount" cborgen:"useCount"`
 }
 
 // ServerCreateInviteCodes_Output is the output of a com.atproto.server.createInviteCodes call.

--- a/api/atproto/servercreateSession.go
+++ b/api/atproto/servercreateSession.go
@@ -7,6 +7,7 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -19,11 +20,11 @@ type ServerCreateSession_Input struct {
 
 // ServerCreateSession_Output is the output of a com.atproto.server.createSession call.
 type ServerCreateSession_Output struct {
-	AccessJwt  string  `json:"accessJwt" cborgen:"accessJwt"`
-	Did        string  `json:"did" cborgen:"did"`
-	Email      *string `json:"email,omitempty" cborgen:"email,omitempty"`
-	Handle     string  `json:"handle" cborgen:"handle"`
-	RefreshJwt string  `json:"refreshJwt" cborgen:"refreshJwt"`
+	AccessJwt  string            `json:"accessJwt" cborgen:"accessJwt"`
+	Did        util.FormatDID    `json:"did" cborgen:"did"`
+	Email      *string           `json:"email,omitempty" cborgen:"email,omitempty"`
+	Handle     util.FormatHandle `json:"handle" cborgen:"handle"`
+	RefreshJwt string            `json:"refreshJwt" cborgen:"refreshJwt"`
 }
 
 // ServerCreateSession calls the XRPC method "com.atproto.server.createSession".

--- a/api/atproto/serverdefs.go
+++ b/api/atproto/serverdefs.go
@@ -4,6 +4,10 @@ package atproto
 
 // schema: com.atproto.server.defs
 
+import (
+	"github.com/bluesky-social/indigo/lex/util"
+)
+
 // ServerDefs_InviteCode is a "inviteCode" in the com.atproto.server.defs schema.
 type ServerDefs_InviteCode struct {
 	Available  int64                       `json:"available" cborgen:"available"`
@@ -17,6 +21,6 @@ type ServerDefs_InviteCode struct {
 
 // ServerDefs_InviteCodeUse is a "inviteCodeUse" in the com.atproto.server.defs schema.
 type ServerDefs_InviteCodeUse struct {
-	UsedAt string `json:"usedAt" cborgen:"usedAt"`
-	UsedBy string `json:"usedBy" cborgen:"usedBy"`
+	UsedAt string         `json:"usedAt" cborgen:"usedAt"`
+	UsedBy util.FormatDID `json:"usedBy" cborgen:"usedBy"`
 }

--- a/api/atproto/serverdeleteAccount.go
+++ b/api/atproto/serverdeleteAccount.go
@@ -7,14 +7,15 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // ServerDeleteAccount_Input is the input argument to a com.atproto.server.deleteAccount call.
 type ServerDeleteAccount_Input struct {
-	Did      string `json:"did" cborgen:"did"`
-	Password string `json:"password" cborgen:"password"`
-	Token    string `json:"token" cborgen:"token"`
+	Did      util.FormatDID `json:"did" cborgen:"did"`
+	Password string         `json:"password" cborgen:"password"`
+	Token    string         `json:"token" cborgen:"token"`
 }
 
 // ServerDeleteAccount calls the XRPC method "com.atproto.server.deleteAccount".

--- a/api/atproto/servergetSession.go
+++ b/api/atproto/servergetSession.go
@@ -7,14 +7,15 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // ServerGetSession_Output is the output of a com.atproto.server.getSession call.
 type ServerGetSession_Output struct {
-	Did    string  `json:"did" cborgen:"did"`
-	Email  *string `json:"email,omitempty" cborgen:"email,omitempty"`
-	Handle string  `json:"handle" cborgen:"handle"`
+	Did    util.FormatDID    `json:"did" cborgen:"did"`
+	Email  *string           `json:"email,omitempty" cborgen:"email,omitempty"`
+	Handle util.FormatHandle `json:"handle" cborgen:"handle"`
 }
 
 // ServerGetSession calls the XRPC method "com.atproto.server.getSession".

--- a/api/atproto/serverrefreshSession.go
+++ b/api/atproto/serverrefreshSession.go
@@ -7,15 +7,16 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // ServerRefreshSession_Output is the output of a com.atproto.server.refreshSession call.
 type ServerRefreshSession_Output struct {
-	AccessJwt  string `json:"accessJwt" cborgen:"accessJwt"`
-	Did        string `json:"did" cborgen:"did"`
-	Handle     string `json:"handle" cborgen:"handle"`
-	RefreshJwt string `json:"refreshJwt" cborgen:"refreshJwt"`
+	AccessJwt  string            `json:"accessJwt" cborgen:"accessJwt"`
+	Did        util.FormatDID    `json:"did" cborgen:"did"`
+	Handle     util.FormatHandle `json:"handle" cborgen:"handle"`
+	RefreshJwt string            `json:"refreshJwt" cborgen:"refreshJwt"`
 }
 
 // ServerRefreshSession calls the XRPC method "com.atproto.server.refreshSession".

--- a/api/atproto/syncgetBlob.go
+++ b/api/atproto/syncgetBlob.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -15,7 +16,7 @@ import (
 //
 // cid: The CID of the blob to fetch
 // did: The DID of the repo.
-func SyncGetBlob(ctx context.Context, c *xrpc.Client, cid string, did string) ([]byte, error) {
+func SyncGetBlob(ctx context.Context, c *xrpc.Client, cid util.FormatCID, did util.FormatDID) ([]byte, error) {
 	buf := new(bytes.Buffer)
 
 	params := map[string]interface{}{

--- a/api/atproto/syncgetBlocks.go
+++ b/api/atproto/syncgetBlocks.go
@@ -8,13 +8,14 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // SyncGetBlocks calls the XRPC method "com.atproto.sync.getBlocks".
 //
 // did: The DID of the repo.
-func SyncGetBlocks(ctx context.Context, c *xrpc.Client, cids []string, did string) ([]byte, error) {
+func SyncGetBlocks(ctx context.Context, c *xrpc.Client, cids []util.FormatCID, did util.FormatDID) ([]byte, error) {
 	buf := new(bytes.Buffer)
 
 	params := map[string]interface{}{

--- a/api/atproto/syncgetCheckout.go
+++ b/api/atproto/syncgetCheckout.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -15,7 +16,7 @@ import (
 //
 // commit: The commit to get the checkout from. Defaults to current HEAD.
 // did: The DID of the repo.
-func SyncGetCheckout(ctx context.Context, c *xrpc.Client, commit string, did string) ([]byte, error) {
+func SyncGetCheckout(ctx context.Context, c *xrpc.Client, commit util.FormatCID, did util.FormatDID) ([]byte, error) {
 	buf := new(bytes.Buffer)
 
 	params := map[string]interface{}{

--- a/api/atproto/syncgetCommitPath.go
+++ b/api/atproto/syncgetCommitPath.go
@@ -7,12 +7,13 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // SyncGetCommitPath_Output is the output of a com.atproto.sync.getCommitPath call.
 type SyncGetCommitPath_Output struct {
-	Commits []string `json:"commits" cborgen:"commits"`
+	Commits []util.FormatCID `json:"commits" cborgen:"commits"`
 }
 
 // SyncGetCommitPath calls the XRPC method "com.atproto.sync.getCommitPath".
@@ -20,7 +21,7 @@ type SyncGetCommitPath_Output struct {
 // did: The DID of the repo.
 // earliest: The earliest commit to start from
 // latest: The most recent commit
-func SyncGetCommitPath(ctx context.Context, c *xrpc.Client, did string, earliest string, latest string) (*SyncGetCommitPath_Output, error) {
+func SyncGetCommitPath(ctx context.Context, c *xrpc.Client, did util.FormatDID, earliest util.FormatCID, latest util.FormatCID) (*SyncGetCommitPath_Output, error) {
 	var out SyncGetCommitPath_Output
 
 	params := map[string]interface{}{

--- a/api/atproto/syncgetHead.go
+++ b/api/atproto/syncgetHead.go
@@ -7,18 +7,19 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // SyncGetHead_Output is the output of a com.atproto.sync.getHead call.
 type SyncGetHead_Output struct {
-	Root string `json:"root" cborgen:"root"`
+	Root util.FormatCID `json:"root" cborgen:"root"`
 }
 
 // SyncGetHead calls the XRPC method "com.atproto.sync.getHead".
 //
 // did: The DID of the repo.
-func SyncGetHead(ctx context.Context, c *xrpc.Client, did string) (*SyncGetHead_Output, error) {
+func SyncGetHead(ctx context.Context, c *xrpc.Client, did util.FormatDID) (*SyncGetHead_Output, error) {
 	var out SyncGetHead_Output
 
 	params := map[string]interface{}{

--- a/api/atproto/syncgetRecord.go
+++ b/api/atproto/syncgetRecord.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -15,7 +16,7 @@ import (
 //
 // commit: An optional past commit CID.
 // did: The DID of the repo.
-func SyncGetRecord(ctx context.Context, c *xrpc.Client, collection string, commit string, did string, rkey string) ([]byte, error) {
+func SyncGetRecord(ctx context.Context, c *xrpc.Client, collection util.FormatNSID, commit util.FormatCID, did util.FormatDID, rkey string) ([]byte, error) {
 	buf := new(bytes.Buffer)
 
 	params := map[string]interface{}{

--- a/api/atproto/syncgetRepo.go
+++ b/api/atproto/syncgetRepo.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -16,7 +17,7 @@ import (
 // did: The DID of the repo.
 // earliest: The earliest commit in the commit range (not inclusive)
 // latest: The latest commit in the commit range (inclusive)
-func SyncGetRepo(ctx context.Context, c *xrpc.Client, did string, earliest string, latest string) ([]byte, error) {
+func SyncGetRepo(ctx context.Context, c *xrpc.Client, did util.FormatDID, earliest util.FormatCID, latest util.FormatCID) ([]byte, error) {
 	buf := new(bytes.Buffer)
 
 	params := map[string]interface{}{

--- a/api/atproto/synclistBlobs.go
+++ b/api/atproto/synclistBlobs.go
@@ -7,12 +7,13 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // SyncListBlobs_Output is the output of a com.atproto.sync.listBlobs call.
 type SyncListBlobs_Output struct {
-	Cids []string `json:"cids" cborgen:"cids"`
+	Cids []util.FormatCID `json:"cids" cborgen:"cids"`
 }
 
 // SyncListBlobs calls the XRPC method "com.atproto.sync.listBlobs".
@@ -20,7 +21,7 @@ type SyncListBlobs_Output struct {
 // did: The DID of the repo.
 // earliest: The earliest commit to start from
 // latest: The most recent commit
-func SyncListBlobs(ctx context.Context, c *xrpc.Client, did string, earliest string, latest string) (*SyncListBlobs_Output, error) {
+func SyncListBlobs(ctx context.Context, c *xrpc.Client, did util.FormatDID, earliest util.FormatCID, latest util.FormatCID) (*SyncListBlobs_Output, error) {
 	var out SyncListBlobs_Output
 
 	params := map[string]interface{}{

--- a/api/atproto/synclistRepos.go
+++ b/api/atproto/synclistRepos.go
@@ -7,6 +7,7 @@ package atproto
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -18,8 +19,8 @@ type SyncListRepos_Output struct {
 
 // SyncListRepos_Repo is a "repo" in the com.atproto.sync.listRepos schema.
 type SyncListRepos_Repo struct {
-	Did  string `json:"did" cborgen:"did"`
-	Head string `json:"head" cborgen:"head"`
+	Did  util.FormatDID `json:"did" cborgen:"did"`
+	Head util.FormatCID `json:"head" cborgen:"head"`
 }
 
 // SyncListRepos calls the XRPC method "com.atproto.sync.listRepos".

--- a/api/atproto/syncsubscribeRepos.go
+++ b/api/atproto/syncsubscribeRepos.go
@@ -17,7 +17,7 @@ type SyncSubscribeRepos_Commit struct {
 	Ops    []*SyncSubscribeRepos_RepoOp `json:"ops" cborgen:"ops"`
 	Prev   *util.LexLink                `json:"prev" cborgen:"prev"`
 	Rebase bool                         `json:"rebase" cborgen:"rebase"`
-	Repo   string                       `json:"repo" cborgen:"repo"`
+	Repo   util.FormatDID               `json:"repo" cborgen:"repo"`
 	Seq    int64                        `json:"seq" cborgen:"seq"`
 	Time   string                       `json:"time" cborgen:"time"`
 	TooBig bool                         `json:"tooBig" cborgen:"tooBig"`
@@ -25,10 +25,10 @@ type SyncSubscribeRepos_Commit struct {
 
 // SyncSubscribeRepos_Handle is a "handle" in the com.atproto.sync.subscribeRepos schema.
 type SyncSubscribeRepos_Handle struct {
-	Did    string `json:"did" cborgen:"did"`
-	Handle string `json:"handle" cborgen:"handle"`
-	Seq    int64  `json:"seq" cborgen:"seq"`
-	Time   string `json:"time" cborgen:"time"`
+	Did    util.FormatDID    `json:"did" cborgen:"did"`
+	Handle util.FormatHandle `json:"handle" cborgen:"handle"`
+	Seq    int64             `json:"seq" cborgen:"seq"`
+	Time   string            `json:"time" cborgen:"time"`
 }
 
 // SyncSubscribeRepos_Info is a "info" in the com.atproto.sync.subscribeRepos schema.
@@ -39,10 +39,10 @@ type SyncSubscribeRepos_Info struct {
 
 // SyncSubscribeRepos_Migrate is a "migrate" in the com.atproto.sync.subscribeRepos schema.
 type SyncSubscribeRepos_Migrate struct {
-	Did       string  `json:"did" cborgen:"did"`
-	MigrateTo *string `json:"migrateTo" cborgen:"migrateTo"`
-	Seq       int64   `json:"seq" cborgen:"seq"`
-	Time      string  `json:"time" cborgen:"time"`
+	Did       util.FormatDID `json:"did" cborgen:"did"`
+	MigrateTo *string        `json:"migrateTo" cborgen:"migrateTo"`
+	Seq       int64          `json:"seq" cborgen:"seq"`
+	Time      string         `json:"time" cborgen:"time"`
 }
 
 // SyncSubscribeRepos_RepoOp is a "repoOp" in the com.atproto.sync.subscribeRepos schema.
@@ -54,7 +54,7 @@ type SyncSubscribeRepos_RepoOp struct {
 
 // SyncSubscribeRepos_Tombstone is a "tombstone" in the com.atproto.sync.subscribeRepos schema.
 type SyncSubscribeRepos_Tombstone struct {
-	Did  string `json:"did" cborgen:"did"`
-	Seq  int64  `json:"seq" cborgen:"seq"`
-	Time string `json:"time" cborgen:"time"`
+	Did  util.FormatDID `json:"did" cborgen:"did"`
+	Seq  int64          `json:"seq" cborgen:"seq"`
+	Time string         `json:"time" cborgen:"time"`
 }

--- a/api/bsky/actordefs.go
+++ b/api/bsky/actordefs.go
@@ -6,15 +6,16 @@ package bsky
 
 import (
 	comatprototypes "github.com/bluesky-social/indigo/api/atproto"
+	"github.com/bluesky-social/indigo/lex/util"
 )
 
 // ActorDefs_ProfileView is a "profileView" in the app.bsky.actor.defs schema.
 type ActorDefs_ProfileView struct {
 	Avatar      *string                            `json:"avatar,omitempty" cborgen:"avatar,omitempty"`
 	Description *string                            `json:"description,omitempty" cborgen:"description,omitempty"`
-	Did         string                             `json:"did" cborgen:"did"`
+	Did         util.FormatDID                     `json:"did" cborgen:"did"`
 	DisplayName *string                            `json:"displayName,omitempty" cborgen:"displayName,omitempty"`
-	Handle      string                             `json:"handle" cborgen:"handle"`
+	Handle      util.FormatHandle                  `json:"handle" cborgen:"handle"`
 	IndexedAt   *string                            `json:"indexedAt,omitempty" cborgen:"indexedAt,omitempty"`
 	Labels      []*comatprototypes.LabelDefs_Label `json:"labels,omitempty" cborgen:"labels,omitempty"`
 	Viewer      *ActorDefs_ViewerState             `json:"viewer,omitempty" cborgen:"viewer,omitempty"`
@@ -23,9 +24,9 @@ type ActorDefs_ProfileView struct {
 // ActorDefs_ProfileViewBasic is a "profileViewBasic" in the app.bsky.actor.defs schema.
 type ActorDefs_ProfileViewBasic struct {
 	Avatar      *string                            `json:"avatar,omitempty" cborgen:"avatar,omitempty"`
-	Did         string                             `json:"did" cborgen:"did"`
+	Did         util.FormatDID                     `json:"did" cborgen:"did"`
 	DisplayName *string                            `json:"displayName,omitempty" cborgen:"displayName,omitempty"`
-	Handle      string                             `json:"handle" cborgen:"handle"`
+	Handle      util.FormatHandle                  `json:"handle" cborgen:"handle"`
 	Labels      []*comatprototypes.LabelDefs_Label `json:"labels,omitempty" cborgen:"labels,omitempty"`
 	Viewer      *ActorDefs_ViewerState             `json:"viewer,omitempty" cborgen:"viewer,omitempty"`
 }
@@ -35,11 +36,11 @@ type ActorDefs_ProfileViewDetailed struct {
 	Avatar         *string                            `json:"avatar,omitempty" cborgen:"avatar,omitempty"`
 	Banner         *string                            `json:"banner,omitempty" cborgen:"banner,omitempty"`
 	Description    *string                            `json:"description,omitempty" cborgen:"description,omitempty"`
-	Did            string                             `json:"did" cborgen:"did"`
+	Did            util.FormatDID                     `json:"did" cborgen:"did"`
 	DisplayName    *string                            `json:"displayName,omitempty" cborgen:"displayName,omitempty"`
 	FollowersCount *int64                             `json:"followersCount,omitempty" cborgen:"followersCount,omitempty"`
 	FollowsCount   *int64                             `json:"followsCount,omitempty" cborgen:"followsCount,omitempty"`
-	Handle         string                             `json:"handle" cborgen:"handle"`
+	Handle         util.FormatHandle                  `json:"handle" cborgen:"handle"`
 	IndexedAt      *string                            `json:"indexedAt,omitempty" cborgen:"indexedAt,omitempty"`
 	Labels         []*comatprototypes.LabelDefs_Label `json:"labels,omitempty" cborgen:"labels,omitempty"`
 	PostsCount     *int64                             `json:"postsCount,omitempty" cborgen:"postsCount,omitempty"`
@@ -48,7 +49,7 @@ type ActorDefs_ProfileViewDetailed struct {
 
 // ActorDefs_ViewerState is a "viewerState" in the app.bsky.actor.defs schema.
 type ActorDefs_ViewerState struct {
-	FollowedBy *string `json:"followedBy,omitempty" cborgen:"followedBy,omitempty"`
-	Following  *string `json:"following,omitempty" cborgen:"following,omitempty"`
-	Muted      *bool   `json:"muted,omitempty" cborgen:"muted,omitempty"`
+	FollowedBy *util.FormatAtURI `json:"followedBy,omitempty" cborgen:"followedBy,omitempty"`
+	Following  *util.FormatAtURI `json:"following,omitempty" cborgen:"following,omitempty"`
+	Muted      *bool             `json:"muted,omitempty" cborgen:"muted,omitempty"`
 }

--- a/api/bsky/actorgetProfile.go
+++ b/api/bsky/actorgetProfile.go
@@ -7,11 +7,12 @@ package bsky
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // ActorGetProfile calls the XRPC method "app.bsky.actor.getProfile".
-func ActorGetProfile(ctx context.Context, c *xrpc.Client, actor string) (*ActorDefs_ProfileViewDetailed, error) {
+func ActorGetProfile(ctx context.Context, c *xrpc.Client, actor util.FormatAtIdentifier) (*ActorDefs_ProfileViewDetailed, error) {
 	var out ActorDefs_ProfileViewDetailed
 
 	params := map[string]interface{}{

--- a/api/bsky/actorgetProfiles.go
+++ b/api/bsky/actorgetProfiles.go
@@ -7,6 +7,7 @@ package bsky
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -16,7 +17,7 @@ type ActorGetProfiles_Output struct {
 }
 
 // ActorGetProfiles calls the XRPC method "app.bsky.actor.getProfiles".
-func ActorGetProfiles(ctx context.Context, c *xrpc.Client, actors []string) (*ActorGetProfiles_Output, error) {
+func ActorGetProfiles(ctx context.Context, c *xrpc.Client, actors []util.FormatAtIdentifier) (*ActorGetProfiles_Output, error) {
 	var out ActorGetProfiles_Output
 
 	params := map[string]interface{}{

--- a/api/bsky/cbor_gen.go
+++ b/api/bsky/cbor_gen.go
@@ -1295,7 +1295,7 @@ func (t *EmbedExternal_External) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Uri (string) (string)
+	// t.Uri (util.FormatURI) (struct)
 	if len("uri") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"uri\" was too long")
 	}
@@ -1307,14 +1307,7 @@ func (t *EmbedExternal_External) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if len(t.Uri) > cbg.MaxLength {
-		return xerrors.Errorf("Value in field t.Uri was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Uri))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string(t.Uri)); err != nil {
+	if err := t.Uri.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -1423,16 +1416,15 @@ func (t *EmbedExternal_External) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 		switch name {
-		// t.Uri (string) (string)
+		// t.Uri (util.FormatURI) (struct)
 		case "uri":
 
 			{
-				sval, err := cbg.ReadString(cr)
-				if err != nil {
-					return err
+
+				if err := t.Uri.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Uri: %w", err)
 				}
 
-				t.Uri = string(sval)
 			}
 			// t.Thumb (util.LexBlob) (struct)
 		case "thumb":
@@ -1647,7 +1639,7 @@ func (t *GraphFollow) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Subject (string) (string)
+	// t.Subject (util.FormatDID) (struct)
 	if len("subject") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"subject\" was too long")
 	}
@@ -1659,14 +1651,7 @@ func (t *GraphFollow) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if len(t.Subject) > cbg.MaxLength {
-		return xerrors.Errorf("Value in field t.Subject was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Subject))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string(t.Subject)); err != nil {
+	if err := t.Subject.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -1744,16 +1729,15 @@ func (t *GraphFollow) UnmarshalCBOR(r io.Reader) (err error) {
 
 				t.LexiconTypeID = string(sval)
 			}
-			// t.Subject (string) (string)
+			// t.Subject (util.FormatDID) (struct)
 		case "subject":
 
 			{
-				sval, err := cbg.ReadString(cr)
-				if err != nil {
-					return err
+
+				if err := t.Subject.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Subject: %w", err)
 				}
 
-				t.Subject = string(sval)
 			}
 			// t.CreatedAt (string) (string)
 		case "createdAt":
@@ -2675,7 +2659,7 @@ func (t *RichtextFacet_Link) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Uri (string) (string)
+	// t.Uri (util.FormatURI) (struct)
 	if len("uri") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"uri\" was too long")
 	}
@@ -2687,14 +2671,7 @@ func (t *RichtextFacet_Link) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if len(t.Uri) > cbg.MaxLength {
-		return xerrors.Errorf("Value in field t.Uri was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Uri))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string(t.Uri)); err != nil {
+	if err := t.Uri.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -2757,16 +2734,15 @@ func (t *RichtextFacet_Link) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 		switch name {
-		// t.Uri (string) (string)
+		// t.Uri (util.FormatURI) (struct)
 		case "uri":
 
 			{
-				sval, err := cbg.ReadString(cr)
-				if err != nil {
-					return err
+
+				if err := t.Uri.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Uri: %w", err)
 				}
 
-				t.Uri = string(sval)
 			}
 			// t.LexiconTypeID (string) (string)
 		case "$type":
@@ -2800,7 +2776,7 @@ func (t *RichtextFacet_Mention) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Did (string) (string)
+	// t.Did (util.FormatDID) (struct)
 	if len("did") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"did\" was too long")
 	}
@@ -2812,14 +2788,7 @@ func (t *RichtextFacet_Mention) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if len(t.Did) > cbg.MaxLength {
-		return xerrors.Errorf("Value in field t.Did was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Did))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string(t.Did)); err != nil {
+	if err := t.Did.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -2882,16 +2851,15 @@ func (t *RichtextFacet_Mention) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 		switch name {
-		// t.Did (string) (string)
+		// t.Did (util.FormatDID) (struct)
 		case "did":
 
 			{
-				sval, err := cbg.ReadString(cr)
-				if err != nil {
-					return err
+
+				if err := t.Did.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Did: %w", err)
 				}
 
-				t.Did = string(sval)
 			}
 			// t.LexiconTypeID (string) (string)
 		case "$type":
@@ -3088,7 +3056,7 @@ func (t *FeedDefs_NotFoundPost) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Uri (string) (string)
+	// t.Uri (util.FormatAtURI) (struct)
 	if len("uri") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"uri\" was too long")
 	}
@@ -3100,14 +3068,7 @@ func (t *FeedDefs_NotFoundPost) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	if len(t.Uri) > cbg.MaxLength {
-		return xerrors.Errorf("Value in field t.Uri was too long")
-	}
-
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Uri))); err != nil {
-		return err
-	}
-	if _, err := io.WriteString(w, string(t.Uri)); err != nil {
+	if err := t.Uri.MarshalCBOR(cw); err != nil {
 		return err
 	}
 
@@ -3186,16 +3147,15 @@ func (t *FeedDefs_NotFoundPost) UnmarshalCBOR(r io.Reader) (err error) {
 		}
 
 		switch name {
-		// t.Uri (string) (string)
+		// t.Uri (util.FormatAtURI) (struct)
 		case "uri":
 
 			{
-				sval, err := cbg.ReadString(cr)
-				if err != nil {
-					return err
+
+				if err := t.Uri.UnmarshalCBOR(cr); err != nil {
+					return xerrors.Errorf("unmarshaling t.Uri: %w", err)
 				}
 
-				t.Uri = string(sval)
 			}
 			// t.LexiconTypeID (string) (string)
 		case "$type":

--- a/api/bsky/embedexternal.go
+++ b/api/bsky/embedexternal.go
@@ -19,10 +19,10 @@ type EmbedExternal struct {
 
 // EmbedExternal_External is a "external" in the app.bsky.embed.external schema.
 type EmbedExternal_External struct {
-	Description string        `json:"description" cborgen:"description"`
-	Thumb       *util.LexBlob `json:"thumb,omitempty" cborgen:"thumb,omitempty"`
-	Title       string        `json:"title" cborgen:"title"`
-	Uri         string        `json:"uri" cborgen:"uri"`
+	Description string         `json:"description" cborgen:"description"`
+	Thumb       *util.LexBlob  `json:"thumb,omitempty" cborgen:"thumb,omitempty"`
+	Title       string         `json:"title" cborgen:"title"`
+	Uri         util.FormatURI `json:"uri" cborgen:"uri"`
 }
 
 // EmbedExternal_View is a "view" in the app.bsky.embed.external schema.
@@ -35,8 +35,8 @@ type EmbedExternal_View struct {
 
 // EmbedExternal_ViewExternal is a "viewExternal" in the app.bsky.embed.external schema.
 type EmbedExternal_ViewExternal struct {
-	Description string  `json:"description" cborgen:"description"`
-	Thumb       *string `json:"thumb,omitempty" cborgen:"thumb,omitempty"`
-	Title       string  `json:"title" cborgen:"title"`
-	Uri         string  `json:"uri" cborgen:"uri"`
+	Description string         `json:"description" cborgen:"description"`
+	Thumb       *string        `json:"thumb,omitempty" cborgen:"thumb,omitempty"`
+	Title       string         `json:"title" cborgen:"title"`
+	Uri         util.FormatURI `json:"uri" cborgen:"uri"`
 }

--- a/api/bsky/embedrecord.go
+++ b/api/bsky/embedrecord.go
@@ -33,8 +33,8 @@ type EmbedRecord_View struct {
 //
 // RECORDTYPE: EmbedRecord_ViewNotFound
 type EmbedRecord_ViewNotFound struct {
-	LexiconTypeID string `json:"$type,const=app.bsky.embed.record" cborgen:"$type,const=app.bsky.embed.record"`
-	Uri           string `json:"uri" cborgen:"uri"`
+	LexiconTypeID string           `json:"$type,const=app.bsky.embed.record" cborgen:"$type,const=app.bsky.embed.record"`
+	Uri           util.FormatAtURI `json:"uri" cborgen:"uri"`
 }
 
 // EmbedRecord_ViewRecord is a "viewRecord" in the app.bsky.embed.record schema.
@@ -43,11 +43,11 @@ type EmbedRecord_ViewNotFound struct {
 type EmbedRecord_ViewRecord struct {
 	LexiconTypeID string                                `json:"$type,const=app.bsky.embed.record" cborgen:"$type,const=app.bsky.embed.record"`
 	Author        *ActorDefs_ProfileViewBasic           `json:"author" cborgen:"author"`
-	Cid           string                                `json:"cid" cborgen:"cid"`
+	Cid           util.FormatCID                        `json:"cid" cborgen:"cid"`
 	Embeds        []*EmbedRecord_ViewRecord_Embeds_Elem `json:"embeds,omitempty" cborgen:"embeds,omitempty"`
 	IndexedAt     string                                `json:"indexedAt" cborgen:"indexedAt"`
 	Labels        []*comatprototypes.LabelDefs_Label    `json:"labels,omitempty" cborgen:"labels,omitempty"`
-	Uri           string                                `json:"uri" cborgen:"uri"`
+	Uri           util.FormatAtURI                      `json:"uri" cborgen:"uri"`
 	Value         *util.LexiconTypeDecoder              `json:"value" cborgen:"value"`
 }
 

--- a/api/bsky/feeddefs.go
+++ b/api/bsky/feeddefs.go
@@ -50,15 +50,15 @@ func (t *FeedDefs_FeedViewPost_Reason) UnmarshalJSON(b []byte) error {
 //
 // RECORDTYPE: FeedDefs_NotFoundPost
 type FeedDefs_NotFoundPost struct {
-	LexiconTypeID string `json:"$type,const=app.bsky.feed.defs" cborgen:"$type,const=app.bsky.feed.defs"`
-	NotFound      bool   `json:"notFound" cborgen:"notFound"`
-	Uri           string `json:"uri" cborgen:"uri"`
+	LexiconTypeID string           `json:"$type,const=app.bsky.feed.defs" cborgen:"$type,const=app.bsky.feed.defs"`
+	NotFound      bool             `json:"notFound" cborgen:"notFound"`
+	Uri           util.FormatAtURI `json:"uri" cborgen:"uri"`
 }
 
 // FeedDefs_PostView is a "postView" in the app.bsky.feed.defs schema.
 type FeedDefs_PostView struct {
 	Author      *ActorDefs_ProfileViewBasic        `json:"author" cborgen:"author"`
-	Cid         string                             `json:"cid" cborgen:"cid"`
+	Cid         util.FormatCID                     `json:"cid" cborgen:"cid"`
 	Embed       *FeedDefs_PostView_Embed           `json:"embed,omitempty" cborgen:"embed,omitempty"`
 	IndexedAt   string                             `json:"indexedAt" cborgen:"indexedAt"`
 	Labels      []*comatprototypes.LabelDefs_Label `json:"labels,omitempty" cborgen:"labels,omitempty"`
@@ -66,7 +66,7 @@ type FeedDefs_PostView struct {
 	Record      *util.LexiconTypeDecoder           `json:"record" cborgen:"record"`
 	ReplyCount  *int64                             `json:"replyCount,omitempty" cborgen:"replyCount,omitempty"`
 	RepostCount *int64                             `json:"repostCount,omitempty" cborgen:"repostCount,omitempty"`
-	Uri         string                             `json:"uri" cborgen:"uri"`
+	Uri         util.FormatAtURI                   `json:"uri" cborgen:"uri"`
 	Viewer      *FeedDefs_ViewerState              `json:"viewer,omitempty" cborgen:"viewer,omitempty"`
 }
 
@@ -218,6 +218,6 @@ func (t *FeedDefs_ThreadViewPost_Replies_Elem) UnmarshalJSON(b []byte) error {
 
 // FeedDefs_ViewerState is a "viewerState" in the app.bsky.feed.defs schema.
 type FeedDefs_ViewerState struct {
-	Like   *string `json:"like,omitempty" cborgen:"like,omitempty"`
-	Repost *string `json:"repost,omitempty" cborgen:"repost,omitempty"`
+	Like   *util.FormatAtURI `json:"like,omitempty" cborgen:"like,omitempty"`
+	Repost *util.FormatAtURI `json:"repost,omitempty" cborgen:"repost,omitempty"`
 }

--- a/api/bsky/feedgetAuthorFeed.go
+++ b/api/bsky/feedgetAuthorFeed.go
@@ -7,6 +7,7 @@ package bsky
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -17,7 +18,7 @@ type FeedGetAuthorFeed_Output struct {
 }
 
 // FeedGetAuthorFeed calls the XRPC method "app.bsky.feed.getAuthorFeed".
-func FeedGetAuthorFeed(ctx context.Context, c *xrpc.Client, actor string, cursor string, limit int64) (*FeedGetAuthorFeed_Output, error) {
+func FeedGetAuthorFeed(ctx context.Context, c *xrpc.Client, actor util.FormatAtIdentifier, cursor string, limit int64) (*FeedGetAuthorFeed_Output, error) {
 	var out FeedGetAuthorFeed_Output
 
 	params := map[string]interface{}{

--- a/api/bsky/feedgetLikes.go
+++ b/api/bsky/feedgetLikes.go
@@ -7,6 +7,7 @@ package bsky
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -19,14 +20,14 @@ type FeedGetLikes_Like struct {
 
 // FeedGetLikes_Output is the output of a app.bsky.feed.getLikes call.
 type FeedGetLikes_Output struct {
-	Cid    *string              `json:"cid,omitempty" cborgen:"cid,omitempty"`
+	Cid    *util.FormatCID      `json:"cid,omitempty" cborgen:"cid,omitempty"`
 	Cursor *string              `json:"cursor,omitempty" cborgen:"cursor,omitempty"`
 	Likes  []*FeedGetLikes_Like `json:"likes" cborgen:"likes"`
-	Uri    string               `json:"uri" cborgen:"uri"`
+	Uri    util.FormatAtURI     `json:"uri" cborgen:"uri"`
 }
 
 // FeedGetLikes calls the XRPC method "app.bsky.feed.getLikes".
-func FeedGetLikes(ctx context.Context, c *xrpc.Client, cid string, cursor string, limit int64, uri string) (*FeedGetLikes_Output, error) {
+func FeedGetLikes(ctx context.Context, c *xrpc.Client, cid util.FormatCID, cursor string, limit int64, uri util.FormatAtURI) (*FeedGetLikes_Output, error) {
 	var out FeedGetLikes_Output
 
 	params := map[string]interface{}{

--- a/api/bsky/feedgetPostThread.go
+++ b/api/bsky/feedgetPostThread.go
@@ -54,7 +54,7 @@ func (t *FeedGetPostThread_Output_Thread) UnmarshalJSON(b []byte) error {
 }
 
 // FeedGetPostThread calls the XRPC method "app.bsky.feed.getPostThread".
-func FeedGetPostThread(ctx context.Context, c *xrpc.Client, depth int64, uri string) (*FeedGetPostThread_Output, error) {
+func FeedGetPostThread(ctx context.Context, c *xrpc.Client, depth int64, uri util.FormatAtURI) (*FeedGetPostThread_Output, error) {
 	var out FeedGetPostThread_Output
 
 	params := map[string]interface{}{

--- a/api/bsky/feedgetPosts.go
+++ b/api/bsky/feedgetPosts.go
@@ -7,6 +7,7 @@ package bsky
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -16,7 +17,7 @@ type FeedGetPosts_Output struct {
 }
 
 // FeedGetPosts calls the XRPC method "app.bsky.feed.getPosts".
-func FeedGetPosts(ctx context.Context, c *xrpc.Client, uris []string) (*FeedGetPosts_Output, error) {
+func FeedGetPosts(ctx context.Context, c *xrpc.Client, uris []util.FormatAtURI) (*FeedGetPosts_Output, error) {
 	var out FeedGetPosts_Output
 
 	params := map[string]interface{}{

--- a/api/bsky/feedgetRepostedBy.go
+++ b/api/bsky/feedgetRepostedBy.go
@@ -7,19 +7,20 @@ package bsky
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // FeedGetRepostedBy_Output is the output of a app.bsky.feed.getRepostedBy call.
 type FeedGetRepostedBy_Output struct {
-	Cid        *string                  `json:"cid,omitempty" cborgen:"cid,omitempty"`
+	Cid        *util.FormatCID          `json:"cid,omitempty" cborgen:"cid,omitempty"`
 	Cursor     *string                  `json:"cursor,omitempty" cborgen:"cursor,omitempty"`
 	RepostedBy []*ActorDefs_ProfileView `json:"repostedBy" cborgen:"repostedBy"`
-	Uri        string                   `json:"uri" cborgen:"uri"`
+	Uri        util.FormatAtURI         `json:"uri" cborgen:"uri"`
 }
 
 // FeedGetRepostedBy calls the XRPC method "app.bsky.feed.getRepostedBy".
-func FeedGetRepostedBy(ctx context.Context, c *xrpc.Client, cid string, cursor string, limit int64, uri string) (*FeedGetRepostedBy_Output, error) {
+func FeedGetRepostedBy(ctx context.Context, c *xrpc.Client, cid util.FormatCID, cursor string, limit int64, uri util.FormatAtURI) (*FeedGetRepostedBy_Output, error) {
 	var out FeedGetRepostedBy_Output
 
 	params := map[string]interface{}{

--- a/api/bsky/graphfollow.go
+++ b/api/bsky/graphfollow.go
@@ -13,7 +13,7 @@ func init() {
 } //
 // RECORDTYPE: GraphFollow
 type GraphFollow struct {
-	LexiconTypeID string `json:"$type,const=app.bsky.graph.follow" cborgen:"$type,const=app.bsky.graph.follow"`
-	CreatedAt     string `json:"createdAt" cborgen:"createdAt"`
-	Subject       string `json:"subject" cborgen:"subject"`
+	LexiconTypeID string         `json:"$type,const=app.bsky.graph.follow" cborgen:"$type,const=app.bsky.graph.follow"`
+	CreatedAt     string         `json:"createdAt" cborgen:"createdAt"`
+	Subject       util.FormatDID `json:"subject" cborgen:"subject"`
 }

--- a/api/bsky/graphgetFollowers.go
+++ b/api/bsky/graphgetFollowers.go
@@ -7,6 +7,7 @@ package bsky
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -18,7 +19,7 @@ type GraphGetFollowers_Output struct {
 }
 
 // GraphGetFollowers calls the XRPC method "app.bsky.graph.getFollowers".
-func GraphGetFollowers(ctx context.Context, c *xrpc.Client, actor string, cursor string, limit int64) (*GraphGetFollowers_Output, error) {
+func GraphGetFollowers(ctx context.Context, c *xrpc.Client, actor util.FormatAtIdentifier, cursor string, limit int64) (*GraphGetFollowers_Output, error) {
 	var out GraphGetFollowers_Output
 
 	params := map[string]interface{}{

--- a/api/bsky/graphgetFollows.go
+++ b/api/bsky/graphgetFollows.go
@@ -7,6 +7,7 @@ package bsky
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -18,7 +19,7 @@ type GraphGetFollows_Output struct {
 }
 
 // GraphGetFollows calls the XRPC method "app.bsky.graph.getFollows".
-func GraphGetFollows(ctx context.Context, c *xrpc.Client, actor string, cursor string, limit int64) (*GraphGetFollows_Output, error) {
+func GraphGetFollows(ctx context.Context, c *xrpc.Client, actor util.FormatAtIdentifier, cursor string, limit int64) (*GraphGetFollows_Output, error) {
 	var out GraphGetFollows_Output
 
 	params := map[string]interface{}{

--- a/api/bsky/graphmuteActor.go
+++ b/api/bsky/graphmuteActor.go
@@ -7,12 +7,13 @@ package bsky
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // GraphMuteActor_Input is the input argument to a app.bsky.graph.muteActor call.
 type GraphMuteActor_Input struct {
-	Actor string `json:"actor" cborgen:"actor"`
+	Actor util.FormatAtIdentifier `json:"actor" cborgen:"actor"`
 }
 
 // GraphMuteActor calls the XRPC method "app.bsky.graph.muteActor".

--- a/api/bsky/graphunmuteActor.go
+++ b/api/bsky/graphunmuteActor.go
@@ -7,12 +7,13 @@ package bsky
 import (
 	"context"
 
+	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // GraphUnmuteActor_Input is the input argument to a app.bsky.graph.unmuteActor call.
 type GraphUnmuteActor_Input struct {
-	Actor string `json:"actor" cborgen:"actor"`
+	Actor util.FormatAtIdentifier `json:"actor" cborgen:"actor"`
 }
 
 // GraphUnmuteActor calls the XRPC method "app.bsky.graph.unmuteActor".

--- a/api/bsky/notificationlistNotifications.go
+++ b/api/bsky/notificationlistNotifications.go
@@ -15,15 +15,15 @@ import (
 // NotificationListNotifications_Notification is a "notification" in the app.bsky.notification.listNotifications schema.
 type NotificationListNotifications_Notification struct {
 	Author    *ActorDefs_ProfileView             `json:"author" cborgen:"author"`
-	Cid       string                             `json:"cid" cborgen:"cid"`
+	Cid       util.FormatCID                     `json:"cid" cborgen:"cid"`
 	IndexedAt string                             `json:"indexedAt" cborgen:"indexedAt"`
 	IsRead    bool                               `json:"isRead" cborgen:"isRead"`
 	Labels    []*comatprototypes.LabelDefs_Label `json:"labels,omitempty" cborgen:"labels,omitempty"`
 	// reason: Expected values are 'like', 'repost', 'follow', 'mention', 'reply', and 'quote'.
 	Reason        string                   `json:"reason" cborgen:"reason"`
-	ReasonSubject *string                  `json:"reasonSubject,omitempty" cborgen:"reasonSubject,omitempty"`
+	ReasonSubject *util.FormatAtURI        `json:"reasonSubject,omitempty" cborgen:"reasonSubject,omitempty"`
 	Record        *util.LexiconTypeDecoder `json:"record" cborgen:"record"`
-	Uri           string                   `json:"uri" cborgen:"uri"`
+	Uri           util.FormatAtURI         `json:"uri" cborgen:"uri"`
 }
 
 // NotificationListNotifications_Output is the output of a app.bsky.notification.listNotifications call.

--- a/api/bsky/richtextfacet.go
+++ b/api/bsky/richtextfacet.go
@@ -102,8 +102,8 @@ func (t *RichtextFacet_Features_Elem) UnmarshalCBOR(r io.Reader) error {
 //
 // RECORDTYPE: RichtextFacet_Link
 type RichtextFacet_Link struct {
-	LexiconTypeID string `json:"$type,const=app.bsky.richtext.facet" cborgen:"$type,const=app.bsky.richtext.facet"`
-	Uri           string `json:"uri" cborgen:"uri"`
+	LexiconTypeID string         `json:"$type,const=app.bsky.richtext.facet" cborgen:"$type,const=app.bsky.richtext.facet"`
+	Uri           util.FormatURI `json:"uri" cborgen:"uri"`
 }
 
 // RichtextFacet_Mention is a "mention" in the app.bsky.richtext.facet schema.
@@ -112,6 +112,6 @@ type RichtextFacet_Link struct {
 //
 // RECORDTYPE: RichtextFacet_Mention
 type RichtextFacet_Mention struct {
-	LexiconTypeID string `json:"$type,const=app.bsky.richtext.facet" cborgen:"$type,const=app.bsky.richtext.facet"`
-	Did           string `json:"did" cborgen:"did"`
+	LexiconTypeID string         `json:"$type,const=app.bsky.richtext.facet" cborgen:"$type,const=app.bsky.richtext.facet"`
+	Did           util.FormatDID `json:"did" cborgen:"did"`
 }

--- a/api/extra.go
+++ b/api/extra.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 	did "github.com/whyrusleeping/go-did"
 	otel "go.opentelemetry.io/otel"
@@ -49,12 +50,12 @@ func ResolveDidToHandle(ctx context.Context, xrpcc *xrpc.Client, pls *PLCServer,
 		return "", "", fmt.Errorf("our XRPC client is authed for a different pds (%s != %s)", svc.ServiceEndpoint, xrpcc.Host)
 	}
 
-	verdid, err := comatproto.IdentityResolveHandle(ctx, xrpcc, handle)
+	verdid, err := comatproto.IdentityResolveHandle(ctx, xrpcc, lexutil.NewFormatHandle(handle))
 	if err != nil {
 		return "", "", err
 	}
 
-	if verdid.Did != udid {
+	if verdid.Did.String() != udid {
 		return "", "", fmt.Errorf("pds server reported different did for claimed handle")
 	}
 

--- a/bgs/handlers.go
+++ b/bgs/handlers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	comatprototypes "github.com/bluesky-social/indigo/api/atproto"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 	"github.com/ipfs/go-cid"
 )
 
@@ -49,7 +50,8 @@ func (s *BGS) handleComAtprotoSyncGetHead(ctx context.Context, did string) (*com
 	}
 
 	return &comatprototypes.SyncGetHead_Output{
-		Root: root.String(),
+		// TODO: more graceful type conversion
+		Root: lexutil.NewFormatCID(root.String()),
 	}, nil
 }
 

--- a/cmd/beemo/main.go
+++ b/cmd/beemo/main.go
@@ -118,8 +118,8 @@ func pollNewReports(cctx *cli.Context) error {
 	}
 	xrpcc.Auth.AccessJwt = auth.AccessJwt
 	xrpcc.Auth.RefreshJwt = auth.RefreshJwt
-	xrpcc.Auth.Did = auth.Did
-	xrpcc.Auth.Handle = auth.Handle
+	xrpcc.Auth.Did = auth.Did.String()
+	xrpcc.Auth.Handle = auth.Handle.String()
 
 	adminToken := cctx.String("admin-password")
 	if len(adminToken) > 0 {

--- a/cmd/gosky/debug.go
+++ b/cmd/gosky/debug.go
@@ -212,7 +212,7 @@ var debugStreamCmd = &cli.Command{
 					}
 				}
 
-				cur, ok := infos[evt.Repo]
+				cur, ok := infos[evt.Repo.String()]
 				if ok {
 					if cur.LastCid.String() != cidStr(evt.Prev) {
 						fmt.Println()
@@ -220,7 +220,7 @@ var debugStreamCmd = &cli.Command{
 					}
 				}
 
-				infos[evt.Repo] = &eventInfo{
+				infos[evt.Repo.String()] = &eventInfo{
 					LastCid: cid.Cid(evt.Commit),
 					LastSeq: evt.Seq,
 				}

--- a/cmd/stress/main.go
+++ b/cmd/stress/main.go
@@ -106,7 +106,7 @@ var postingCmd = &cli.Command{
 
 		resp, err := comatproto.ServerCreateAccount(ctx, xrpcc, &comatproto.ServerCreateAccount_Input{
 			Email:      fmt.Sprintf("user-%s@test.com", id),
-			Handle:     "user-" + id + domain,
+			Handle:     lexutil.NewFormatHandle("user-" + id + domain),
 			Password:   "password",
 			InviteCode: invite,
 		})
@@ -117,8 +117,8 @@ var postingCmd = &cli.Command{
 		xrpcc.Auth = &xrpc.AuthInfo{
 			AccessJwt:  resp.AccessJwt,
 			RefreshJwt: resp.RefreshJwt,
-			Handle:     resp.Handle,
-			Did:        resp.Did,
+			Handle:     resp.Handle.String(),
+			Did:        resp.Did.String(),
 		}
 
 		var wg sync.WaitGroup
@@ -131,8 +131,8 @@ var postingCmd = &cli.Command{
 					rand.Read(buf)
 
 					res, err := comatproto.RepoCreateRecord(context.TODO(), xrpcc, &comatproto.RepoCreateRecord_Input{
-						Collection: "app.bsky.feed.post",
-						Repo:       xrpcc.Auth.Did,
+						Collection: lexutil.NewFormatNSID("app.bsky.feed.post"),
+						Repo:       lexutil.NewFormatAtIdentifier(xrpcc.Auth.Did),
 						Record: &lexutil.LexiconTypeDecoder{&appbsky.FeedPost{
 							Text:      hex.EncodeToString(buf),
 							CreatedAt: time.Now().Format(time.RFC3339),

--- a/events/dbpersist.go
+++ b/events/dbpersist.go
@@ -72,7 +72,7 @@ func (p *DbPersistence) Persist(ctx context.Context, e *XRPCStreamEvent) error {
 		evt.Ops = evt.Ops[:8192]
 	}
 
-	uid, err := p.uidForDid(ctx, evt.Repo)
+	uid, err := p.uidForDid(ctx, evt.Repo.String())
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func (p *DbPersistence) hydrateRepoEvent(ctx context.Context, rer *RepoEventReco
 
 	out := &comatproto.SyncSubscribeRepos_Commit{
 		Seq:    int64(rer.Seq),
-		Repo:   did,
+		Repo:   lexutil.NewFormatDID(did),
 		Commit: lexutil.LexLink(rer.Commit.CID),
 		Prev:   prevCID,
 		Time:   rer.Time.Format(util.ISO8601),

--- a/events/repostream.go
+++ b/events/repostream.go
@@ -44,13 +44,13 @@ func ConsumeRepoStreamLite(ctx context.Context, con *websocket.Conn, cb LiteStre
 						return fmt.Errorf("mismatch in record and op cid: %s != %s", rc, *op.Cid)
 					}
 
-					if err := cb(ek, evt.Seq, op.Path, evt.Repo, &rc, rec); err != nil {
+					if err := cb(ek, evt.Seq, op.Path, evt.Repo.String(), &rc, rec); err != nil {
 						log.Errorf("event consumer callback (%s): %s", ek, err)
 						continue
 					}
 
 				case repomgr.EvtKindDeleteRecord:
-					if err := cb(ek, evt.Seq, op.Path, evt.Repo, nil, nil); err != nil {
+					if err := cb(ek, evt.Seq, op.Path, evt.Repo.String(), nil, nil); err != nil {
 						log.Errorf("event consumer callback (%s): %s", ek, err)
 						continue
 					}

--- a/go.mod
+++ b/go.mod
@@ -105,6 +105,7 @@ require (
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/prometheus/statsd_exporter v0.23.1 // indirect
+	github.com/relvacode/iso8601 v1.3.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -580,6 +580,8 @@ github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB
 github.com/prometheus/statsd_exporter v0.22.7/go.mod h1:N/TevpjkIh9ccs6nuzY3jQn9dFqnUakOjnEuMPJJJnI=
 github.com/prometheus/statsd_exporter v0.23.1 h1:TiNAE1XevlZZrpSbmf51l/Ryl2Eek9rYh//KlvcNvKw=
 github.com/prometheus/statsd_exporter v0.23.1/go.mod h1:FFmnBRWf+HxX+PR+2fnc0ciBIONVAPJ6k4lqIbdqVxo=
+github.com/relvacode/iso8601 v1.3.0 h1:HguUjsGpIMh/zsTczGN3DVJFxTU/GX+MMmzcKoMO7ko=
+github.com/relvacode/iso8601 v1.3.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=

--- a/labeler/admin.go
+++ b/labeler/admin.go
@@ -15,9 +15,9 @@ import (
 func (s *Server) hydrateRepoView(ctx context.Context, did, indexedAt string) *comatproto.AdminDefs_RepoView {
 	return &comatproto.AdminDefs_RepoView{
 		// TODO(bnewbold): populate more, or more correctly, from some backend?
-		Did:            did,
+		Did:            lexutil.NewFormatDID(did),
 		Email:          nil,
-		Handle:         "TODO",
+		Handle:         lexutil.NewFormatHandle("TODO.TODO"),
 		IndexedAt:      indexedAt,
 		Moderation:     nil,
 		RelatedRecords: nil,
@@ -29,7 +29,7 @@ func (s *Server) hydrateRecordView(ctx context.Context, did string, uri, cid *st
 	repoView := s.hydrateRepoView(ctx, did, indexedAt)
 	// TODO(bnewbold): populate more, or more correctly, from some backend?
 	recordView := comatproto.AdminDefs_RecordView{
-		BlobCids:   []string{},
+		BlobCids:   []lexutil.FormatCID{},
 		IndexedAt:  indexedAt,
 		Moderation: nil,
 		Repo:       repoView,
@@ -37,10 +37,10 @@ func (s *Server) hydrateRecordView(ctx context.Context, did string, uri, cid *st
 		Value: &lexutil.LexiconTypeDecoder{&appbsky.FeedPost{}},
 	}
 	if uri != nil {
-		recordView.Uri = *uri
+		recordView.Uri = lexutil.NewFormatAtURI(*uri)
 	}
 	if cid != nil {
-		recordView.Cid = *cid
+		recordView.Cid = lexutil.NewFormatCID(*cid)
 	}
 	return &recordView
 }
@@ -75,7 +75,7 @@ func (s *Server) hydrateModerationActionViews(ctx context.Context, rows []models
 		if row.ReversedAt != nil {
 			reversal = &comatproto.AdminDefs_ActionReversal{
 				CreatedAt: row.ReversedAt.Format(time.RFC3339),
-				CreatedBy: *row.ReversedByDid,
+				CreatedBy: lexutil.NewFormatDID(*row.ReversedByDid),
 				Reason:    *row.ReversedReason,
 			}
 		}
@@ -85,15 +85,15 @@ func (s *Server) hydrateModerationActionViews(ctx context.Context, rows []models
 			subj = &comatproto.AdminDefs_ActionView_Subject{
 				AdminDefs_RepoRef: &comatproto.AdminDefs_RepoRef{
 					LexiconTypeID: "com.atproto.repo.repoRef",
-					Did:           row.SubjectDid,
+					Did:           lexutil.NewFormatDID(row.SubjectDid),
 				},
 			}
 		case "com.atproto.repo.recordRef":
 			subj = &comatproto.AdminDefs_ActionView_Subject{
 				RepoStrongRef: &comatproto.RepoStrongRef{
 					LexiconTypeID: "com.atproto.repo.strongRef",
-					Uri:           *row.SubjectUri,
-					Cid:           *row.SubjectCid,
+					Uri:           lexutil.NewFormatAtURI(*row.SubjectUri),
+					Cid:           lexutil.NewFormatCID(*row.SubjectCid),
 				},
 			}
 		default:
@@ -103,7 +103,7 @@ func (s *Server) hydrateModerationActionViews(ctx context.Context, rows []models
 		view := &comatproto.AdminDefs_ActionView{
 			Action:            &row.Action,
 			CreatedAt:         row.CreatedAt.Format(time.RFC3339),
-			CreatedBy:         row.CreatedByDid,
+			CreatedBy:         lexutil.NewFormatDID(row.CreatedByDid),
 			Id:                int64(row.ID),
 			Reason:            row.Reason,
 			ResolvedReportIds: resolvedReportIds,
@@ -139,7 +139,7 @@ func (s *Server) hydrateModerationActionDetails(ctx context.Context, rows []mode
 		}
 		for _, row := range cidRows {
 			subjectBlobViews = append(subjectBlobViews, &comatproto.AdminDefs_BlobView{
-				Cid: row.Cid,
+				Cid: lexutil.NewFormatCID(row.Cid),
 				/* TODO(bnewbold): all these other blob fields (from another backed)
 				CreatedAt     string
 				Details       *AdminDefs_BlobView_Details
@@ -154,7 +154,7 @@ func (s *Server) hydrateModerationActionDetails(ctx context.Context, rows []mode
 		if row.ReversedAt != nil {
 			reversal = &comatproto.AdminDefs_ActionReversal{
 				CreatedAt: row.ReversedAt.Format(time.RFC3339),
-				CreatedBy: *row.ReversedByDid,
+				CreatedBy: lexutil.NewFormatDID(*row.ReversedByDid),
 				Reason:    *row.ReversedReason,
 			}
 		}
@@ -175,7 +175,7 @@ func (s *Server) hydrateModerationActionDetails(ctx context.Context, rows []mode
 		viewDetail := &comatproto.AdminDefs_ActionViewDetail{
 			Action:          &row.Action,
 			CreatedAt:       row.CreatedAt.Format(time.RFC3339),
-			CreatedBy:       row.CreatedByDid,
+			CreatedBy:       lexutil.NewFormatDID(row.CreatedByDid),
 			Id:              int64(row.ID),
 			Reason:          row.Reason,
 			ResolvedReports: resolvedReports,
@@ -208,15 +208,15 @@ func (s *Server) hydrateModerationReportViews(ctx context.Context, rows []models
 			subj = &comatproto.AdminDefs_ReportView_Subject{
 				AdminDefs_RepoRef: &comatproto.AdminDefs_RepoRef{
 					LexiconTypeID: "com.atproto.repo.repoRef",
-					Did:           row.SubjectDid,
+					Did:           lexutil.NewFormatDID(row.SubjectDid),
 				},
 			}
 		case "com.atproto.repo.recordRef":
 			subj = &comatproto.AdminDefs_ReportView_Subject{
 				RepoStrongRef: &comatproto.RepoStrongRef{
 					LexiconTypeID: "com.atproto.repo.strongRef",
-					Uri:           *row.SubjectUri,
-					Cid:           *row.SubjectCid,
+					Uri:           lexutil.NewFormatAtURI(*row.SubjectUri),
+					Cid:           lexutil.NewFormatCID(*row.SubjectCid),
 				},
 			}
 		default:
@@ -228,7 +228,7 @@ func (s *Server) hydrateModerationReportViews(ctx context.Context, rows []models
 			Reason:              row.Reason,
 			ReasonType:          &row.ReasonType,
 			Subject:             subj,
-			ReportedBy:          row.ReportedByDid,
+			ReportedBy:          lexutil.NewFormatDID(row.ReportedByDid),
 			CreatedAt:           row.CreatedAt.Format(time.RFC3339),
 			ResolvedByActionIds: resolvedByActionIds,
 		}
@@ -270,7 +270,7 @@ func (s *Server) hydrateModerationReportDetails(ctx context.Context, rows []mode
 			Reason:            row.Reason,
 			ReasonType:        &row.ReasonType,
 			Subject:           subj,
-			ReportedBy:        row.ReportedByDid,
+			ReportedBy:        lexutil.NewFormatDID(row.ReportedByDid),
 			CreatedAt:         row.CreatedAt.Format(time.RFC3339),
 			ResolvedByActions: resolvedByActionViews,
 		}

--- a/labeler/service.go
+++ b/labeler/service.go
@@ -358,7 +358,7 @@ func (s *Server) handleBgsRepoEvent(ctx context.Context, pds *models.PDS, evt *e
 
 	labels := []*label.Label{}
 	for _, op := range evt.RepoCommit.Ops {
-		uri := "at://" + evt.RepoCommit.Repo + "/" + op.Path
+		uri := "at://" + evt.RepoCommit.Repo.String() + "/" + op.Path
 		nsid := strings.SplitN(op.Path, "/", 2)[0]
 
 		if !(op.Action == "create" || op.Action == "update") {
@@ -370,7 +370,7 @@ func (s *Server) handleBgsRepoEvent(ctx context.Context, pds *models.PDS, evt *e
 			return fmt.Errorf("record not in CAR slice: %s", uri)
 		}
 		cidStr := cid.String()
-		labelVals, err := s.labelRecord(ctx, evt.RepoCommit.Repo, nsid, uri, cidStr, rec)
+		labelVals, err := s.labelRecord(ctx, evt.RepoCommit.Repo.String(), nsid, uri, cidStr, rec)
 		if err != nil {
 			return err
 		}
@@ -380,7 +380,7 @@ func (s *Server) handleBgsRepoEvent(ctx context.Context, pds *models.PDS, evt *e
 				val = strings.SplitN(val, ":", 2)[1]
 				labels = append(labels, &label.Label{
 					Src: s.user.Did,
-					Uri: "at://" + evt.RepoCommit.Repo,
+					Uri: "at://" + evt.RepoCommit.Repo.String(),
 					Val: val,
 					//Neg
 					//Cts

--- a/labeler/xrpc_test.go
+++ b/labeler/xrpc_test.go
@@ -12,6 +12,7 @@ import (
 
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	label "github.com/bluesky-social/indigo/api/label"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -30,14 +31,14 @@ func TestLabelMakerXRPCReportRepo(t *testing.T) {
 		ReasonType: &rt,
 		Subject: &comatproto.ModerationCreateReport_Input_Subject{
 			AdminDefs_RepoRef: &comatproto.AdminDefs_RepoRef{
-				Did: reportedDid,
+				Did: lexutil.NewFormatDID(reportedDid),
 			},
 		},
 	}
 	out := testCreateReport(t, e, lm, &report)
 	assert.Equal(&rt, out.ReasonType)
 	assert.Nil(out.Reason)
-	assert.Equal(reportedDid, out.Subject.AdminDefs_RepoRef.Did)
+	assert.Equal(reportedDid, out.Subject.AdminDefs_RepoRef.Did.String())
 }
 
 func TestLabelMakerXRPCReportRepoBad(t *testing.T) {
@@ -62,7 +63,7 @@ func TestLabelMakerXRPCReportRepoBad(t *testing.T) {
 			ReasonType: &row.rType,
 			Subject: &comatproto.ModerationCreateReport_Input_Subject{
 				AdminDefs_RepoRef: &comatproto.AdminDefs_RepoRef{
-					Did: row.rDid,
+					Did: lexutil.NewFormatDID(row.rDid),
 				},
 			},
 		}
@@ -99,8 +100,8 @@ func TestLabelMakerXRPCReportRecord(t *testing.T) {
 		Subject: &comatproto.ModerationCreateReport_Input_Subject{
 			RepoStrongRef: &comatproto.RepoStrongRef{
 				//com.atproto.repo.strongRef
-				Uri: uri,
-				Cid: cid,
+				Uri: lexutil.NewFormatAtURI(uri),
+				Cid: lexutil.NewFormatCID(cid),
 			},
 		},
 	}
@@ -140,8 +141,8 @@ func TestLabelMakerXRPCReportRecordBad(t *testing.T) {
 			Subject: &comatproto.ModerationCreateReport_Input_Subject{
 				RepoStrongRef: &comatproto.RepoStrongRef{
 					//com.atproto.repo.strongRef
-					Uri: row.rUri,
-					Cid: row.rCid,
+					Uri: lexutil.NewFormatAtURI(row.rUri),
+					Cid: lexutil.NewFormatCID(row.rCid),
 				},
 			},
 		}
@@ -179,8 +180,8 @@ func TestLabelMakerXRPCReportAction(t *testing.T) {
 		Subject: &comatproto.ModerationCreateReport_Input_Subject{
 			RepoStrongRef: &comatproto.RepoStrongRef{
 				//com.atproto.repo.strongRef
-				Uri: uri,
-				Cid: cid,
+				Uri: lexutil.NewFormatAtURI(uri),
+				Cid: lexutil.NewFormatCID(cid),
 			},
 		},
 	}
@@ -193,18 +194,20 @@ func TestLabelMakerXRPCReportAction(t *testing.T) {
 	actionReason := "chaos reigns"
 	action := comatproto.AdminTakeModerationAction_Input{
 		Action:    actionVerb,
-		CreatedBy: actionDid,
+		CreatedBy: lexutil.NewFormatDID(actionDid),
 		Reason:    actionReason,
 		Subject: &comatproto.AdminTakeModerationAction_Input_Subject{
 			RepoStrongRef: &comatproto.RepoStrongRef{
 				//com.atproto.repo.strongRef
-				Uri: uri,
-				Cid: cid,
+				Uri: lexutil.NewFormatAtURI(uri),
+				Cid: lexutil.NewFormatCID(cid),
 			},
 		},
-		SubjectBlobCids: []string{
-			"abc",
-			"onetwothree",
+		SubjectBlobCids: []lexutil.FormatCID{
+			// lexutil.NewFormatCID("abc"),
+			// lexutil.NewFormatCID("onetwothree"),
+			lexutil.NewFormatCID("bafyreie5cvv4h45feadgeuwhbcutmh6t2ceseocckahdoe6uat64zmz454"),
+			lexutil.NewFormatCID("bafyreie5cvv4h45feadgeuwhbcutmh6t2ceseocckahdoe6uat64zmz455"),
 		},
 	}
 	actionOut := testCreateAction(t, e, lm, &action)
@@ -213,7 +216,7 @@ func TestLabelMakerXRPCReportAction(t *testing.T) {
 	// resolve report with action
 	resolution := comatproto.AdminResolveModerationReports_Input{
 		ActionId:  actionId,
-		CreatedBy: actionDid,
+		CreatedBy: lexutil.NewFormatDID(actionDid),
 		ReportIds: []int64{reportId},
 	}
 	resolutionJSON, err := json.Marshal(resolution)
@@ -250,7 +253,7 @@ func TestLabelMakerXRPCReportAction(t *testing.T) {
 	reversalReason := "changed my mind"
 	reversal := comatproto.AdminReverseModerationAction_Input{
 		Id:        actionId,
-		CreatedBy: actionDid,
+		CreatedBy: lexutil.NewFormatDID(actionDid),
 		Reason:    reversalReason,
 	}
 	reversalJSON, err := json.Marshal(reversal)

--- a/lex/gen.go
+++ b/lex/gen.go
@@ -74,6 +74,7 @@ type TypeSchema struct {
 	Items      *TypeSchema            `json:"items"`
 	Const      any                    `json:"const"`
 	Enum       []string               `json:"enum"`
+	Format     string                 `json:"format"`
 	Closed     bool                   `json:"closed"`
 
 	Default any `json:"default"`
@@ -217,6 +218,8 @@ func ReadSchema(f string) (*Schema, error) {
 	if err := json.NewDecoder(fi).Decode(&s); err != nil {
 		return nil, err
 	}
+
+	json.NewEncoder(os.Stdout).Encode(&s)
 
 	return &s, nil
 }
@@ -1076,7 +1079,24 @@ func (s *TypeSchema) TypeName() string {
 func (s *TypeSchema) typeNameForField(name, k string, v TypeSchema) (string, error) {
 	switch v.Type {
 	case "string":
-		return "string", nil
+		switch v.Format {
+		case "handle":
+			return "util.FormatHandle", nil
+		case "nsid":
+			return "util.FormatNSID", nil
+		case "at-identifier":
+			return "util.FormatAtIdentifier", nil
+		case "uri":
+			return "util.FormatURI", nil
+		case "at-uri":
+			return "util.FormatAtURI", nil
+		case "did":
+			return "util.FormatDID", nil
+		case "cid":
+			return "util.FormatCID", nil
+		default:
+			return "string", nil
+		}
 	case "float":
 		return "float64", nil
 	case "integer":
@@ -1088,8 +1108,7 @@ func (s *TypeSchema) typeNameForField(name, k string, v TypeSchema) (string, err
 	case "ref":
 		return "*" + s.typeNameFromRef(v.Ref), nil
 	case "datetime":
-		// TODO: maybe do a native type?
-		return "string", nil
+		return "util.FormatDateTime", nil
 	case "unknown":
 		return "*util.LexiconTypeDecoder", nil
 	case "union":

--- a/lex/util/lex_format.go
+++ b/lex/util/lex_format.go
@@ -1,0 +1,539 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+
+	"github.com/ipfs/go-cid"
+	"github.com/relvacode/iso8601"
+	"golang.org/x/xerrors"
+
+	cbg "github.com/whyrusleeping/cbor-gen"
+)
+
+// cbor-gen internally uses reflect to determine the type of the field, and
+// if the type definition is an alias, it will treat the type as the underlying type(string) instead of the new type.
+// For this reason, we need to define a new struct for each format types, not using an alias.
+
+type FormatHandle struct{ str string }
+
+// https://github.com/bluesky-social/atproto/blob/main/packages/identifier/src/handle.ts
+var regexValidHandle = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
+
+func ParseFormatHandle(s string) (FormatHandle, error) {
+	if !regexValidHandle.MatchString(s) {
+		return FormatHandle{""}, fmt.Errorf("invalid handle: %s", s)
+	}
+
+	if len(s) > 253 {
+		return FormatHandle{""}, fmt.Errorf("handle is too long(253 chars max): %s", s)
+	}
+
+	return FormatHandle{s}, nil
+}
+
+func (f FormatHandle) String() string {
+	return f.str
+}
+
+func (f FormatHandle) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+	err := MarshalFormatString(cw, f.str)
+	if err != nil {
+		return xerrors.Errorf("failed to write handle string as CBOR: %w", err)
+	}
+
+	return nil
+}
+
+func (f *FormatHandle) UnmarshalCBOR(r io.Reader) error {
+	cr := cbg.NewCborReader(r)
+	s, err := cbg.ReadString(cr)
+	if err != nil {
+		return xerrors.Errorf("failed to read handle string from CBOR: %w", err)
+	}
+	fp, err := ParseFormatHandle(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse handle string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+func (f FormatHandle) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.str)
+}
+
+func (f *FormatHandle) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return xerrors.Errorf("failed to unmarshal handle string: %w", err)
+	}
+	fp, err := ParseFormatHandle(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse handle string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+type FormatNSID struct{ str string }
+
+// https://github.com/bluesky-social/atproto/blob/main/packages/nsid/src/index.ts
+var regexValidNSID = regexp.MustCompile(`^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(\.[a-zA-Z]([a-zA-Z0-9-]{0,126}[a-zA-Z0-9])?)$`)
+
+func ParseFormatNSID(s string) (FormatNSID, error) {
+	if !regexValidNSID.MatchString(s) {
+		return FormatNSID{""}, fmt.Errorf("invalid NSID: %s", s)
+	}
+
+	if len(s) > 253+1+128 {
+		return FormatNSID{""}, fmt.Errorf("NSID is too long(382 chars max): %s", s)
+	}
+
+	return FormatNSID{s}, nil
+}
+
+func (f FormatNSID) String() string {
+	return f.str
+}
+
+func (f FormatNSID) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+	err := MarshalFormatString(cw, f.str)
+	if err != nil {
+		return xerrors.Errorf("failed to write NSID string as CBOR: %w", err)
+	}
+
+	return nil
+}
+
+func (f *FormatNSID) UnmarshalCBOR(r io.Reader) error {
+	cr := cbg.NewCborReader(r)
+	s, err := cbg.ReadString(cr)
+	if err != nil {
+		return xerrors.Errorf("failed to read NSID string from CBOR: %w", err)
+	}
+	fp, err := ParseFormatNSID(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse NSID string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+func (f FormatNSID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.str)
+}
+
+func (f *FormatNSID) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return xerrors.Errorf("failed to unmarshal NSID string: %w", err)
+	}
+	fp, err := ParseFormatNSID(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse NSID string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+type FormatAtIdentifier struct{ str string }
+
+func ParseFormatAtIdentifier(s string) (FormatAtIdentifier, error) {
+	if regexValidDID.MatchString(s) {
+		return FormatAtIdentifier{s}, nil
+	}
+
+	if regexValidHandle.MatchString(s) {
+		return FormatAtIdentifier{s}, nil
+	}
+
+	return FormatAtIdentifier{""}, fmt.Errorf("invalid at-identifier: %s", s)
+}
+
+func (f FormatAtIdentifier) String() string {
+	return f.str
+}
+
+func (f FormatAtIdentifier) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+	err := MarshalFormatString(cw, f.str)
+	if err != nil {
+		return xerrors.Errorf("failed to write at-identifier string as CBOR: %w", err)
+	}
+
+	return nil
+}
+
+func (f *FormatAtIdentifier) UnmarshalCBOR(r io.Reader) error {
+	cr := cbg.NewCborReader(r)
+	s, err := cbg.ReadString(cr)
+	if err != nil {
+		return xerrors.Errorf("failed to read at-identifier string from CBOR: %w", err)
+	}
+	fp, err := ParseFormatAtIdentifier(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse at-identifier string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+func (f FormatAtIdentifier) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.str)
+}
+
+func (f *FormatAtIdentifier) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return xerrors.Errorf("failed to unmarshal at-identifier string: %w", err)
+	}
+	fp, err := ParseFormatAtIdentifier(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse at-identifier string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+type FormatURI struct{ str string }
+
+var regexValidURI = regexp.MustCompile(`^\w+:(?:\/\/)?[^\s/][^\s]*$`)
+
+func ParseFormatURI(s string) (FormatURI, error) {
+	if !regexValidURI.MatchString(s) {
+		return FormatURI{""}, fmt.Errorf("invalid URI: %s", s)
+	}
+
+	return FormatURI{s}, nil
+}
+
+func (f FormatURI) String() string {
+	return f.str
+}
+
+func (f FormatURI) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+	err := MarshalFormatString(cw, f.str)
+	if err != nil {
+		return xerrors.Errorf("failed to write URI string as CBOR: %w", err)
+	}
+
+	return nil
+}
+
+func (f *FormatURI) UnmarshalCBOR(r io.Reader) error {
+	cr := cbg.NewCborReader(r)
+	s, err := cbg.ReadString(cr)
+	if err != nil {
+		return xerrors.Errorf("failed to read URI string from CBOR: %w", err)
+	}
+	fp, err := ParseFormatURI(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse URI string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+func (f FormatURI) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.str)
+}
+
+func (f *FormatURI) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return xerrors.Errorf("failed to unmarshal URI string: %w", err)
+	}
+	fp, err := ParseFormatURI(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse URI string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+type FormatDateTime struct{ str string }
+
+func ParseDateTime(s string) (FormatDateTime, error) {
+	if _, err := iso8601.ParseString(s); err != nil {
+		return FormatDateTime{""}, fmt.Errorf("invalid datetime: %s", s)
+	}
+
+	return FormatDateTime{s}, nil
+}
+
+func (f FormatDateTime) String() string {
+	return f.str
+}
+
+func (f FormatDateTime) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+	err := MarshalFormatString(cw, f.str)
+	if err != nil {
+		return xerrors.Errorf("failed to write datetime string as CBOR: %w", err)
+	}
+
+	return nil
+}
+
+func (f *FormatDateTime) UnmarshalCBOR(r io.Reader) error {
+	cr := cbg.NewCborReader(r)
+	s, err := cbg.ReadString(cr)
+	if err != nil {
+		return xerrors.Errorf("failed to read datetime string from CBOR: %w", err)
+	}
+	fp, err := ParseDateTime(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse datetime string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+func (f FormatDateTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.str)
+}
+
+func (f *FormatDateTime) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return xerrors.Errorf("failed to unmarshal datetime string: %w", err)
+	}
+	fp, err := ParseDateTime(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse datetime string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+type FormatAtURI struct{ str string }
+
+// https://github.com/bluesky-social/atproto/blob/main/packages/uri/src/validation.ts
+var regexValidAtURI = regexp.MustCompile(`^at:\/\/(?P<authority>[a-zA-Z0-9._:%-]+)(\/(?P<collection>[a-zA-Z0-9-.]+)(\/(?P<rkey>[a-zA-Z0-9._~:@!$&%')(*+,;=-]+))?)?(#(?P<fragment>\/[a-zA-Z0-9._~:@!$&%')(*+,;=\-[\]/\\]*))?$`)
+var authorityIndex = regexValidAtURI.SubexpIndex("authority")
+var collectionIndex = regexValidAtURI.SubexpIndex("collection")
+var rkeyIndex = regexValidAtURI.SubexpIndex("rkey")
+var fragmentIndex = regexValidAtURI.SubexpIndex("fragment")
+
+func ParseAtURI(s string) (FormatAtURI, error) {
+	re := regexValidAtURI.FindStringSubmatch(s)
+	if re == nil { // indicates regex matching failed
+		return FormatAtURI{""}, fmt.Errorf("invalid at-uri: %s", s)
+	}
+
+	authority := re[authorityIndex]
+	if !regexValidHandle.MatchString(authority) {
+		if !regexValidDID.MatchString(authority) {
+			return FormatAtURI{""}, fmt.Errorf("invalid at-uri authority: %s", authority)
+		}
+	}
+
+	collection := re[collectionIndex]
+	if collection != "" && !regexValidNSID.MatchString(collection) {
+		return FormatAtURI{""}, fmt.Errorf("invalid at-uri collection: %s", collection)
+	}
+
+	if len(s) > 8*1024 {
+		return FormatAtURI{""}, fmt.Errorf("at-uri too long: %s", s)
+	}
+
+	return FormatAtURI{s}, nil
+}
+
+func (f FormatAtURI) String() string {
+	return f.str
+}
+
+func (f FormatAtURI) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+	err := MarshalFormatString(cw, f.str)
+	if err != nil {
+		return xerrors.Errorf("failed to write at-uri string as CBOR: %w", err)
+	}
+
+	return nil
+}
+
+func (f *FormatAtURI) UnmarshalCBOR(r io.Reader) error {
+	cr := cbg.NewCborReader(r)
+	s, err := cbg.ReadString(cr)
+	if err != nil {
+		return xerrors.Errorf("failed to read at-uri string from CBOR: %w", err)
+	}
+	fp, err := ParseAtURI(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse at-uri string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+type FormatDID struct{ str string }
+
+// https://github.com/bluesky-social/atproto/blob/main/packages/identifier/src/did.ts
+var regexValidDID = regexp.MustCompile(`^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$`)
+
+func ParseFormatDID(s string) (FormatDID, error) {
+	if regexValidDID.MatchString(s) {
+		return FormatDID{s}, nil
+	}
+	return FormatDID{""}, fmt.Errorf("invalid DID: %s", s)
+}
+
+func (f FormatDID) String() string {
+	return f.str
+}
+
+func (f FormatDID) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+	err := MarshalFormatString(cw, f.str)
+	if err != nil {
+		return xerrors.Errorf("failed to write DID string as CBOR: %w", err)
+	}
+
+	return nil
+}
+
+func (f *FormatDID) UnmarshalCBOR(r io.Reader) error {
+	cr := cbg.NewCborReader(r)
+	s, err := cbg.ReadString(cr)
+	if err != nil {
+		return xerrors.Errorf("failed to read DID string from CBOR: %w", err)
+	}
+	fp, err := ParseFormatDID(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse DID string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+func (f FormatDID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.str)
+}
+
+func (f *FormatDID) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return xerrors.Errorf("failed to unmarshal DID string: %w", err)
+	}
+	fp, err := ParseFormatDID(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse DID string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+type FormatCID struct{ str string }
+
+func ParseFormatCID(s string) (FormatCID, error) {
+	if _, err := cid.Decode(s); err == nil {
+		return FormatCID{s}, nil
+	}
+	return FormatCID{""}, fmt.Errorf("invalid CID: %s", s)
+}
+
+func (f FormatCID) String() string {
+	return f.str
+}
+
+func (f FormatCID) MarshalCBOR(w io.Writer) error {
+	cw := cbg.NewCborWriter(w)
+	err := MarshalFormatString(cw, f.str)
+	if err != nil {
+		return xerrors.Errorf("failed to write CID string as CBOR: %w", err)
+	}
+
+	return nil
+}
+
+func (f *FormatCID) UnmarshalCBOR(r io.Reader) error {
+	cr := cbg.NewCborReader(r)
+	s, err := cbg.ReadString(cr)
+	if err != nil {
+		return xerrors.Errorf("failed to read CID string from CBOR: %w", err)
+	}
+	fp, err := ParseFormatCID(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse CID string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+func (f FormatCID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.str)
+}
+
+func (f *FormatCID) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return xerrors.Errorf("failed to unmarshal CID string: %w", err)
+	}
+	fp, err := ParseFormatCID(s)
+	if err != nil {
+		return xerrors.Errorf("failed to parse CID string: %w", err)
+	}
+
+	*f = fp
+
+	return nil
+}
+
+///////////////////////
+// Marshal helper
+
+func MarshalFormatString(cw *cbg.CborWriter, f string) error {
+	if len(f) == 0 {
+		_, err := cw.Write(cbg.CborNull)
+		return err
+	}
+
+	if len(f) > cbg.MaxLength {
+		return xerrors.Errorf("Value in field format was too long")
+	}
+
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(f))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(cw, f); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/models/models.go
+++ b/models/models.go
@@ -6,6 +6,7 @@ import (
 	"gorm.io/gorm"
 
 	bsky "github.com/bluesky-social/indigo/api/bsky"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
@@ -48,9 +49,11 @@ type ActorInfo struct {
 }
 
 func (ai *ActorInfo) ActorRef() *bsky.ActorDefs_ProfileViewBasic {
+	// Models from the database are expected to satisfy the valid DID / handle format, so we skip validation here.
+
 	return &bsky.ActorDefs_ProfileViewBasic{
-		Did:         ai.Did,
-		Handle:      ai.Handle,
+		Did:         lexutil.NewFormatDID(ai.Did),
+		Handle:      lexutil.NewFormatHandle(ai.Handle),
 		DisplayName: &ai.DisplayName,
 	}
 }
@@ -58,8 +61,8 @@ func (ai *ActorInfo) ActorRef() *bsky.ActorDefs_ProfileViewBasic {
 // TODO: this is just s stub; needs to populate more info
 func (ai *ActorInfo) ActorView() *bsky.ActorDefs_ProfileView {
 	return &bsky.ActorDefs_ProfileView{
-		Did:         ai.Did,
-		Handle:      ai.Handle,
+		Did:         lexutil.NewFormatDID(ai.Did),
+		Handle:      lexutil.NewFormatHandle(ai.Handle),
 		DisplayName: &ai.DisplayName,
 	}
 }

--- a/notifs/notifs.go
+++ b/notifs/notifs.go
@@ -172,14 +172,14 @@ func (nm *DBNotifMan) hydrateNotificationUpVote(ctx context.Context, nrec *Notif
 		return nil, err
 	}
 
-	rsub := "at://" + postAuthor.Did + "/app.bsky.feed.post/" + votedOn.Rkey
+	rsub := lexutil.NewFormatAtURI("at://" + postAuthor.Did + "/app.bsky.feed.post/" + votedOn.Rkey)
 
 	return &appbskytypes.NotificationListNotifications_Notification{
 		Record:        &lexutil.LexiconTypeDecoder{Val: rec},
 		IsRead:        nrec.CreatedAt.Before(lastSeen),
 		IndexedAt:     nrec.CreatedAt.Format(time.RFC3339),
-		Uri:           "at://" + voter.Did + "/app.bsky.feed.vote/" + vote.Rkey,
-		Cid:           vote.Cid,
+		Uri:           lexutil.NewFormatAtURI("at://" + voter.Did + "/app.bsky.feed.vote/" + vote.Rkey),
+		Cid:           lexutil.NewFormatCID(vote.Cid),
 		Author:        voter.ActorView(),
 		Reason:        "vote",
 		ReasonSubject: &rsub,
@@ -212,14 +212,14 @@ func (nm *DBNotifMan) hydrateNotificationRepost(ctx context.Context, nrec *Notif
 		return nil, err
 	}
 
-	rsub := "at://" + postAuthor.Did + "/app.bsky.feed.post/" + reposted.Rkey
+	rsub := lexutil.NewFormatAtURI("at://" + postAuthor.Did + "/app.bsky.feed.post/" + reposted.Rkey)
 
 	return &appbskytypes.NotificationListNotifications_Notification{
 		Record:        &lexutil.LexiconTypeDecoder{rec},
 		IsRead:        nrec.CreatedAt.Before(lastSeen),
 		IndexedAt:     nrec.CreatedAt.Format(time.RFC3339),
-		Uri:           "at://" + reposter.Did + "/app.bsky.feed.repost/" + repost.Rkey,
-		Cid:           repost.RecCid,
+		Uri:           lexutil.NewFormatAtURI("at://" + reposter.Did + "/app.bsky.feed.repost/" + repost.Rkey),
+		Cid:           lexutil.NewFormatCID(repost.RecCid),
 		Author:        reposter.ActorView(),
 		Reason:        "repost",
 		ReasonSubject: &rsub,
@@ -252,14 +252,14 @@ func (nm *DBNotifMan) hydrateNotificationReply(ctx context.Context, nrec *NotifR
 		return nil, err
 	}
 
-	rsub := "at://" + opAuthor.Did + "/app.bsky.feed.post/" + replyTo.Rkey
+	rsub := lexutil.NewFormatAtURI("at://" + opAuthor.Did + "/app.bsky.feed.post/" + replyTo.Rkey)
 
 	return &appbskytypes.NotificationListNotifications_Notification{
 		Record:        &lexutil.LexiconTypeDecoder{rec},
 		IsRead:        nrec.CreatedAt.Before(lastSeen),
 		IndexedAt:     nrec.CreatedAt.Format(time.RFC3339),
-		Uri:           "at://" + author.Did + "/app.bsky.feed.post/" + fp.Rkey,
-		Cid:           fp.Cid,
+		Uri:           lexutil.NewFormatAtURI("at://" + author.Did + "/app.bsky.feed.post/" + fp.Rkey),
+		Cid:           lexutil.NewFormatCID(fp.Cid),
 		Author:        author.ActorView(),
 		Reason:        "reply",
 		ReasonSubject: &rsub,
@@ -286,8 +286,8 @@ func (nm *DBNotifMan) hydrateNotificationFollow(ctx context.Context, nrec *Notif
 		Record:    &lexutil.LexiconTypeDecoder{rec},
 		IsRead:    nrec.CreatedAt.Before(lastSeen),
 		IndexedAt: nrec.CreatedAt.Format(time.RFC3339),
-		Uri:       "at://" + follower.Did + "/app.bsky.graph.follow/" + frec.Rkey,
-		Cid:       frec.Cid,
+		Uri:       lexutil.NewFormatAtURI("at://" + follower.Did + "/app.bsky.graph.follow/" + frec.Rkey),
+		Cid:       lexutil.NewFormatCID(frec.Cid),
 		Author:    follower.ActorView(),
 		Reason:    "follow",
 	}, nil

--- a/pds/feedgen.go
+++ b/pds/feedgen.go
@@ -123,11 +123,11 @@ func (fg *FeedGenerator) hydrateItem(ctx context.Context, item *models.FeedPost)
 	out := &bsky.FeedDefs_FeedViewPost{}
 
 	out.Post = &bsky.FeedDefs_PostView{
-		Uri:         "at://" + authorDid + "/app.bsky.feed.post/" + item.Rkey,
+		Uri:         lexutil.NewFormatAtURI("at://" + authorDid + "/app.bsky.feed.post/" + item.Rkey),
 		ReplyCount:  &item.ReplyCount,
 		RepostCount: &item.RepostCount,
 		LikeCount:   &item.UpCount,
-		Cid:         item.Cid,
+		Cid:         lexutil.NewFormatCID(item.Cid),
 		IndexedAt:   item.UpdatedAt.Format(time.RFC3339),
 	}
 
@@ -162,7 +162,7 @@ func (fg *FeedGenerator) getPostViewerState(ctx context.Context, item uint, view
 	}
 
 	if vote.ID != 0 {
-		vuri := fmt.Sprintf("at://%s/app.bsky.feed.vote/%s", viewerDid, vote.Rkey)
+		vuri := lexutil.NewFormatAtURI(fmt.Sprintf("at://%s/app.bsky.feed.vote/%s", viewerDid, vote.Rkey))
 		out.Like = &vuri
 	}
 
@@ -172,7 +172,7 @@ func (fg *FeedGenerator) getPostViewerState(ctx context.Context, item uint, view
 	}
 
 	if rep.ID != 0 {
-		rpuri := fmt.Sprintf("at://%s/app.bsky.feed.repost/%s", viewerDid, rep.Rkey)
+		rpuri := lexutil.NewFormatAtURI(fmt.Sprintf("at://%s/app.bsky.feed.repost/%s", viewerDid, rep.Rkey))
 		out.Repost = &rpuri
 	}
 
@@ -222,7 +222,7 @@ func (fg *FeedGenerator) personalizeFeed(ctx context.Context, feed []*bsky.FeedD
 		// portion of feed generation from the 'per user' portion. An
 		// optimization could be to hide the internal post IDs in the Post
 		// structs for internal use (stripped out before sending to client)
-		item, err := fg.ix.GetPost(ctx, p.Post.Uri)
+		item, err := fg.ix.GetPost(ctx, p.Post.Uri.String())
 		if err != nil {
 			return nil, err
 		}
@@ -317,10 +317,10 @@ func (fg *FeedGenerator) GetPostThread(ctx context.Context, uri string, depth in
 	}
 
 	if p.Reply != nil {
-		out.ParentUri = p.Reply.Parent.Uri
+		out.ParentUri = p.Reply.Parent.Uri.String()
 		if depth > 0 {
 
-			parent, err := fg.GetPostThread(ctx, p.Reply.Parent.Uri, depth-1)
+			parent, err := fg.GetPostThread(ctx, p.Reply.Parent.Uri.String(), depth-1)
 			if err != nil {
 				// TODO: check for and handle 'not found'
 				return nil, err

--- a/pds/handlers_test.go
+++ b/pds/handlers_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/carstore"
 	cliutil "github.com/bluesky-social/indigo/cmd/gosky/util"
+	"github.com/bluesky-social/indigo/lex/util"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/plc"
 	"github.com/whyrusleeping/go-did"
 	"gorm.io/gorm"
@@ -78,12 +80,12 @@ func TestHandleComAtprotoAccountCreate(t *testing.T) {
 	o, err := s.handleComAtprotoServerCreateAccount(context.Background(), &atproto.ServerCreateAccount_Input{
 		Email:    "test@foo.com",
 		Password: "password",
-		Handle:   "testman.test",
+		Handle:   util.NewFormatHandle("testman.test"),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	u, err := s.lookupUserByDid(context.Background(), o.Did)
+	u, err := s.lookupUserByDid(context.Background(), o.Did.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,13 +102,13 @@ func TestHandleComAtprotoSessionCreate(t *testing.T) {
 	o, err := s.handleComAtprotoServerCreateAccount(context.Background(), &atproto.ServerCreateAccount_Input{
 		Email:    "test@foo.com",
 		Password: "password",
-		Handle:   "testman.test",
+		Handle:   lexutil.NewFormatHandle("testman.test"),
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	so, err := s.handleComAtprotoServerCreateSession(context.Background(), &atproto.ServerCreateSession_Input{
-		Identifier: o.Handle,
+		Identifier: o.Handle.String(),
 		Password:   "password",
 	})
 	if err != nil {
@@ -117,7 +119,7 @@ func TestHandleComAtprotoSessionCreate(t *testing.T) {
 	}
 
 	_, err = s.handleComAtprotoServerCreateSession(context.Background(), &atproto.ServerCreateSession_Input{
-		Identifier: o.Handle,
+		Identifier: o.Handle.String(),
 		Password:   "invalid",
 	})
 	if err != ErrInvalidUsernameOrPassword {

--- a/repomgr/repomgr.go
+++ b/repomgr/repomgr.go
@@ -692,10 +692,10 @@ func (rm *RepoManager) BatchWrite(ctx context.Context, user util.Uid, writes []*
 			if c.Rkey != nil {
 				rkey = *c.Rkey
 			} else {
-				rkey = rkeyForCollection(c.Collection)
+				rkey = rkeyForCollection(c.Collection.String())
 			}
 
-			nsid := c.Collection + "/" + rkey
+			nsid := c.Collection.String() + "/" + rkey
 			cc, err := r.PutRecord(ctx, nsid, c.Value.Val)
 			if err != nil {
 				return err
@@ -703,7 +703,7 @@ func (rm *RepoManager) BatchWrite(ctx context.Context, user util.Uid, writes []*
 
 			ops = append(ops, RepoOp{
 				Kind:       EvtKindCreateRecord,
-				Collection: c.Collection,
+				Collection: c.Collection.String(),
 				Rkey:       rkey,
 				RecCid:     &cc,
 				Record:     c.Value.Val,
@@ -711,14 +711,14 @@ func (rm *RepoManager) BatchWrite(ctx context.Context, user util.Uid, writes []*
 		case w.RepoApplyWrites_Update != nil:
 			u := w.RepoApplyWrites_Update
 
-			cc, err := r.PutRecord(ctx, u.Collection+"/"+u.Rkey, u.Value.Val)
+			cc, err := r.PutRecord(ctx, u.Collection.String()+"/"+u.Rkey, u.Value.Val)
 			if err != nil {
 				return err
 			}
 
 			ops = append(ops, RepoOp{
 				Kind:       EvtKindUpdateRecord,
-				Collection: u.Collection,
+				Collection: u.Collection.String(),
 				Rkey:       u.Rkey,
 				RecCid:     &cc,
 				Record:     u.Value.Val,
@@ -726,13 +726,13 @@ func (rm *RepoManager) BatchWrite(ctx context.Context, user util.Uid, writes []*
 		case w.RepoApplyWrites_Delete != nil:
 			d := w.RepoApplyWrites_Delete
 
-			if err := r.DeleteRecord(ctx, d.Collection+"/"+d.Rkey); err != nil {
+			if err := r.DeleteRecord(ctx, d.Collection.String()+"/"+d.Rkey); err != nil {
 				return err
 			}
 
 			ops = append(ops, RepoOp{
 				Kind:       EvtKindDeleteRecord,
-				Collection: d.Collection,
+				Collection: d.Collection.String(),
 				Rkey:       d.Rkey,
 			})
 		default:

--- a/testing/feedpost_test.go
+++ b/testing/feedpost_test.go
@@ -68,8 +68,8 @@ func TestFeedPostParse(t *testing.T) {
 			Record: &appbsky.EmbedRecord{
 				LexiconTypeID: "app.bsky.embed.record",
 				Record: &comatproto.RepoStrongRef{
-					Cid: "bafyreiaku7udekkiijxcuue3sn6esz7qijqj637rigz4xqdw57fk5houji",
-					Uri: "at://did:plc:rbtury4cp2sdk4tvnedaqu54/app.bsky.feed.post/3jilislho4s2k",
+					Cid: lexutil.NewFormatCID("bafyreiaku7udekkiijxcuue3sn6esz7qijqj637rigz4xqdw57fk5houji"),
+					Uri: lexutil.NewFormatAtURI("at://did:plc:rbtury4cp2sdk4tvnedaqu54/app.bsky.feed.post/3jilislho4s2k"),
 				},
 			},
 		},

--- a/testing/integ_test.go
+++ b/testing/integ_test.go
@@ -50,21 +50,21 @@ func TestBGSBasic(t *testing.T) {
 	fmt.Println("event 1")
 	e1 := evts.Next()
 	assert.NotNil(e1.RepoCommit)
-	assert.Equal(e1.RepoCommit.Repo, bob.DID())
+	assert.Equal(e1.RepoCommit.Repo.String(), bob.DID())
 
 	fmt.Println("event 2")
 	e2 := evts.Next()
 	assert.NotNil(e2.RepoCommit)
-	assert.Equal(e2.RepoCommit.Repo, alice.DID())
+	assert.Equal(e2.RepoCommit.Repo.String(), alice.DID())
 
 	fmt.Println("event 3")
 	e3 := evts.Next()
-	assert.Equal(e3.RepoCommit.Repo, bob.DID())
+	assert.Equal(e3.RepoCommit.Repo.String(), bob.DID())
 	//assert.Equal(e3.RepoCommit.Ops[0].Kind, "createRecord")
 
 	fmt.Println("event 4")
 	e4 := evts.Next()
-	assert.Equal(e4.RepoCommit.Repo, alice.DID())
+	assert.Equal(e4.RepoCommit.Repo.String(), alice.DID())
 	//assert.Equal(e4.RepoCommit.Ops[0].Kind, "createRecord")
 
 	// playback
@@ -165,7 +165,7 @@ func TestBGSMultiPDS(t *testing.T) {
 	// repos its already partially scraped, as long as its seen *something* after the missing post
 	// this is the 'catchup' process
 	ctx := context.Background()
-	_, err := b1.bgs.Index.GetPost(ctx, p2posts2[4].Uri)
+	_, err := b1.bgs.Index.GetPost(ctx, p2posts2[4].Uri.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func TestBGSMultiGap(t *testing.T) {
 	time.Sleep(time.Millisecond * 100)
 
 	ctx := context.Background()
-	_, err := b1.bgs.Index.GetPost(ctx, p2posts[3].Uri)
+	_, err := b1.bgs.Index.GetPost(ctx, p2posts[3].Uri.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func TestBGSMultiGap(t *testing.T) {
 	// we expect the bgs to learn about posts that it didnt directly see from
 	// repos its already partially scraped, as long as its seen *something* after the missing post
 	// this is the 'catchup' process
-	_, err = b1.bgs.Index.GetPost(ctx, p2posts2[4].Uri)
+	_, err = b1.bgs.Index.GetPost(ctx, p2posts2[4].Uri.String())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Closes: #101 

Hi! I recently got into Bluesky ecosystem and found interest in the codebase. The issue above seemed to be not a breaking change and already had a reference implementation under atproto repo, so I decide to tackle on implementing it. I know the repo is not open to public contributions yet, so feel free to close the PR if it was too early!

### Implementation Approach

I have followed the third option from the issue:

```
declare string type aliases for each of the identifier types. put these in lexutil, and have them implement Parse(raw string) (Identifier, error) and (ident *Identifier) ToString() string helpers (though type coercion could also work) and JSON/CBOR marshaling helpers.
```

I just used the struct instead of the aliases, because the they didn't work for cbor-gen as it internally uses reflect to determine the type of the field. If an alias is used, `reflect.TypeOf` treats it as a value of the underlying type, not the alias.

Apart from the lexicon-related code, I avoided to use the `Format` types and use string values as possible because of the two reasons:
* Some external APIs(such as `gorm` models) uses the reflect-based marshal/unmarshal for the interop, and they complains when the non-primitive values(such as sturcts) are used. 
* I was not sure if the additional overhead for validating the strings are also useful for interacting with trusted internal data sources(such as SQL database). If this is not a big concern, I can simply add the validation for each `NewFormatIdentifier` methods(currently they are just a wrapper function and do noop for validation).

### Tasks left

* Port tests from atproto repo