### PR TITLE
extract headStore to make it easier to swap out database

### DIFF
--- a/cmd/bigsky/main.go
+++ b/cmd/bigsky/main.go
@@ -207,7 +207,7 @@ func run(args []string) {
 
 		kmgr := indexer.NewKeyManager(cachedidr, nil)
 
-		repoman := repomgr.NewRepoManager(db, cstore, kmgr)
+		repoman := repomgr.NewRepoManager(repomgr.NewDbHeadStore(db), cstore, kmgr)
 
 		dbp, err := events.NewDbPersistence(db, cstore, nil)
 		if err != nil {

--- a/events/dbpersist_test.go
+++ b/events/dbpersist_test.go
@@ -43,7 +43,7 @@ func BenchmarkDBPersist(b *testing.B) {
 		Did: "did:example:123",
 	})
 
-	mgr := repomgr.NewRepoManager(db, cs, &util.FakeKeyManager{})
+	mgr := repomgr.NewRepoManager(repomgr.NewDbHeadStore(db), cs, &util.FakeKeyManager{})
 
 	err = mgr.InitNewActor(ctx, 1, "alice", "did:example:123", "Alice", "", "")
 	if err != nil {

--- a/indexer/posts_test.go
+++ b/indexer/posts_test.go
@@ -55,7 +55,7 @@ func testIndexer(t *testing.T) *testIx {
 		t.Fatal(err)
 	}
 
-	repoman := repomgr.NewRepoManager(maindb, cs, &util.FakeKeyManager{})
+	repoman := repomgr.NewRepoManager(repomgr.NewDbHeadStore(maindb), cs, &util.FakeKeyManager{})
 	notifman := notifs.NewNotificationManager(maindb, repoman.GetRecord)
 	evtman := events.NewEventManager(events.NewMemPersister())
 

--- a/labeler/service.go
+++ b/labeler/service.go
@@ -75,7 +75,7 @@ func NewServer(db *gorm.DB, cs *carstore.CarStore, repoUser RepoConfig, plcURL, 
 	didr := &api.PLCServer{Host: plcURL}
 	kmgr := indexer.NewKeyManager(didr, repoUser.SigningKey)
 	evtmgr := events.NewEventManager(events.NewMemPersister())
-	repoman := repomgr.NewRepoManager(db, cs, kmgr)
+	repoman := repomgr.NewRepoManager(repomgr.NewDbHeadStore(db), cs, kmgr)
 
 	if repoUser.Password == "" || repoUser.Did == "" || repoUser.Handle == "" {
 		return nil, fmt.Errorf("bad labeler repo config (empty string)")

--- a/pds/server.go
+++ b/pds/server.go
@@ -77,7 +77,8 @@ func NewServer(db *gorm.DB, cs *carstore.CarStore, serkey *did.PrivKey, handleSu
 
 	kmgr := indexer.NewKeyManager(didr, serkey)
 
-	repoman := repomgr.NewRepoManager(db, cs, kmgr)
+	hs := repomgr.NewDbHeadStore(db)
+	repoman := repomgr.NewRepoManager(hs, cs, kmgr)
 	notifman := notifs.NewNotificationManager(db, repoman.GetRecord)
 
 	ix, err := indexer.NewIndexer(db, notifman, evtman, didr, repoman, false, true)

--- a/repomgr/bench_test.go
+++ b/repomgr/bench_test.go
@@ -1,0 +1,66 @@
+package repomgr
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	bsky "github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/indigo/carstore"
+	"github.com/bluesky-social/indigo/util"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupDb(t testing.TB, p string) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(p))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Exec("PRAGMA journal_mode=WAL;").Error; err != nil {
+		t.Fatal(err)
+	}
+
+	return db
+}
+
+func BenchmarkRepoMgrCreates(b *testing.B) {
+	dir, err := os.MkdirTemp("", "integtest")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	cardb := setupDb(b, filepath.Join(dir, "car.sqlite"))
+
+	cspath := filepath.Join(dir, "carstore")
+	if err := os.Mkdir(cspath, 0775); err != nil {
+		b.Fatal(err)
+	}
+
+	cs, err := carstore.NewCarStore(cardb, cspath)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	hs := NewMemHeadStore()
+	repoman := NewRepoManager(hs, cs, &util.FakeKeyManager{})
+
+	ctx := context.TODO()
+	if err := repoman.InitNewActor(ctx, 1, "hello.world", "did:foo:bar", "catdog", "", ""); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, err = repoman.CreateRecord(ctx, 1, "app.bsky.feed.post", &bsky.FeedPost{
+			Text: "cats",
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/repomgr/dbheadstore.go
+++ b/repomgr/dbheadstore.go
@@ -1,0 +1,67 @@
+package repomgr
+
+import (
+	"context"
+
+	"github.com/bluesky-social/indigo/util"
+	"github.com/ipfs/go-cid"
+	"go.opentelemetry.io/otel"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func NewDbHeadStore(db *gorm.DB) *DbHeadStore {
+	db.AutoMigrate(RepoHead{})
+
+	return &DbHeadStore{db}
+}
+
+type DbHeadStore struct {
+	db *gorm.DB
+}
+
+func (hs *DbHeadStore) InitUser(ctx context.Context, user util.Uid, root cid.Cid) error {
+	if err := hs.db.Create(&RepoHead{
+		Usr:  user,
+		Root: root.String(),
+	}).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (hs *DbHeadStore) UpdateUserRepoHead(ctx context.Context, user util.Uid, root cid.Cid) error {
+	if err := hs.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "usr"}},
+		DoUpdates: clause.AssignmentColumns([]string{"root"}),
+	}).Create(&RepoHead{
+		Usr:  user,
+		Root: root.String(),
+	}).Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (hs *DbHeadStore) GetUserRepoHead(ctx context.Context, user util.Uid) (cid.Cid, error) {
+	ctx, span := otel.Tracer("repoman").Start(ctx, "GetUserRepoHead")
+	defer span.End()
+
+	var headrec RepoHead
+	if err := hs.db.Find(&headrec, "usr = ?", user).Error; err != nil {
+		return cid.Undef, err
+	}
+
+	if headrec.ID == 0 {
+		return cid.Undef, gorm.ErrRecordNotFound
+	}
+
+	cc, err := cid.Decode(headrec.Root)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	return cc, nil
+}

--- a/repomgr/ingest_test.go
+++ b/repomgr/ingest_test.go
@@ -59,7 +59,8 @@ func TestLoadNewRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repoman := NewRepoManager(maindb, cs, &util.FakeKeyManager{})
+	hs := NewDbHeadStore(maindb)
+	repoman := NewRepoManager(hs, cs, &util.FakeKeyManager{})
 
 	fi, err := os.Open("../testing/testdata/divy.repo")
 	if err != nil {
@@ -112,7 +113,8 @@ func TestIngestWithGap(t *testing.T) {
 
 	cs := testCarstore(t, dir)
 
-	repoman := NewRepoManager(maindb, cs, &util.FakeKeyManager{})
+	hs := NewDbHeadStore(maindb)
+	repoman := NewRepoManager(hs, cs, &util.FakeKeyManager{})
 
 	dir2, err := os.MkdirTemp("", "integtest")
 	if err != nil {

--- a/repomgr/memheadstore.go
+++ b/repomgr/memheadstore.go
@@ -1,0 +1,48 @@
+package repomgr
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bluesky-social/indigo/util"
+	"github.com/ipfs/go-cid"
+)
+
+type MemHeadStore struct {
+	heads map[util.Uid]cid.Cid
+}
+
+func NewMemHeadStore() *MemHeadStore {
+	return &MemHeadStore{
+		heads: make(map[util.Uid]cid.Cid),
+	}
+}
+
+func (hs *MemHeadStore) GetUserRepoHead(ctx context.Context, user util.Uid) (cid.Cid, error) {
+	h, ok := hs.heads[user]
+	if !ok {
+		return cid.Undef, fmt.Errorf("user head not found")
+	}
+
+	return h, nil
+}
+
+func (hs *MemHeadStore) UpdateUserRepoHead(ctx context.Context, user util.Uid, root cid.Cid) error {
+	_, ok := hs.heads[user]
+	if !ok {
+		return fmt.Errorf("cannot update user head if it doesnt exist already")
+	}
+
+	hs.heads[user] = root
+	return nil
+}
+
+func (hs *MemHeadStore) InitUser(ctx context.Context, user util.Uid, root cid.Cid) error {
+	_, ok := hs.heads[user]
+	if ok {
+		return fmt.Errorf("cannot init user head if it exists already")
+	}
+
+	hs.heads[user] = root
+	return nil
+}

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -425,7 +425,7 @@ func SetupBGS(ctx context.Context, didr plc.PLCClient) (*TestBGS, error) {
 	//kmgr := indexer.NewKeyManager(didr, nil)
 	kmgr := &bsutil.FakeKeyManager{}
 
-	repoman := repomgr.NewRepoManager(maindb, cs, kmgr)
+	repoman := repomgr.NewRepoManager(repomgr.NewDbHeadStore(maindb), cs, kmgr)
 
 	notifman := notifs.NewNotificationManager(maindb, repoman.GetRecord)
 


### PR DESCRIPTION
The in-memory variant goes about 20% faster in the benchmark. The rest is carstore costs