### PR TITLE
clean up README.md, fix default username

### DIFF
--- a/cmd/palomar/README.md
+++ b/cmd/palomar/README.md
@@ -4,7 +4,7 @@ Palomar is an Elasticsearch/OpenSearch frontend and ATP (ActivityPub) repository
 
 ## Prerequisites
 
-- GoLang (version 1.x)
+- GoLang (version 1.20)
 - Running instance of Elasticsearch or OpenSearch for indexing.
 - Valid credentials for the Personal Data Store (PDS) you want to index against.
 

--- a/cmd/palomar/README.md
+++ b/cmd/palomar/README.md
@@ -1,7 +1,12 @@
-# palomo
+# Palomar
 
-An elasticsearch/opensearch frontend and ATP repo crawler meant to provide
-search services for the bluesky network.
+Palomar is an Elasticsearch/OpenSearch frontend and ATP (ActivityPub) repository crawler designed to provide search services for the Bluesky network.
+
+## Prerequisites
+
+- GoLang (version 1.x)
+- Running instance of Elasticsearch or OpenSearch for indexing.
+- Valid credentials for the Personal Data Store (PDS) you want to index against.
 
 ## Building
 
@@ -9,29 +14,20 @@ search services for the bluesky network.
 go build
 ```
 
-## Setup
+## Configuration
 
-You will need a running elasticsearch instance (or cluster) for indexing, and
-valid credentials for the PDS you wish to index against.
+Palomar uses environment variables for configuration. Here are the required ones:
 
-The following environment variables should be set:
+- `ATP_BGS_HOST`: URL of the Bluesky BGS (e.g., `https://bgs.staging.bsky.dev`).
+- `ELASTIC_HTTPS_FINGERPRINT`: Required if using a self-signed cert for your Elasticsearch deployment.
+- `ELASTIC_USERNAME`: Elasticsearch username (default: `admin`).
+- `ELASTIC_PASSWORD`: Password for Elasticsearch authentication.
+- `ELASTIC_HOSTS`: Comma-separated list of Elasticsearch endpoints.
+- `READONLY`: Set this if the instance should act as a readonly HTTP server (no indexing).
 
-- `ATP_BGS_HOST`
-  - The url of the bluesky BGS, e.g. `https://bgs.staging.bsky.dev`
-- `ELASTIC_HTTPS_FINGERPRINT` 
-  - if using a self signed cert for your elasticsearch deployment, this must be set
-- `ELASTIC_USERNAME`
-  - elasticsearch username, defaults to `elastic`
-- `ELASTIC_PASSWORD`
-  - password for elasticsearch auth
-- `ELASTIC_HOSTS`
-  - comma separated list of elasticsearch endpoints 
-- `READONLY`
-  - To be set only if the instance should act as a readonly HTTP server (no indexing)
+## Running the Application
 
-## Running
-
-After ensuring the env is properly configured, run:
+Once the environment variables are set properly, you can start Palomar by running:
 
 ```
 ./palomar run
@@ -44,8 +40,7 @@ index up to date you will periodcally need to scrape the data.
 ## API
 
 ### `/index/:did`
-Index the content in the given users repo. Keeps track of the last repo update
-and only fetches incremental changes
+Indexes the content in the given user's repository. It keeps track of the last repository update and only fetches incremental changes.
 
 ### `/search?q=QUERY`
-Very simple case-insensitive search results from across the entire app.
+Performs a simple, case-insensitive search across the entire application.

--- a/cmd/palomar/README.md
+++ b/cmd/palomar/README.md
@@ -1,12 +1,11 @@
 # Palomar
 
-Palomar is an Elasticsearch/OpenSearch frontend and ATP (ActivityPub) repository crawler designed to provide search services for the Bluesky network.
+Palomar is an Elasticsearch/OpenSearch frontend and ATP (AT Protocol) repository crawler designed to provide search services for the Bluesky network.
 
 ## Prerequisites
 
 - GoLang (version 1.20)
 - Running instance of Elasticsearch or OpenSearch for indexing.
-- Valid credentials for the Personal Data Store (PDS) you want to index against.
 
 ## Building
 
@@ -16,7 +15,7 @@ go build
 
 ## Configuration
 
-Palomar uses environment variables for configuration. Here are the required ones:
+Palomar uses environment variables for configuration.
 
 - `ATP_BGS_HOST`: URL of the Bluesky BGS (e.g., `https://bgs.staging.bsky.dev`).
 - `ELASTIC_HTTPS_FINGERPRINT`: Required if using a self-signed cert for your Elasticsearch deployment.


### PR DESCRIPTION
Tried to clean up the README. Also found an error with the default username for es. You may not appreciate the choices, and that's fine. I was going over the code to test it out and it just didn't seem as clean as I'd go for.