### PR TITLE
implement repo takedowns

### DIFF
--- a/bgs/admin.go
+++ b/bgs/admin.go
@@ -3,26 +3,14 @@ package bgs
 import (
 	"strconv"
 
-	"github.com/bluesky-social/indigo/util"
 	"github.com/labstack/echo/v4"
 )
-
-func (bgs *BGS) handleAdminDeleteRecord(e echo.Context) error {
-	puri, err := util.ParseAtUri(e.QueryParam("uri"))
-	if err != nil {
-		return err
-	}
-
-	_ = puri
-
-	panic("TODO")
-}
 
 func (bgs *BGS) handleAdminBlockRepoStream(e echo.Context) error {
 	panic("TODO")
 }
 
-func (bgs *BGS) handleAdminDisableNewSlurps(e echo.Context) error {
+func (bgs *BGS) handleAdminSetSubsEnabled(e echo.Context) error {
 	enabled, err := strconv.ParseBool(e.QueryParam("enabled"))
 	if err != nil {
 		return err
@@ -32,5 +20,8 @@ func (bgs *BGS) handleAdminDisableNewSlurps(e echo.Context) error {
 }
 
 func (bgs *BGS) handleAdminTakedownRepo(e echo.Context) error {
-	panic("TODO")
+	did := e.QueryParam("did")
+	ctx := e.Request().Context()
+
+	return bgs.TakedownRepo(ctx, did)
 }

--- a/bgs/admin.go
+++ b/bgs/admin.go
@@ -19,9 +19,16 @@ func (bgs *BGS) handleAdminSetSubsEnabled(e echo.Context) error {
 	return bgs.slurper.SetNewSubsDisabled(!enabled)
 }
 
-func (bgs *BGS) handleAdminTakedownRepo(e echo.Context) error {
+func (bgs *BGS) handleAdminTakeDownRepo(e echo.Context) error {
 	did := e.QueryParam("did")
 	ctx := e.Request().Context()
 
-	return bgs.TakedownRepo(ctx, did)
+	return bgs.TakeDownRepo(ctx, did)
+}
+
+func (bgs *BGS) handleAdminReverseTakedown(e echo.Context) error {
+	did := e.QueryParam("did")
+	ctx := e.Request().Context()
+
+	return bgs.ReverseTakedown(ctx, did)
 }

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -199,6 +199,7 @@ func (bgs *BGS) Start(listen string) error {
 
 	admin := e.Group("/admin", bgs.checkAdminAuth)
 	admin.POST("/subs/setEnabled", bgs.handleAdminSetSubsEnabled)
+	admin.POST("/repo/takedown", bgs.handleAdminTakedownRepo)
 
 	return e.Start(listen)
 }

--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -708,9 +708,9 @@ func (cs *CarStore) checkFork(ctx context.Context, user util.Uid, prev cid.Cid) 
 		return false, err
 	}
 
-	if maybeShard.ID == lastShard.ID {
+	if maybeShard.ID != 0 && maybeShard.ID == lastShard.ID {
 		// somehow we are checking if a valid 'append' is a fork, seems buggy, throw an error
-		return false, fmt.Errorf("invariant broken: checked for forkiness of a valid append")
+		return false, fmt.Errorf("invariant broken: checked for forkiness of a valid append (%d - %d)", lastShard.ID, maybeShard.ID)
 	}
 
 	if maybeShard.ID == 0 {
@@ -720,7 +720,7 @@ func (cs *CarStore) checkFork(ctx context.Context, user util.Uid, prev cid.Cid) 
 	return true, nil
 }
 
-func (cs *CarStore) TakedownRepo(ctx context.Context, user util.Uid) error {
+func (cs *CarStore) TakeDownRepo(ctx context.Context, user util.Uid) error {
 	var shards []CarShard
 	if err := cs.meta.Find(&shards, "usr = ?", user).Error; err != nil {
 		return err

--- a/cmd/gosky/main.go
+++ b/cmd/gosky/main.go
@@ -1012,6 +1012,29 @@ var getRecordCmd = &cli.Command{
 				return err
 			}
 			repob = rrb
+		} else if strings.HasPrefix(cctx.Args().First(), "at://") {
+			xrpcc, err := cliutil.GetXrpcClient(cctx, false)
+			if err != nil {
+				return err
+			}
+
+			puri, err := util.ParseAtUri(cctx.Args().First())
+			if err != nil {
+				return err
+			}
+
+			out, err := comatproto.RepoGetRecord(ctx, xrpcc, "", puri.Collection, puri.Did, puri.Rkey)
+			if err != nil {
+				return err
+			}
+
+			b, err := json.MarshalIndent(out.Value.Val, "", "  ")
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(string(b))
+			return nil
 		} else {
 			fb, err := os.ReadFile(rfi)
 			if err != nil {

--- a/events/events.go
+++ b/events/events.go
@@ -217,3 +217,7 @@ func (em *EventManager) Subscribe(ctx context.Context, filter func(*XRPCStreamEv
 
 	return sub.outgoing, cleanup, nil
 }
+
+func (em *EventManager) TakedownRepo(ctx context.Context, user util.Uid) error {
+	return em.persister.TakedownRepo(ctx, user)
+}

--- a/events/events.go
+++ b/events/events.go
@@ -218,6 +218,6 @@ func (em *EventManager) Subscribe(ctx context.Context, filter func(*XRPCStreamEv
 	return sub.outgoing, cleanup, nil
 }
 
-func (em *EventManager) TakedownRepo(ctx context.Context, user util.Uid) error {
-	return em.persister.TakedownRepo(ctx, user)
+func (em *EventManager) TakeDownRepo(ctx context.Context, user util.Uid) error {
+	return em.persister.TakeDownRepo(ctx, user)
 }

--- a/events/persist.go
+++ b/events/persist.go
@@ -2,13 +2,17 @@ package events
 
 import (
 	"context"
+	"fmt"
 	"sync"
+
+	"github.com/bluesky-social/indigo/util"
 )
 
 // Note that this interface looks generic, but some persisters might only work with RepoAppend or LabelLabels
 type EventPersistence interface {
 	Persist(ctx context.Context, e *XRPCStreamEvent) error
 	Playback(ctx context.Context, since int64, cb func(*XRPCStreamEvent) error) error
+	TakedownRepo(ctx context.Context, usr util.Uid) error
 }
 
 // MemPersister is the most naive implementation of event persistence
@@ -64,4 +68,8 @@ func (mp *MemPersister) Playback(ctx context.Context, since int64, cb func(*XRPC
 	}
 
 	return nil
+}
+
+func (mp *MemPersister) TakedownRepo(ctx context.Context, uid util.Uid) error {
+	return fmt.Errorf("repo takedowns not currently supported by memory persister, test usage only")
 }

--- a/events/persist.go
+++ b/events/persist.go
@@ -12,7 +12,7 @@ import (
 type EventPersistence interface {
 	Persist(ctx context.Context, e *XRPCStreamEvent) error
 	Playback(ctx context.Context, since int64, cb func(*XRPCStreamEvent) error) error
-	TakedownRepo(ctx context.Context, usr util.Uid) error
+	TakeDownRepo(ctx context.Context, usr util.Uid) error
 }
 
 // MemPersister is the most naive implementation of event persistence
@@ -70,6 +70,6 @@ func (mp *MemPersister) Playback(ctx context.Context, since int64, cb func(*XRPC
 	return nil
 }
 
-func (mp *MemPersister) TakedownRepo(ctx context.Context, uid util.Uid) error {
+func (mp *MemPersister) TakeDownRepo(ctx context.Context, uid util.Uid) error {
 	return fmt.Errorf("repo takedowns not currently supported by memory persister, test usage only")
 }

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -373,7 +373,7 @@ func (ix *Indexer) crawlRecordReferences(ctx context.Context, op *repomgr.RepoOp
 	case *bsky.ActorProfile:
 		return nil
 	default:
-		log.Warnf("unrecognized record type: %T", rec)
+		log.Warnf("unrecognized record type: %T", op.Record)
 		return nil
 	}
 }

--- a/repomgr/repomgr.go
+++ b/repomgr/repomgr.go
@@ -1094,9 +1094,9 @@ func walkTree(ctx context.Context, skip map[cid.Cid]bool, root cid.Cid, bs block
 	return out, nil
 }
 
-func (rm *RepoManager) TakedownRepo(ctx context.Context, uid util.Uid) error {
+func (rm *RepoManager) TakeDownRepo(ctx context.Context, uid util.Uid) error {
 	unlock := rm.lockUser(ctx, uid)
 	defer unlock()
 
-	return rm.cs.TakedownRepo(ctx, uid)
+	return rm.cs.TakeDownRepo(ctx, uid)
 }

--- a/repomgr/repomgr.go
+++ b/repomgr/repomgr.go
@@ -1093,3 +1093,10 @@ func walkTree(ctx context.Context, skip map[cid.Cid]bool, root cid.Cid, bs block
 
 	return out, nil
 }
+
+func (rm *RepoManager) TakedownRepo(ctx context.Context, uid util.Uid) error {
+	unlock := rm.lockUser(ctx, uid)
+	defer unlock()
+
+	return rm.cs.TakedownRepo(ctx, uid)
+}

--- a/xrpc/xrpc.go
+++ b/xrpc/xrpc.go
@@ -121,6 +121,7 @@ func (c *Client) Do(ctx context.Context, kind XRPCRequestType, inpenc string, me
 	if resp.StatusCode != 200 {
 		var i interface{}
 		_ = json.NewDecoder(resp.Body).Decode(&i)
+		//fmt.Println(i)
 		return fmt.Errorf("XRPC ERROR %d: %s", resp.StatusCode, resp.Status)
 	}
 


### PR DESCRIPTION
Adds a basic admin route to fully take down a given repo, including marking the user as 'taken down' and fully deleting all associated data.