### PR TITLE
fix cleanup of rebases in carstore

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -687,8 +687,11 @@ func (bgs *BGS) handleFedEvent(ctx context.Context, host *models.PDS, env *event
 				return err
 			}
 
+			fmt.Println("adding to slow path")
+			fmt.Println("NEED TO HANDLE THINGS THAT GOT QUEUED UP IN THE CATCHUP QUEUE BEHIND AN ALREADY IN-PROGRESS THING")
 			return bgs.Index.Crawler.AddToCatchupQueue(ctx, host, ai, evt)
 		}
+		fmt.Println("fast pathhhh")
 
 		if err := bgs.repoman.HandleExternalUserEvent(ctx, host.ID, u.ID, u.Did, (*cid.Cid)(evt.Prev), evt.Blocks, evt.Ops); err != nil {
 			log.Warnw("failed handling event", "err", err, "host", host.Host, "seq", evt.Seq, "repo", u.Did, "prev", stringLink(evt.Prev), "commit", evt.Commit.String())

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -687,11 +687,16 @@ func (bgs *BGS) handleFedEvent(ctx context.Context, host *models.PDS, env *event
 				return err
 			}
 
-			fmt.Println("adding to slow path")
-			fmt.Println("NEED TO HANDLE THINGS THAT GOT QUEUED UP IN THE CATCHUP QUEUE BEHIND AN ALREADY IN-PROGRESS THING")
+			// TODO: we currently do not handle events that get queued up
+			// behind an already 'in progress' slow path event.
+			// this is strictly less efficient than it could be, and while it
+			// does 'work' (due to falling back to resyncing the repo), its
+			// technically incorrect. Now that we have the parallel event
+			// processor coming off of the pds stream, we should investigate
+			// whether or not we even need this 'slow path' logic, as it makes
+			// accounting for which events have been processed much harder
 			return bgs.Index.Crawler.AddToCatchupQueue(ctx, host, ai, evt)
 		}
-		fmt.Println("fast pathhhh")
 
 		if err := bgs.repoman.HandleExternalUserEvent(ctx, host.ID, u.ID, u.Did, (*cid.Cid)(evt.Prev), evt.Blocks, evt.Ops); err != nil {
 			log.Warnw("failed handling event", "err", err, "host", host.Host, "seq", evt.Seq, "repo", u.Did, "prev", stringLink(evt.Prev), "commit", evt.Commit.String())

--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -743,6 +743,10 @@ func (ds *DeltaSession) CloseAsRebase(ctx context.Context, root cid.Cid) error {
 		if err := ds.cs.meta.Delete(&sl).Error; err != nil {
 			return err
 		}
+
+		if err := ds.cs.meta.Where("shard = ?", sl.ID).Delete(&blockRef{}).Error; err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/indexer/crawler.go
+++ b/indexer/crawler.go
@@ -196,7 +196,7 @@ func (c *CrawlDispatcher) fetchWorker() {
 
 func (c *CrawlDispatcher) Crawl(ctx context.Context, ai *models.ActorInfo) error {
 	if ai.PDS == 0 {
-		panic("not today!")
+		panic("must have pds for user in queue")
 	}
 
 	ctx, span := otel.Tracer("crawler").Start(ctx, "addToCrawler")
@@ -212,7 +212,7 @@ func (c *CrawlDispatcher) Crawl(ctx context.Context, ai *models.ActorInfo) error
 
 func (c *CrawlDispatcher) AddToCatchupQueue(ctx context.Context, host *models.PDS, u *models.ActorInfo, evt *comatproto.SyncSubscribeRepos_Commit) error {
 	if u.PDS == 0 {
-		panic("not okay")
+		panic("must have pds for user in queue")
 	}
 
 	catchup := &catchupJob{

--- a/indexer/crawler.go
+++ b/indexer/crawler.go
@@ -16,7 +16,7 @@ type CrawlDispatcher struct {
 
 	repoSync chan *crawlWork
 
-	catchup chan *catchupJob
+	catchup chan *crawlWork
 
 	complete chan models.Uid
 
@@ -38,7 +38,7 @@ func NewCrawlDispatcher(repoFn func(context.Context, *crawlWork) error, concurre
 		ingest:      make(chan *models.ActorInfo),
 		repoSync:    make(chan *crawlWork),
 		complete:    make(chan models.Uid),
-		catchup:     make(chan *catchupJob),
+		catchup:     make(chan *crawlWork),
 		doRepoCrawl: repoFn,
 		concurrency: concurrency,
 		todo:        make(map[models.Uid]*crawlWork),
@@ -121,30 +121,7 @@ func (c *CrawlDispatcher) mainLoop() {
 				next = nil
 				rs = nil
 			}
-		case catchup := <-c.catchup:
-			c.maplk.Lock()
-			job, ok := c.todo[catchup.user.Uid]
-			// TODO: in the event of receiving a rebase event, we *could* pre-empt all other pending events
-			if ok {
-				job.catchup = append(job.catchup, catchup)
-				c.maplk.Unlock()
-				break
-			}
-
-			job, ok = c.inProgress[catchup.user.Uid]
-			if ok {
-				job.next = append(job.next, catchup)
-				c.maplk.Unlock()
-				break
-			}
-
-			cw := &crawlWork{
-				act:     catchup.user,
-				catchup: []*catchupJob{catchup},
-			}
-			c.todo[catchup.user.Uid] = cw
-			c.maplk.Unlock()
-
+		case cw := <-c.catchup:
 			if next == nil {
 				next = cw
 				rs = c.repoSync
@@ -177,6 +154,30 @@ func (c *CrawlDispatcher) mainLoop() {
 
 		}
 	}
+}
+
+func (c *CrawlDispatcher) addToCatchupQueue(catchup *catchupJob) *crawlWork {
+	c.maplk.Lock()
+	defer c.maplk.Unlock()
+	job, ok := c.todo[catchup.user.Uid]
+	// TODO: in the event of receiving a rebase event, we *could* pre-empt all other pending events
+	if ok {
+		job.catchup = append(job.catchup, catchup)
+		return nil
+	}
+
+	job, ok = c.inProgress[catchup.user.Uid]
+	if ok {
+		job.next = append(job.next, catchup)
+		return nil
+	}
+
+	cw := &crawlWork{
+		act:     catchup.user,
+		catchup: []*catchupJob{catchup},
+	}
+	c.todo[catchup.user.Uid] = cw
+	return cw
 }
 
 func (c *CrawlDispatcher) fetchWorker() {
@@ -214,12 +215,19 @@ func (c *CrawlDispatcher) AddToCatchupQueue(ctx context.Context, host *models.PD
 		panic("not okay")
 	}
 
-	select {
-	case c.catchup <- &catchupJob{
+	catchup := &catchupJob{
 		evt:  evt,
 		host: host,
 		user: u,
-	}:
+	}
+
+	cw := c.addToCatchupQueue(catchup)
+	if cw == nil {
+		return nil
+	}
+
+	select {
+	case c.catchup <- cw:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -841,7 +841,6 @@ func (ix *Indexer) FetchAndIndexRepo(ctx context.Context, job *crawlWork) error 
 	var rebaseIx int
 	for i, j := range job.catchup {
 		if j.evt.Rebase {
-			fmt.Println("REBASE AT: ", i, len(job.catchup))
 			rebase = j.evt
 			rebaseIx = i
 			break
@@ -869,7 +868,6 @@ func (ix *Indexer) FetchAndIndexRepo(ctx context.Context, job *crawlWork) error 
 		first := job.catchup[0]
 		if first.evt.Prev == nil || curHead == (cid.Cid)(*first.evt.Prev) {
 			for _, j := range job.catchup {
-				fmt.Println("Processing catchup job")
 				if err := ix.repomgr.HandleExternalUserEvent(ctx, pds.ID, ai.Uid, ai.Did, (*cid.Cid)(j.evt.Prev), j.evt.Blocks, j.evt.Ops); err != nil {
 					// TODO: if we fail here, we should probably fall back to a repo re-sync
 					return fmt.Errorf("post rebase catchup failed: %w", err)

--- a/repomgr/ingest_test.go
+++ b/repomgr/ingest_test.go
@@ -201,8 +201,7 @@ func TestRebase(t *testing.T) {
 
 	cs := testCarstore(t, dir)
 
-	hs := NewDbHeadStore(maindb)
-	repoman := NewRepoManager(hs, cs, &util.FakeKeyManager{})
+	repoman := NewRepoManager(cs, &util.FakeKeyManager{})
 
 	ctx := context.TODO()
 	if err := repoman.InitNewActor(ctx, 1, "hello.world", "did:plc:foobar", "", "", ""); err != nil {

--- a/repomgr/repomgr.go
+++ b/repomgr/repomgr.go
@@ -562,10 +562,6 @@ func (rm *RepoManager) DoRebase(ctx context.Context, uid models.Uid) error {
 		return fmt.Errorf("finalizing rebase: %w", err)
 	}
 
-	if err := rm.hs.UpdateUserRepoHead(ctx, uid, nroot); err != nil {
-		return fmt.Errorf("updating user head: %w", err)
-	}
-
 	// outbound car slice should just be the new signed root
 	buf := new(bytes.Buffer)
 	if _, err := carstore.WriteCarHeader(buf, nroot); err != nil {

--- a/testing/integ_test.go
+++ b/testing/integ_test.go
@@ -406,6 +406,7 @@ func TestRebaseMulti(t *testing.T) {
 		bob.Post(t, fmt.Sprintf("this is bobs post %d", i))
 	}
 
+	fmt.Println("REBASE TWO")
 	bob.DoRebase(t)
 
 	var posts []*atproto.RepoStrongRef
@@ -422,9 +423,11 @@ func TestRebaseMulti(t *testing.T) {
 	all := evts1.WaitFor(11)
 
 	assert.Equal(true, all[0].RepoCommit.Rebase)
+	assert.Equal(int64(1), all[0].RepoCommit.Seq)
 	assert.Equal(posts[0].Cid, all[1].RepoCommit.Ops[0].Cid.String())
 
 	// and another one!
+	fmt.Println("REBASE TWO")
 	bob.DoRebase(t)
 
 	var posts2 []*atproto.RepoStrongRef

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -526,9 +526,9 @@ func (b *TestBGS) Events(t *testing.T, since int64) *EventStream {
 	go func() {
 		rsc := &events.RepoStreamCallbacks{
 			RepoCommit: func(evt *atproto.SyncSubscribeRepos_Commit) error {
+				fmt.Println("received event: ", evt.Seq, evt.Repo, len(es.Events))
 				es.Lk.Lock()
 				es.Events = append(es.Events, &events.XRPCStreamEvent{RepoCommit: evt})
-				fmt.Println("received event: ", evt.Seq, evt.Repo, len(es.Events))
 				es.Lk.Unlock()
 				return nil
 			},


### PR DESCRIPTION
This fixes two things, first the test-pds didnt properly implement rebases which caused some issues in tests. 
The second thing was that old blockRefs werent getting deleted after the rebase, despite their associated CarShards getting deleted.