### PR TITLE
mst: make countPrefixLen match JavaScript's UTF-16-edness

### DIFF
--- a/mst/mst_test.go
+++ b/mst/mst_test.go
@@ -599,3 +599,37 @@ func BenchmarkDiffTrees(b *testing.B) {
 		b.Fatal("diffs not equal")
 	}
 }
+
+var countPrefixLenTests = []struct {
+	a, b string
+	want int
+}{
+	{"", "", 0},
+	{"a", "", 0},
+	{"", "a", 0},
+	{"a", "b", 0},
+	{"a", "a", 1},
+	{"ab", "a", 1},
+	{"a", "ab", 1},
+	{"ab", "ab", 2},
+	{"abcdefghijklmnop", "abcdefghijklmnoq", 15},
+}
+
+func TestCountPrefixLen(t *testing.T) {
+	for _, tt := range countPrefixLenTests {
+		if got := countPrefixLen(tt.a, tt.b); got != tt.want {
+			t.Errorf("countPrefixLenTests(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func BenchmarkCountPrefixLen(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		for _, tt := range countPrefixLenTests {
+			if got := countPrefixLen(tt.a, tt.b); got != tt.want {
+				b.Fatalf("countPrefixLenTests(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		}
+	}
+}

--- a/mst/mst_util.go
+++ b/mst/mst_util.go
@@ -170,25 +170,18 @@ func serializeNodeData(entries []nodeEntry) (*nodeData, error) {
 	return &data, nil
 }
 
-func min(a, b int) int {
-	if a <= b {
-		return a
-	}
-	return b
-}
-
-// how many leading chars are identical between the two strings?
+// how many leading bytes are identical between the two strings?
 // Typescript: countPrefixLen(a: string, b: string) -> number
 func countPrefixLen(a, b string) int {
-	aa := []byte(a)
-	bb := []byte(b)
-	count := min(len(aa), len(bb))
-	for i := 0; i < count; i++ {
-		if aa[i] != bb[i] {
+	// This pattern avoids panicindex calls, as the Go compiler's prove pass can
+	// convince itself that neither a[i] nor b[i] are ever out of bounds.
+	var i int
+	for i = 0; i < len(a) && i < len(b); i++ {
+		if a[i] != b[i] {
 			return i
 		}
 	}
-	return count
+	return i
 }
 
 // both computes *and* persists a tree entry; this is different from typescript


### PR DESCRIPTION
And optimize it a bit, so the Go compiler can avoid some bounds checks.

benchstat:

                     │   before    │                after                │
                     │   sec/op    │   sec/op     vs base                │
    CountPrefixLen-8   78.85n ± 1%   38.45n ± 5%  -51.23% (p=0.000 n=10)

                     │   before   │             after              │
                     │    B/op    │    B/op     vs base            │
    CountPrefixLen-8   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
    ¹ all samples are equal

                     │   before   │             after              │
                     │ allocs/op  │ allocs/op   vs base            │
    CountPrefixLen-8   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹
    ¹ all samples are equal
