### PR TITLE
add in smarter timestamp parsing

### DIFF
--- a/util/time.go
+++ b/util/time.go
@@ -1,3 +1,38 @@
 package util
 
+import (
+	"fmt"
+	"time"
+)
+
 const ISO8601 = "2006-01-02T15:04:05.000Z"
+
+const ISO8601_milli = "2006-01-02T15:04:05.000000Z"
+
+const ISO8601_numtz = "2006-01-02T15:04:05.000-07:00"
+
+const ISO8601_numtz_milli = "2006-01-02T15:04:05.000000-07:00"
+
+func ParseTimestamp(s string) (time.Time, error) {
+	t, err := time.Parse(ISO8601, s)
+	if err == nil {
+		return t, nil
+	}
+
+	t, err = time.Parse(ISO8601_milli, s)
+	if err == nil {
+		return t, nil
+	}
+
+	t, err = time.Parse(ISO8601_numtz, s)
+	if err == nil {
+		return t, nil
+	}
+
+	t, err = time.Parse(ISO8601_numtz_milli, s)
+	if err == nil {
+		return t, nil
+	}
+
+	return time.Time{}, fmt.Errorf("failed to parse %q as timestamp", s)
+}

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -1,0 +1,19 @@
+package util
+
+import "testing"
+
+func TestTimeParsing(t *testing.T) {
+	good := []string{
+		"2023-07-19T21:54:14.165300Z",
+		"2023-07-19T21:54:14.163Z",
+		"2023-07-19T21:52:02.000+00:00",
+		"2023-07-19T21:52:02.123456+00:00",
+	}
+
+	for _, g := range good {
+		_, err := ParseTimestamp(g)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
i'm surely missing some that are *Technically* valid, but i'd prefer we just got more strict on whats allowed.