### PR TITLE
use parallel event processor in bgs

### DIFF
--- a/bgs/fedmgr.go
+++ b/bgs/fedmgr.go
@@ -332,8 +332,8 @@ func (s *Slurper) handleConnection(ctx context.Context, host *models.PDS, con *w
 		},
 	}
 
-	// TODO: probably make this use the parallel handler after some thought
-	return events.HandleRepoStream(ctx, con, &events.SequentialScheduler{rsc.EventHandler})
+	pool := events.NewConsumerPool(32, 20, rsc.EventHandler)
+	return events.HandleRepoStream(ctx, con, pool)
 }
 
 func (s *Slurper) updateCursor(host *models.PDS, curs int64) error {

--- a/testing/integ_test.go
+++ b/testing/integ_test.go
@@ -44,7 +44,16 @@ func TestBGSBasic(t *testing.T) {
 	defer evts.Cancel()
 
 	bob := p1.MustNewUser(t, "bob.tpds")
+	fmt.Println("event 1")
+	e1 := evts.Next()
+	assert.NotNil(e1.RepoCommit)
+	assert.Equal(e1.RepoCommit.Repo, bob.DID())
+
 	alice := p1.MustNewUser(t, "alice.tpds")
+	fmt.Println("event 2")
+	e2 := evts.Next()
+	assert.NotNil(e2.RepoCommit)
+	assert.Equal(e2.RepoCommit.Repo, alice.DID())
 
 	bp1 := bob.Post(t, "cats for cats")
 	ap1 := alice.Post(t, "no i like dogs")
@@ -53,23 +62,12 @@ func TestBGSBasic(t *testing.T) {
 	_ = ap1
 
 	fmt.Println("bob:", bob.DID())
-	fmt.Println("alice:", alice.DID())
-
-	fmt.Println("event 1")
-	e1 := evts.Next()
-	assert.NotNil(e1.RepoCommit)
-	assert.Equal(e1.RepoCommit.Repo, bob.DID())
-
-	fmt.Println("event 2")
-	e2 := evts.Next()
-	assert.NotNil(e2.RepoCommit)
-	assert.Equal(e2.RepoCommit.Repo, alice.DID())
-
 	fmt.Println("event 3")
 	e3 := evts.Next()
 	assert.Equal(e3.RepoCommit.Repo, bob.DID())
 	//assert.Equal(e3.RepoCommit.Ops[0].Kind, "createRecord")
 
+	fmt.Println("alice:", alice.DID())
 	fmt.Println("event 4")
 	e4 := evts.Next()
 	assert.Equal(e4.RepoCommit.Repo, alice.DID())


### PR DESCRIPTION
There might be other test failures as a result of this, but i ran them 20 or so times and this was the only one that popped up locally.

We might want to make the settings on the consumer pool tuneable, but for now this should get us some much better numbers on our load testing