### PR TITLE
avoid deleted_at condition, add note for further improvements

### DIFF
--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -64,7 +64,8 @@ type UserInfo struct {
 }
 
 type CarShard struct {
-	gorm.Model
+	ID        uint `gorm:"primarykey"`
+	CreatedAt time.Time
 
 	Root      util.DbCID
 	DataStart int64
@@ -270,6 +271,8 @@ func (cs *CarStore) getLastShard(ctx context.Context, user util.Uid) (*CarShard,
 	}
 
 	var lastShard CarShard
+	// this is often slow (which is why we're caching it) but could be sped up with an extra index:
+	// CREATE INDEX idx_car_shards_usr_id ON car_shards (usr, id DESC);
 	if err := cs.meta.WithContext(ctx).Model(CarShard{}).Limit(1).Order("id desc").Find(&lastShard, "usr = ?", user).Error; err != nil {
 		//if err := cs.meta.Model(CarShard{}).Where("user = ?", user).Last(&lastShard).Error; err != nil {
 		//if err != gorm.ErrRecordNotFound {


### PR DESCRIPTION
This route is already cached, but when we have a cache miss its currently a ~2 second query because its doing an index scan on the primary key index. Dropping the deleted_at implicit condition helps reduce this to ~500ms which is a good gain (unfortunately doesnt show up in any benchmarks because this is only slow at scale).

If this ever ends up being a problem, the simple solution is to add an extra index, but that makes the write path slower which I don't really want to do right now. 