### PR TITLE
Replace deprecated ioutil.ReadAll, ioutil.WriteFile

### DIFF
--- a/api/extra.go
+++ b/api/extra.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -98,7 +97,7 @@ func (dr *ProdHandleResolver) ResolveHandleToDid(ctx context.Context, handle str
 			return "", fmt.Errorf("http well-known route returned too much data")
 		}
 
-		b, err := ioutil.ReadAll(io.LimitReader(resp.Body, 2048))
+		b, err := io.ReadAll(io.LimitReader(resp.Body, 2048))
 		if err != nil {
 			return "", fmt.Errorf("failed to read resolved did: %w", err)
 		}
@@ -158,7 +157,7 @@ func (tr *TestHandleResolver) ResolveHandleToDid(ctx context.Context, handle str
 			continue
 		}
 
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", fmt.Errorf("failed to read resolved did: %w", err)
 		}

--- a/cmd/gosky/debug.go
+++ b/cmd/gosky/debug.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
@@ -717,7 +716,7 @@ func loadCache(filename string) (map[string]*bsky.FeedDefs_PostView, error) {
 	}
 	defer jsonFile.Close()
 
-	byteValue, err := ioutil.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
@@ -736,7 +735,7 @@ func saveCache(filename string, data map[string]*bsky.FeedDefs_PostView) error {
 		return fmt.Errorf("failed to marshal json: %w", err)
 	}
 
-	err = ioutil.WriteFile(filename, file, 0644)
+	err = os.WriteFile(filename, file, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to write file: %w", err)
 	}


### PR DESCRIPTION
Cleaning up a deprecation to ioutil.ReadAll, ioutil.WriteFile.
it's deprecated to go1.16.