### PR TITLE
support booting PDS on a random port in testing

### DIFF
--- a/pds/server.go
+++ b/pds/server.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"net/mail"
 	"net/url"
 	"strings"
@@ -265,7 +267,22 @@ func (s *Server) readRecordFunc(ctx context.Context, user bsutil.Uid, c cid.Cid)
 	return lexutil.CborDecodeValue(blk.RawData())
 }
 
-func (s *Server) RunAPI(listen string) error {
+func (s *Server) RunAPI(addr string) error {
+	var lc net.ListenConfig
+	// This is an arbitrary timeout that should be safe on any platform, but
+	// there's no great way to weave this timeout without adding another
+	// parameter to the (at time of writing) long signature of NewServer.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	li, err := lc.Listen(ctx, "tcp", addr)
+	if err != nil {
+		return err
+	}
+	return s.RunAPIWithListener(li)
+}
+
+func (s *Server) RunAPIWithListener(listen net.Listener) error {
 	e := echo.New()
 	s.echo = e
 	e.HideBanner = true
@@ -330,7 +347,12 @@ func (s *Server) RunAPI(listen string) error {
 	e.GET("/xrpc/com.atproto.sync.subscribeRepos", s.EventsHandler)
 	e.GET("/xrpc/_health", s.HandleHealthCheck)
 
-	return e.Start(listen)
+	// In order to support booting on random ports in tests, we need to tell the
+	// Echo instance it's already got a port, and then use its StartServer
+	// method to re-use that listener.
+	e.Listener = listen
+	srv := &http.Server{}
+	return e.StartServer(srv)
 }
 
 type HealthStatus struct {

--- a/testing/integ_test.go
+++ b/testing/integ_test.go
@@ -26,7 +26,7 @@ func TestBGSBasic(t *testing.T) {
 	}
 	assert := assert.New(t)
 	didr := TestPLC(t)
-	p1 := MustSetupPDS(t, "localhost:5155", ".tpds", didr)
+	p1 := MustSetupPDS(t, ".tpds", didr)
 	p1.Run(t)
 
 	b1 := MustSetupBGS(t, "localhost:8231", didr)
@@ -119,10 +119,10 @@ func TestBGSMultiPDS(t *testing.T) {
 	assert := assert.New(t)
 	_ = assert
 	didr := TestPLC(t)
-	p1 := MustSetupPDS(t, "localhost:5185", ".pdsuno", didr)
+	p1 := MustSetupPDS(t, ".pdsuno", didr)
 	p1.Run(t)
 
-	p2 := MustSetupPDS(t, "localhost:5186", ".pdsdos", didr)
+	p2 := MustSetupPDS(t, ".pdsdos", didr)
 	p2.Run(t)
 
 	b1 := MustSetupBGS(t, "localhost:8281", didr)
@@ -183,10 +183,10 @@ func TestBGSMultiGap(t *testing.T) {
 	assert := assert.New(t)
 	_ = assert
 	didr := TestPLC(t)
-	p1 := MustSetupPDS(t, "localhost:5195", ".pdsuno", didr)
+	p1 := MustSetupPDS(t, ".pdsuno", didr)
 	p1.Run(t)
 
-	p2 := MustSetupPDS(t, "localhost:5196", ".pdsdos", didr)
+	p2 := MustSetupPDS(t, ".pdsdos", didr)
 	p2.Run(t)
 
 	b1 := MustSetupBGS(t, "localhost:8291", didr)
@@ -240,7 +240,7 @@ func TestHandleChange(t *testing.T) {
 	assert := assert.New(t)
 	_ = assert
 	didr := TestPLC(t)
-	p1 := MustSetupPDS(t, "localhost:5385", ".pdsuno", didr)
+	p1 := MustSetupPDS(t, ".pdsuno", didr)
 	p1.Run(t)
 
 	b1 := MustSetupBGS(t, "localhost:8391", didr)
@@ -273,7 +273,7 @@ func TestBGSTakedown(t *testing.T) {
 	_ = assert
 
 	didr := TestPLC(t)
-	p1 := MustSetupPDS(t, "localhost:5151", ".tpds", didr)
+	p1 := MustSetupPDS(t, ".tpds", didr)
 	p1.Run(t)
 
 	b1 := MustSetupBGS(t, "localhost:3231", didr)
@@ -324,7 +324,7 @@ func TestRebase(t *testing.T) {
 	}
 	assert := assert.New(t)
 	didr := TestPLC(t)
-	p1 := MustSetupPDS(t, "localhost:9155", ".tpds", didr)
+	p1 := MustSetupPDS(t, ".tpds", didr)
 	p1.Run(t)
 
 	b1 := MustSetupBGS(t, "localhost:1531", didr)

--- a/testing/labelmaker_fakedata_test.go
+++ b/testing/labelmaker_fakedata_test.go
@@ -129,7 +129,7 @@ func TestLabelmakerBasic(t *testing.T) {
 	_ = assert
 	ctx := context.TODO()
 	didr := TestPLC(t)
-	p1 := MustSetupPDS(t, "localhost:5115", ".tpds", didr)
+	p1 := MustSetupPDS(t, ".tpds", didr)
 	p1.Run(t)
 
 	b1 := MustSetupBGS(t, "localhost:8322", didr)

--- a/testing/pds_fakedata_test.go
+++ b/testing/pds_fakedata_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 const (
-	pdsHost       = "http://localhost:5159"
 	adminPassword = "admin"
 	celebCount    = 2
 	regularCount  = 5
@@ -60,18 +59,18 @@ func TestPDSFakedata(t *testing.T) {
 	}
 	assert := assert.New(t)
 	plcc := TestPLC(t)
-	pds := MustSetupPDS(t, "localhost:5159", ".test", plcc)
+	pds := MustSetupPDS(t, ".test", plcc)
 	pds.Run(t)
 
 	time.Sleep(time.Millisecond * 50)
 
-	catalog := genTestCatalog(t, pdsHost)
+	catalog := genTestCatalog(t, pds.HTTPHost())
 	combined := catalog.Combined()
 	testClient := util.TestingHTTPClient()
 
 	// generate profile, graph, posts
 	for _, acc := range combined {
-		xrpcc, err := fakedata.AccountXrpcClient(pdsHost, &acc)
+		xrpcc, err := fakedata.AccountXrpcClient(pds.HTTPHost(), &acc)
 		xrpcc.Client = testClient
 		if err != nil {
 			t.Fatal(err)
@@ -84,7 +83,7 @@ func TestPDSFakedata(t *testing.T) {
 
 	// generate interactions (additional posts, etc)
 	for _, acc := range combined {
-		xrpcc, err := fakedata.AccountXrpcClient(pdsHost, &acc)
+		xrpcc, err := fakedata.AccountXrpcClient(pds.HTTPHost(), &acc)
 		xrpcc.Client = testClient
 		if err != nil {
 			t.Fatal(err)
@@ -95,7 +94,7 @@ func TestPDSFakedata(t *testing.T) {
 
 	// do browsing (read-only)
 	for _, acc := range combined {
-		xrpcc, err := fakedata.AccountXrpcClient(pdsHost, &acc)
+		xrpcc, err := fakedata.AccountXrpcClient(pds.HTTPHost(), &acc)
 		xrpcc.Client = testClient
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This patch makes PDS boot on a random port in the integration tests.
It's a first step towards #165 ("Integration tests need randomly
assigned ports") and request for feedback on its strategy before I apply
it to BDS.

To do this work, we have to teach `pds.Server` how to boot with an
existing net.Listener and teach its Echo instance to do the same. That
required using `Echo#StartServer` instead of `Echo#Start`. Using
`Echo#StartServer` seems to be the accepted pattern for booting from an
existing Listener in Echo and both it and `Start` call the same
`Echo#configureServer` under the hood.

PDS isn't a production service right now, but I believe I've reproduced the 
configuration that echo would have done that there wouldn't be production 
impact. However, if BGS is, we could talk about what feature flagging we'd 
like to prevent problems when this is applied there.

Along the way, we refactor the uses of the `TestPDS.host` field into
more explicit methods on `TestPDS`. I'm not completely sold on those
methods' names, but they seem handy.

Updates #165
