### PR TITLE
Batch cursor updates for PDSs

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -317,9 +317,7 @@ func (bgs *BGS) StartWithListener(listen net.Listener) error {
 }
 
 func (bgs *BGS) Shutdown() []error {
-	errs := []error{}
-	errs = append(errs, bgs.slurper.Shutdown()...)
-	return errs
+	return bgs.slurper.Shutdown()
 }
 
 type HealthStatus struct {

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -316,6 +316,12 @@ func (bgs *BGS) StartWithListener(listen net.Listener) error {
 	return e.StartServer(srv)
 }
 
+func (bgs *BGS) Shutdown() []error {
+	errs := []error{}
+	errs = append(errs, bgs.slurper.Shutdown()...)
+	return errs
+}
+
 type HealthStatus struct {
 	Status  string `json:"status"`
 	Message string `json:"msg,omitempty"`

--- a/bgs/fedmgr.go
+++ b/bgs/fedmgr.go
@@ -94,8 +94,7 @@ func NewSlurper(db *gorm.DB, cb IndexCallback, ssl bool) (*Slurper, error) {
 }
 
 // Shutdown shuts down the slurper
-func (s *Slurper) Shutdown() {
-	log.Info("shutting down slurper")
+func (s *Slurper) Shutdown() []error {
 	s.shutdownChan <- true
 	log.Info("waiting for slurper shutdown")
 	errs := <-s.shutdownResult
@@ -105,6 +104,7 @@ func (s *Slurper) Shutdown() {
 		}
 	}
 	log.Info("slurper shutdown complete")
+	return errs
 }
 
 func (s *Slurper) loadConfig() error {

--- a/bgs/fedmgr.go
+++ b/bgs/fedmgr.go
@@ -11,6 +11,7 @@ import (
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/events"
 	"github.com/bluesky-social/indigo/models"
+	"go.opentelemetry.io/otel"
 
 	"github.com/gorilla/websocket"
 	"gorm.io/gorm"
@@ -29,11 +30,15 @@ type Slurper struct {
 
 	newSubsDisabled bool
 
+	shutdownChan   chan bool
+	shutdownResult chan []error
+
 	ssl bool
 }
 
 type activeSub struct {
 	pds    *models.PDS
+	lk     sync.RWMutex
 	ctx    context.Context
 	cancel func()
 }
@@ -41,16 +46,65 @@ type activeSub struct {
 func NewSlurper(db *gorm.DB, cb IndexCallback, ssl bool) (*Slurper, error) {
 	db.AutoMigrate(&SlurpConfig{})
 	s := &Slurper{
-		cb:     cb,
-		db:     db,
-		active: make(map[string]*activeSub),
-		ssl:    ssl,
+		cb:             cb,
+		db:             db,
+		active:         make(map[string]*activeSub),
+		ssl:            ssl,
+		shutdownChan:   make(chan bool),
+		shutdownResult: make(chan []error),
 	}
 	if err := s.loadConfig(); err != nil {
 		return nil, err
 	}
 
+	// Start a goroutine to flush cursors to the DB every 30s
+	go func() {
+		for {
+			select {
+			case <-s.shutdownChan:
+				log.Info("flushing PDS cursors on shutdown")
+				ctx := context.Background()
+				ctx, span := otel.Tracer("feedmgr").Start(ctx, "CursorFlusherShutdown")
+				defer span.End()
+				var errs []error
+				if errs = s.flushCursors(ctx); len(errs) > 0 {
+					for _, err := range errs {
+						log.Errorf("failed to flush cursors on shutdown: %s", err)
+					}
+				}
+				log.Info("done flushing PDS cursors on shutdown")
+				s.shutdownResult <- errs
+				return
+			case <-time.After(time.Second * 10):
+				log.Debug("flushing PDS cursors")
+				ctx := context.Background()
+				ctx, span := otel.Tracer("feedmgr").Start(ctx, "CursorFlusher")
+				defer span.End()
+				if errs := s.flushCursors(ctx); len(errs) > 0 {
+					for _, err := range errs {
+						log.Errorf("failed to flush cursors: %s", err)
+					}
+				}
+				log.Debug("done flushing PDS cursors")
+			}
+		}
+	}()
+
 	return s, nil
+}
+
+// Shutdown shuts down the slurper
+func (s *Slurper) Shutdown() {
+	log.Info("shutting down slurper")
+	s.shutdownChan <- true
+	log.Info("waiting for slurper shutdown")
+	errs := <-s.shutdownResult
+	if len(errs) > 0 {
+		for _, err := range errs {
+			log.Errorf("shutdown error: %s", err)
+		}
+	}
+	log.Info("slurper shutdown complete")
 }
 
 func (s *Slurper) loadConfig() error {
@@ -140,13 +194,14 @@ func (s *Slurper) SubscribeToPds(ctx context.Context, host string, reg bool) err
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	s.active[host] = &activeSub{
+	sub := activeSub{
 		pds:    &peering,
 		ctx:    ctx,
 		cancel: cancel,
 	}
+	s.active[host] = &sub
 
-	go s.subscribeWithRedialer(ctx, &peering)
+	go s.subscribeWithRedialer(ctx, &peering, &sub)
 
 	return nil
 }
@@ -164,18 +219,19 @@ func (s *Slurper) RestartAll() error {
 		pds := pds
 
 		ctx, cancel := context.WithCancel(context.Background())
-		s.active[pds.Host] = &activeSub{
+		sub := activeSub{
 			pds:    &pds,
 			ctx:    ctx,
 			cancel: cancel,
 		}
-		go s.subscribeWithRedialer(ctx, &pds)
+		s.active[pds.Host] = &sub
+		go s.subscribeWithRedialer(ctx, &pds, &sub)
 	}
 
 	return nil
 }
 
-func (s *Slurper) subscribeWithRedialer(ctx context.Context, host *models.PDS) {
+func (s *Slurper) subscribeWithRedialer(ctx context.Context, host *models.PDS, sub *activeSub) {
 	defer func() {
 		s.lk.Lock()
 		defer s.lk.Unlock()
@@ -221,7 +277,7 @@ func (s *Slurper) subscribeWithRedialer(ctx context.Context, host *models.PDS) {
 
 		log.Info("event subscription response code: ", res.StatusCode)
 
-		if err := s.handleConnection(ctx, host, con, &cursor); err != nil {
+		if err := s.handleConnection(ctx, host, con, &cursor, sub); err != nil {
 			if errors.Is(err, ErrTimeoutShutdown) {
 				log.Infof("shutting down pds subscription to %s, no activity after %s", host.Host, EventsTimeout)
 				return
@@ -247,7 +303,7 @@ var ErrTimeoutShutdown = fmt.Errorf("timed out waiting for new events")
 
 var EventsTimeout = time.Minute
 
-func (s *Slurper) handleConnection(ctx context.Context, host *models.PDS, con *websocket.Conn, lastCursor *int64) error {
+func (s *Slurper) handleConnection(ctx context.Context, host *models.PDS, con *websocket.Conn, lastCursor *int64, sub *activeSub) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -261,7 +317,7 @@ func (s *Slurper) handleConnection(ctx context.Context, host *models.PDS, con *w
 			}
 			*lastCursor = evt.Seq
 
-			if err := s.updateCursor(host, *lastCursor); err != nil {
+			if err := s.updateCursor(sub, *lastCursor); err != nil {
 				return fmt.Errorf("updating cursor: %w", err)
 			}
 
@@ -276,7 +332,7 @@ func (s *Slurper) handleConnection(ctx context.Context, host *models.PDS, con *w
 			}
 			*lastCursor = evt.Seq
 
-			if err := s.updateCursor(host, *lastCursor); err != nil {
+			if err := s.updateCursor(sub, *lastCursor); err != nil {
 				return fmt.Errorf("updating cursor: %w", err)
 			}
 
@@ -291,7 +347,7 @@ func (s *Slurper) handleConnection(ctx context.Context, host *models.PDS, con *w
 			}
 			*lastCursor = evt.Seq
 
-			if err := s.updateCursor(host, *lastCursor); err != nil {
+			if err := s.updateCursor(sub, *lastCursor); err != nil {
 				return fmt.Errorf("updating cursor: %w", err)
 			}
 
@@ -306,7 +362,7 @@ func (s *Slurper) handleConnection(ctx context.Context, host *models.PDS, con *w
 			}
 			*lastCursor = evt.Seq
 
-			if err := s.updateCursor(host, *lastCursor); err != nil {
+			if err := s.updateCursor(sub, *lastCursor); err != nil {
 				return fmt.Errorf("updating cursor: %w", err)
 			}
 
@@ -336,8 +392,34 @@ func (s *Slurper) handleConnection(ctx context.Context, host *models.PDS, con *w
 	return events.HandleRepoStream(ctx, con, pool)
 }
 
-func (s *Slurper) updateCursor(host *models.PDS, curs int64) error {
-	return s.db.Model(models.PDS{}).Where("id = ?", host.ID).UpdateColumn("cursor", curs).Error
+func (s *Slurper) updateCursor(sub *activeSub, curs int64) error {
+	sub.lk.Lock()
+	defer sub.lk.Unlock()
+	sub.pds.Cursor = curs
+	return nil
+}
+
+// flushCursors updates the PDS cursors in the DB for all active subscriptions
+func (s *Slurper) flushCursors(ctx context.Context) []error {
+	ctx, span := otel.Tracer("feedmgr").Start(ctx, "flushCursors")
+	defer span.End()
+
+	s.lk.Lock()
+	defer s.lk.Unlock()
+
+	errs := []error{}
+
+	// Iterate over active subs and update the PDS cursor in the DB
+	for _, sub := range s.active {
+		sub.lk.RLock()
+		if err := s.db.WithContext(ctx).Model(models.PDS{}).Where("id = ?", sub.pds.ID).UpdateColumn("cursor", sub.pds.Cursor).Error; err != nil {
+			sub.lk.RUnlock()
+			errs = append(errs, err)
+		}
+		sub.lk.RUnlock()
+	}
+
+	return errs
 }
 
 func (s *Slurper) GetActiveList() []string {

--- a/bgs/fedmgr.go
+++ b/bgs/fedmgr.go
@@ -413,7 +413,6 @@ func (s *Slurper) flushCursors(ctx context.Context) []error {
 	for _, sub := range s.active {
 		sub.lk.RLock()
 		if err := s.db.WithContext(ctx).Model(models.PDS{}).Where("id = ?", sub.pds.ID).UpdateColumn("cursor", sub.pds.Cursor).Error; err != nil {
-			sub.lk.RUnlock()
 			errs = append(errs, err)
 		}
 		sub.lk.RUnlock()

--- a/cmd/bigsky/main.go
+++ b/cmd/bigsky/main.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/bluesky-social/indigo/api"
@@ -49,7 +51,6 @@ func main() {
 }
 
 func run(args []string) {
-
 	app := cli.App{
 		Name:    "bigsky",
 		Usage:   "atproto BGS/firehose daemon",
@@ -120,186 +121,206 @@ func run(args []string) {
 		},
 	}
 
-	app.Action = func(cctx *cli.Context) error {
+	app.Action = Bigsky
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
 
-		if cctx.Bool("jaeger") {
-			url := "http://localhost:14268/api/traces"
-			exp, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(url)))
-			if err != nil {
-				return err
-			}
-			tp := tracesdk.NewTracerProvider(
-				// Always be sure to batch in production.
-				tracesdk.WithBatcher(exp),
-				// Record information about this application in a Resource.
-				tracesdk.WithResource(resource.NewWithAttributes(
-					semconv.SchemaURL,
-					semconv.ServiceNameKey.String("bgs"),
-					attribute.String("environment", "test"),
-					attribute.Int64("ID", 1),
-				)),
-			)
+func Bigsky(cctx *cli.Context) error {
+	// Trap SIGINT to trigger a shutdown.
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 
-			otel.SetTracerProvider(tp)
+	if cctx.Bool("jaeger") {
+		url := "http://localhost:14268/api/traces"
+		exp, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(url)))
+		if err != nil {
+			return err
 		}
+		tp := tracesdk.NewTracerProvider(
+			// Always be sure to batch in production.
+			tracesdk.WithBatcher(exp),
+			// Record information about this application in a Resource.
+			tracesdk.WithResource(resource.NewWithAttributes(
+				semconv.SchemaURL,
+				semconv.ServiceNameKey.String("bgs"),
+				attribute.String("environment", "test"),
+				attribute.Int64("ID", 1),
+			)),
+		)
 
-		// Enable OTLP HTTP exporter
-		// For relevant environment variables:
-		// https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace#readme-environment-variables
-		// At a minimum, you need to set
-		// OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
-		if os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" {
-			ctx, cancel := context.WithCancel(context.Background())
+		otel.SetTracerProvider(tp)
+	}
+
+	// Enable OTLP HTTP exporter
+	// For relevant environment variables:
+	// https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace#readme-environment-variables
+	// At a minimum, you need to set
+	// OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+	if os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT") != "" {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		exp, err := otlptracehttp.New(ctx)
+		if err != nil {
+			log.Fatalw("failed to create trace exporter", "error", err)
+		}
+		defer func() {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
-
-			exp, err := otlptracehttp.New(ctx)
-			if err != nil {
-				log.Fatalw("failed to create trace exporter", "error", err)
-			}
-			defer func() {
-				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-				defer cancel()
-				if err := exp.Shutdown(ctx); err != nil {
-					log.Errorw("failed to shutdown trace exporter", "error", err)
-				}
-			}()
-
-			tp := tracesdk.NewTracerProvider(
-				tracesdk.WithBatcher(exp),
-				tracesdk.WithResource(resource.NewWithAttributes(
-					semconv.SchemaURL,
-					semconv.ServiceNameKey.String("bgs"),
-					attribute.String("env", os.Getenv("ENVIRONMENT")),         // DataDog
-					attribute.String("environment", os.Getenv("ENVIRONMENT")), // Others
-					attribute.Int64("ID", 1),
-				)),
-			)
-			otel.SetTracerProvider(tp)
-		}
-
-		// ensure data directory exists; won't error if it does
-		datadir := cctx.String("data-dir")
-		csdir := filepath.Join(datadir, "carstore")
-		if err := os.MkdirAll(datadir, os.ModePerm); err != nil {
-			return err
-		}
-
-		dburl := cctx.String("db-url")
-		db, err := cliutil.SetupDatabase(dburl)
-		if err != nil {
-			return err
-		}
-
-		csdburl := cctx.String("carstore-db-url")
-		csdb, err := cliutil.SetupDatabase(csdburl)
-		if err != nil {
-			return err
-		}
-
-		if cctx.Bool("db-tracing") {
-			if err := db.Use(tracing.NewPlugin()); err != nil {
-				return err
-			}
-			if err := csdb.Use(tracing.NewPlugin()); err != nil {
-				return err
-			}
-		}
-
-		os.MkdirAll(filepath.Dir(csdir), os.ModePerm)
-		cstore, err := carstore.NewCarStore(csdb, csdir)
-		if err != nil {
-			return err
-		}
-
-		mr := did.NewMultiResolver()
-
-		didr := &api.PLCServer{Host: cctx.String("plc-host")}
-		mr.AddHandler("plc", didr)
-
-		webr := did.WebResolver{}
-		if cctx.Bool("crawl-insecure-ws") {
-			webr.Insecure = true
-		}
-		mr.AddHandler("web", &webr)
-
-		cachedidr := plc.NewCachingDidResolver(mr, time.Minute*5, 1000)
-
-		kmgr := indexer.NewKeyManager(cachedidr, nil)
-
-		repoman := repomgr.NewRepoManager(repomgr.NewDbHeadStore(db), cstore, kmgr)
-
-		var persister events.EventPersistence
-
-		if dpd := cctx.String("disk-persister-dir"); dpd != "" {
-			dp, err := events.NewDiskPersistence(dpd, "", db, events.DefaultDiskPersistOptions())
-			if err != nil {
-				return fmt.Errorf("setting up disk persister: %w", err)
-			}
-			persister = dp
-		} else {
-			dbp, err := events.NewDbPersistence(db, cstore, nil)
-			if err != nil {
-				return fmt.Errorf("setting up db event persistence: %w", err)
-			}
-			persister = dbp
-		}
-
-		evtman := events.NewEventManager(persister)
-
-		notifman := &notifs.NullNotifs{}
-
-		ix, err := indexer.NewIndexer(db, notifman, evtman, cachedidr, repoman, true, cctx.Bool("aggregation"))
-		if err != nil {
-			return err
-		}
-
-		rlskip := os.Getenv("BSKY_SOCIAL_RATE_LIMIT_SKIP")
-		ix.ApplyPDSClientSettings = func(c *xrpc.Client) {
-			if c.Host == "https://bsky.social" && rlskip != "" {
-				c.Headers = map[string]string{
-					"x-ratelimit-bypass": rlskip,
-				}
-			}
-		}
-
-		repoman.SetEventHandler(func(ctx context.Context, evt *repomgr.RepoEvent) {
-			if err := ix.HandleRepoEvent(ctx, evt); err != nil {
-				log.Errorw("failed to handle repo event", "err", err)
-			}
-		})
-
-		var blobstore blobs.BlobStore
-		if bsdir := cctx.String("disk-blob-store"); bsdir != "" {
-			blobstore = &blobs.DiskBlobStore{bsdir}
-		}
-
-		var hr api.HandleResolver = &api.ProdHandleResolver{}
-		if cctx.StringSlice("handle-resolver-hosts") != nil {
-			hr = &api.TestHandleResolver{
-				TrialHosts: cctx.StringSlice("handle-resolver-hosts"),
-			}
-		}
-
-		bgs, err := bgs.NewBGS(db, ix, repoman, evtman, cachedidr, blobstore, hr, !cctx.Bool("crawl-insecure-ws"))
-		if err != nil {
-			return err
-		}
-
-		if tok := cctx.String("admin-key"); tok != "" {
-			if err := bgs.CreateAdminToken(tok); err != nil {
-				return fmt.Errorf("failed to set up admin token: %w", err)
-			}
-		}
-
-		// set up pprof endpoint
-		go func() {
-			if err := bgs.StartDebug(cctx.String("debug-listen")); err != nil {
-				panic(err)
+			if err := exp.Shutdown(ctx); err != nil {
+				log.Errorw("failed to shutdown trace exporter", "error", err)
 			}
 		}()
 
-		return bgs.Start(cctx.String("api-listen"))
+		tp := tracesdk.NewTracerProvider(
+			tracesdk.WithBatcher(exp),
+			tracesdk.WithResource(resource.NewWithAttributes(
+				semconv.SchemaURL,
+				semconv.ServiceNameKey.String("bgs"),
+				attribute.String("env", os.Getenv("ENVIRONMENT")),         // DataDog
+				attribute.String("environment", os.Getenv("ENVIRONMENT")), // Others
+				attribute.Int64("ID", 1),
+			)),
+		)
+		otel.SetTracerProvider(tp)
 	}
 
-	app.RunAndExitOnError()
+	// ensure data directory exists; won't error if it does
+	datadir := cctx.String("data-dir")
+	csdir := filepath.Join(datadir, "carstore")
+	if err := os.MkdirAll(datadir, os.ModePerm); err != nil {
+		return err
+	}
+
+	dburl := cctx.String("db-url")
+	db, err := cliutil.SetupDatabase(dburl)
+	if err != nil {
+		return err
+	}
+
+	csdburl := cctx.String("carstore-db-url")
+	csdb, err := cliutil.SetupDatabase(csdburl)
+	if err != nil {
+		return err
+	}
+
+	if cctx.Bool("db-tracing") {
+		if err := db.Use(tracing.NewPlugin()); err != nil {
+			return err
+		}
+		if err := csdb.Use(tracing.NewPlugin()); err != nil {
+			return err
+		}
+	}
+
+	os.MkdirAll(filepath.Dir(csdir), os.ModePerm)
+	cstore, err := carstore.NewCarStore(csdb, csdir)
+	if err != nil {
+		return err
+	}
+
+	mr := did.NewMultiResolver()
+
+	didr := &api.PLCServer{Host: cctx.String("plc-host")}
+	mr.AddHandler("plc", didr)
+
+	webr := did.WebResolver{}
+	if cctx.Bool("crawl-insecure-ws") {
+		webr.Insecure = true
+	}
+	mr.AddHandler("web", &webr)
+
+	cachedidr := plc.NewCachingDidResolver(mr, time.Minute*5, 1000)
+
+	kmgr := indexer.NewKeyManager(cachedidr, nil)
+
+	repoman := repomgr.NewRepoManager(repomgr.NewDbHeadStore(db), cstore, kmgr)
+
+	var persister events.EventPersistence
+
+	if dpd := cctx.String("disk-persister-dir"); dpd != "" {
+		dp, err := events.NewDiskPersistence(dpd, "", db, events.DefaultDiskPersistOptions())
+		if err != nil {
+			return fmt.Errorf("setting up disk persister: %w", err)
+		}
+		persister = dp
+	} else {
+		dbp, err := events.NewDbPersistence(db, cstore, nil)
+		if err != nil {
+			return fmt.Errorf("setting up db event persistence: %w", err)
+		}
+		persister = dbp
+	}
+
+	evtman := events.NewEventManager(persister)
+
+	notifman := &notifs.NullNotifs{}
+
+	ix, err := indexer.NewIndexer(db, notifman, evtman, cachedidr, repoman, true, cctx.Bool("aggregation"))
+	if err != nil {
+		return err
+	}
+
+	rlskip := os.Getenv("BSKY_SOCIAL_RATE_LIMIT_SKIP")
+	ix.ApplyPDSClientSettings = func(c *xrpc.Client) {
+		if c.Host == "https://bsky.social" && rlskip != "" {
+			c.Headers = map[string]string{
+				"x-ratelimit-bypass": rlskip,
+			}
+		}
+	}
+
+	repoman.SetEventHandler(func(ctx context.Context, evt *repomgr.RepoEvent) {
+		if err := ix.HandleRepoEvent(ctx, evt); err != nil {
+			log.Errorw("failed to handle repo event", "err", err)
+		}
+	})
+
+	var blobstore blobs.BlobStore
+	if bsdir := cctx.String("disk-blob-store"); bsdir != "" {
+		blobstore = &blobs.DiskBlobStore{bsdir}
+	}
+
+	var hr api.HandleResolver = &api.ProdHandleResolver{}
+	if cctx.StringSlice("handle-resolver-hosts") != nil {
+		hr = &api.TestHandleResolver{
+			TrialHosts: cctx.StringSlice("handle-resolver-hosts"),
+		}
+	}
+
+	bgs, err := bgs.NewBGS(db, ix, repoman, evtman, cachedidr, blobstore, hr, !cctx.Bool("crawl-insecure-ws"))
+	if err != nil {
+		return err
+	}
+
+	if tok := cctx.String("admin-key"); tok != "" {
+		if err := bgs.CreateAdminToken(tok); err != nil {
+			return fmt.Errorf("failed to set up admin token: %w", err)
+		}
+	}
+
+	// set up pprof endpoint
+	go func() {
+		if err := bgs.StartDebug(cctx.String("debug-listen")); err != nil {
+			panic(err)
+		}
+	}()
+
+	go bgs.Start(cctx.String("api-listen"))
+
+	select {
+	case <-signals:
+		log.Info("received shutdown signal")
+		errs := bgs.Shutdown()
+		for err := range errs {
+			log.Errorw("error during BGS shutdown", "err", err)
+		}
+	}
+
+	log.Info("shutting down")
+
+	return nil
 }


### PR DESCRIPTION
Bumping the cursor in the DB for every event has become a bottleneck on event throughput.

To ameliorate this, we can batch cursor updates and flush them to the DB every 10 seconds.

![image](https://github.com/bluesky-social/indigo/assets/1617325/2b37cd64-15d6-4a82-9381-db9a1da0508b)
