### PR TITLE
Upgrade from actions/setup-go@v3 to actions/setup-go@v4

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v3
       - name: Set up Go tooling
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: "1.20"
       - name: Build
@@ -30,7 +30,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v3
       - name: Set up Go tooling
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: "1.20"
       - name: Lint


### PR DESCRIPTION
Small version bump to use the setup-go@v4 action, which has built-in caching: https://github.blog/changelog/2023-03-24-github-actions-the-setup-go-action-now-enables-caching-by-default/

This shaved off 2 minutes in back-to-back runs while testing this.

https://github.com/jcsalterego/indigo/actions/runs/5662793038/attempts/1 - v3
https://github.com/jcsalterego/indigo/actions/runs/5662793038/attempts/2 - v4
