### PR TITLE
Refactor Supercollider to have Reload and Fire modes for higher burst emission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ bsky.auth
 
 # Sonar cursor file
 sonar_cursor.json
+out/

--- a/Makefile
+++ b/Makefile
@@ -90,3 +90,21 @@ run-dev-search: .env ## Runs search daemon for local dev
 .PHONY: sonar-up
 sonar-up: # Runs sonar docker container
 	docker compose -f cmd/sonar/docker-compose.yml up --build -d || docker-compose -f cmd/sonar/docker-compose.yml up --build -d
+
+.PHONY: sc-reload
+sc-reload: # Reloads supercollider
+	go run cmd/supercollider/main.go \
+		reload \
+		--port 6125 --total-events 2000000 \
+		--hostname alpha.supercollider.jazco.io \
+		--key-file out/alpha.pem \
+		--output-file out/alpha_in.cbor
+
+.PHONY: sc-fire
+sc-fire: # Fires supercollider
+	go run cmd/supercollider/main.go \
+		fire \
+		--port 6125 --events-per-second 10000 \
+		--hostname alpha.supercollider.jazco.io \
+		--key-file out/alpha.pem \
+		--input-file out/alpha_in.cbor

--- a/cmd/supercollider/Dockerfile
+++ b/cmd/supercollider/Dockerfile
@@ -1,0 +1,28 @@
+# Stage 1: Build the Go binary
+FROM golang:1.20.5 AS builder
+
+# Create a directory for the application
+WORKDIR /app
+
+# Fetch dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# Build the application
+RUN CGO_ENABLED=1 GOOS=linux go build -o /supercollider ./cmd/supercollider
+
+FROM alpine:latest as certs
+
+RUN apk --update add ca-certificates
+
+FROM debian:stable-slim
+
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Copy the binary from the first stage.
+COPY --from=builder /supercollider /supercollider
+
+# Set the startup command to run the binary
+CMD ["/supercollider"]

--- a/cmd/supercollider/main.go
+++ b/cmd/supercollider/main.go
@@ -8,9 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -28,6 +26,7 @@ import (
 	"github.com/bluesky-social/indigo/plc"
 	"github.com/bluesky-social/indigo/util/version"
 	petname "github.com/dustinkirkland/golang-petname"
+	"github.com/icrowley/fake"
 	"github.com/labstack/echo-contrib/pprof"
 	"github.com/urfave/cli/v2"
 	godid "github.com/whyrusleeping/go-did"
@@ -43,7 +42,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
@@ -73,6 +71,8 @@ type Server struct {
 	// Event Loop Parameters
 	TotalDesiredEvents int
 	MaxEventsPerSecond int
+
+	PlaybackFile string
 }
 
 func main() {
@@ -93,38 +93,72 @@ func main() {
 			Value:   "supercollider.jazco.io",
 			EnvVars: []string{"SUPERCOLLIDER_HOST"},
 		},
-		&cli.StringFlag{
-			Name:    "postgres-url",
-			Usage:   "postgres connection string for CarDB (if not set, will use sqlite in-memory)",
-			EnvVars: []string{"SUPERCOLLIDER_POSTGRES_URL"},
-		},
 		&cli.BoolFlag{
-			Name:  "use-ssl",
-			Usage: "listen on port 443 and use SSL (needs to be run as root and have external DNS setup)",
-			Value: false,
+			Name:    "use-ssl",
+			Usage:   "listen on port 443 and use SSL (needs to be run as root and have external DNS setup)",
+			Value:   false,
+			EnvVars: []string{"SUPERCOLLIDER_USE_SSL"},
 		},
 		&cli.IntFlag{
-			Name:  "port",
-			Usage: "port for the HTTP(S) server to listen on (defaults to 80 if not using SSL, 443 if using SSL)",
+			Name:    "port",
+			Usage:   "port for the HTTP(S) server to listen on (defaults to 80 if not using SSL, 443 if using SSL)",
+			EnvVars: []string{"SUPERCOLLIDER_PORT"},
 		},
-		&cli.IntFlag{
-			Name:  "num-users",
-			Usage: "number of fake users to produce events for",
-			Value: 100,
-		},
-		&cli.IntFlag{
-			Name:  "events-per-second",
-			Usage: "maximum number of events to generate per second",
-			Value: 300,
-		},
-		&cli.IntFlag{
-			Name:  "total-events-per-loop",
-			Usage: "total number of events to generate per loop",
-			Value: 1_000_000,
+
+		&cli.StringFlag{
+			Name:    "key-file",
+			Usage:   "file to store the private key used to sign events",
+			Value:   "key.raw",
+			EnvVars: []string{"KEY_FILE"},
 		},
 	}
 
-	app.Action = Supercollider
+	app.Commands = []*cli.Command{
+		{
+			Name:   "reload",
+			Usage:  "reload events from a file and write them to an output file",
+			Action: Reload,
+			Flags: append([]cli.Flag{
+				&cli.IntFlag{
+					Name:    "num-users",
+					Usage:   "number of fake users to produce events for",
+					Value:   100,
+					EnvVars: []string{"NUM_USERS"},
+				},
+				&cli.IntFlag{
+					Name:    "total-events",
+					Usage:   "total number of events to generate",
+					Value:   1_000_000,
+					EnvVars: []string{"TOTAL_EVENTS"},
+				},
+				&cli.StringFlag{
+					Name:    "output-file",
+					Usage:   "output file for the generated events",
+					Value:   "events_out.cbor",
+					EnvVars: []string{"OUTPUT_FILE"},
+				},
+			}, app.Flags...),
+		},
+		{
+			Name:   "fire",
+			Usage:  "fire events from a file over a websocket",
+			Action: Fire,
+			Flags: append([]cli.Flag{
+				&cli.IntFlag{
+					Name:    "events-per-second",
+					Usage:   "maximum number of events to generate per second",
+					Value:   300,
+					EnvVars: []string{"EVENTS_PER_SECOND"},
+				},
+				&cli.StringFlag{
+					Name:    "input-file",
+					Usage:   "input file for the generated events (if set, will read events from this file instead of generating them)",
+					Value:   "events_in.cbor",
+					EnvVars: []string{"INPUT_FILE"},
+				},
+			}, app.Flags...),
+		},
+	}
 
 	err := app.Run(os.Args)
 	if err != nil {
@@ -132,7 +166,7 @@ func main() {
 	}
 }
 
-func Supercollider(cctx *cli.Context) error {
+func Reload(cctx *cli.Context) error {
 	ctx := cctx.Context
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -168,12 +202,41 @@ func Supercollider(cctx *cli.Context) error {
 
 	log := rawlog.Sugar().With("source", "supercollider_main")
 
-	log.Info("starting supercollider")
+	log.Info("Starting Supercollider in Reload Mode")
+	log.Infof("Generating %d total events and writing them to %s",
+		cctx.Int("total-events"), cctx.String("output-file"))
 
 	em := events.NewEventManager(events.NewYoloPersister())
 
+	// Try to read the key from disk
+	keyBytes, err := os.ReadFile(cctx.String("key-file"))
+	if err != nil {
+		log.Warnf("failed to read key from disk, creating new key: %s", err.Error())
+	}
+
+	var privkey *godid.PrivKey
+	if len(keyBytes) == 0 {
+		privkey, err = godid.GeneratePrivKey(rand.Reader, godid.KeyTypeSecp256k1)
+		if err != nil {
+			log.Fatalf("failed to generate privkey: %+v\n", err)
+		}
+		rawKey, err := privkey.RawBytes()
+		if err != nil {
+			log.Fatalf("failed to serialize privkey: %+v\n", err)
+		}
+		err = os.WriteFile(cctx.String("key-file"), rawKey, 0644)
+		if err != nil {
+			log.Fatalf("failed to write privkey to disk: %+v\n", err)
+		}
+	} else {
+		privkey, err = godid.PrivKeyFromRawBytes(godid.KeyTypeSecp256k1, keyBytes)
+		if err != nil {
+			log.Fatalf("failed to parse privkey from disk: %+v\n", err)
+		}
+	}
+
 	// Configure the repomanager and keypair for our fake accounts
-	repoman, privkey, err := initSpeedyRepoMan(cctx.String("postgres-url"))
+	repoman, privkey, err := initSpeedyRepoMan(privkey)
 	if err != nil {
 		log.Fatalf("failed to init repo manager: %+v\n", err)
 	}
@@ -201,9 +264,204 @@ func Supercollider(cctx *cli.Context) error {
 		Dids:         dids,
 
 		Events:             em,
-		EventControl:       make(chan string),
-		TotalDesiredEvents: cctx.Int("total-events-per-loop"),
+		TotalDesiredEvents: cctx.Int("total-events"),
+	}
+
+	repoman.SetEventHandler(s.HandleRepoEvent)
+
+	// HTTP Server setup and Middleware Plumbing
+	e := echo.New()
+	e.AutoTLSManager.Cache = autocert.DirCache("/var/www/.cache")
+	pprof.Register(e)
+	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
+		Format: "method=${method}, ip=${remote_ip}, uri=${uri}, status=${status} latency=${latency_human} (ua=${user_agent})\n",
+	}))
+
+	e.GET("/", func(c echo.Context) error {
+		return c.HTML(http.StatusOK, `<h1>Supercollider is reloading...</h1>`)
+	})
+	e.GET("/metrics", echo.WrapHandler(promhttp.Handler()))
+
+	port := cctx.Int("port")
+	if port == 0 {
+		if cctx.Bool("use-ssl") {
+			port = 443
+		} else {
+			port = 80
+		}
+	}
+
+	// Start a loop to subscribe to events and write them to a file
+	go func() {
+		outFile := cctx.String("output-file")
+		f, err := os.OpenFile(outFile, os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			log.Fatalf("failed to open output file: %+v\n", err)
+		}
+		defer f.Close()
+		since := int64(0)
+		evts, cancel, err := s.Events.Subscribe(ctx, "supercollider_file", func(evt *events.XRPCStreamEvent) bool {
+			return true
+		}, &since)
+		if err != nil {
+			log.Fatalf("failed to subscribe to events: %+v\n", err)
+		}
+		defer cancel()
+
+		log.Infof("writing events to %s", outFile)
+
+		header := events.EventHeader{Op: events.EvtKindMessage}
+		for {
+			select {
+			case <-ctx.Done():
+				log.Info("shutting down file writer")
+				err = f.Sync()
+				if err != nil {
+					log.Errorf("failed to sync file: %+v\n", err)
+				}
+				err = f.Close()
+				if err != nil {
+					log.Errorf("failed to close file: %+v\n", err)
+				}
+				log.Info("file writer shutdown complete")
+				return
+			case evt := <-evts:
+				if evt.Error != nil {
+					log.Errorf("error in event stream: %+v\n", evt.Error)
+					continue
+				}
+				var obj lexutil.CBOR
+				switch {
+				case evt.Error != nil:
+					header.Op = events.EvtKindErrorFrame
+					obj = evt.Error
+				case evt.RepoCommit != nil:
+					header.MsgType = "#commit"
+					obj = evt.RepoCommit
+				case evt.RepoHandle != nil:
+					header.MsgType = "#handle"
+					obj = evt.RepoHandle
+				case evt.RepoInfo != nil:
+					header.MsgType = "#info"
+					obj = evt.RepoInfo
+				case evt.RepoMigrate != nil:
+					header.MsgType = "#migrate"
+					obj = evt.RepoMigrate
+				case evt.RepoTombstone != nil:
+					header.MsgType = "#tombstone"
+					obj = evt.RepoTombstone
+				default:
+					log.Errorf("unrecognized event kind")
+					continue
+				}
+
+				if err := header.MarshalCBOR(f); err != nil {
+					log.Errorf("failed to write header: %+v\n", err)
+				}
+
+				if err := obj.MarshalCBOR(f); err != nil {
+					log.Errorf("failed to write event: %+v\n", err)
+				}
+			}
+		}
+	}()
+
+	// Start the event generation loop
+	go func() {
+		time.Sleep(time.Second * 5)
+		s.EventGenerationLoop(ctx)
+	}()
+
+	listenAddress := fmt.Sprintf(":%d", port)
+	if cctx.Bool("use-ssl") {
+		err = e.StartAutoTLS(listenAddress)
+	} else {
+		err = e.Start(listenAddress)
+	}
+	if err != nil {
+		log.Errorf("failed to start server: %+v\n", err)
+	}
+	return nil
+}
+
+func Fire(cctx *cli.Context) error {
+	ctx := cctx.Context
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Trap SIGINT to trigger a shutdown.
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		select {
+		case <-signals:
+			cancel()
+			fmt.Println("shutting down on signal")
+			// Give the server some time to shutdown gracefully, then exit.
+			time.Sleep(time.Second * 5)
+			os.Exit(0)
+		case <-ctx.Done():
+			fmt.Println("shutting down on context done")
+		}
+	}()
+
+	rawlog, err := zap.NewDevelopment()
+	if err != nil {
+		log.Fatalf("failed to create logger: %+v\n", err)
+	}
+	defer func() {
+		log.Printf("main function teardown\n")
+		err := rawlog.Sync()
+		if err != nil {
+			log.Printf("failed to sync logger on teardown: %+v", err.Error())
+		}
+	}()
+
+	log := rawlog.Sugar().With("source", "supercollider_main")
+
+	log.Info("Starting Supercollider in Fire Mode")
+
+	// Try to read the key from disk
+	keyBytes, err := os.ReadFile(cctx.String("key-file"))
+	if err != nil {
+		log.Warnf("failed to read key from disk, creating new key: %s", err.Error())
+	}
+
+	var privkey *godid.PrivKey
+	if len(keyBytes) == 0 {
+		privkey, err = godid.GeneratePrivKey(rand.Reader, godid.KeyTypeSecp256k1)
+		if err != nil {
+			log.Fatalf("failed to generate privkey: %+v\n", err)
+		}
+		rawKey, err := privkey.RawBytes()
+		if err != nil {
+			log.Fatalf("failed to serialize privkey: %+v\n", err)
+		}
+		err = os.WriteFile(cctx.String("key-file"), rawKey, 0644)
+		if err != nil {
+			log.Fatalf("failed to write privkey to disk: %+v\n", err)
+		}
+	} else {
+		privkey, err = godid.PrivKeyFromRawBytes(godid.KeyTypeSecp256k1, keyBytes)
+		if err != nil {
+			log.Fatalf("failed to parse privkey from disk: %+v\n", err)
+		}
+	}
+
+	vMethod, err := godid.VerificationMethodFromKey(privkey.Public())
+	if err != nil {
+		log.Fatalf("failed to generate verification method: %+v\n", err)
+	}
+
+	// Instantiate Server
+	s := &Server{
+		Logger:             log,
+		EnableSSL:          cctx.Bool("use-ssl"),
+		Host:               cctx.String("hostname"),
+		MultibaseKey:       *vMethod.PublicKeyMultibase,
 		MaxEventsPerSecond: cctx.Int("events-per-second"),
+		PlaybackFile:       cctx.String("input-file"),
 	}
 
 	// HTTP Server setup and Middleware Plumbing
@@ -238,18 +496,14 @@ func Supercollider(cctx *cli.Context) error {
 	}
 
 	e.GET("/", func(c echo.Context) error {
-		return c.HTML(http.StatusOK, `<h1>Welcome to Supercollider!</h1>`)
+		return c.HTML(http.StatusOK, `<h1>Supercollider is firing...</h1>`)
 	})
-
-	repoman.SetEventHandler(s.HandleRepoEvent)
 
 	e.GET("/.well-known/did.json", s.HandleWellKnownDid)
 	e.GET("/.well-known/atproto-did", s.HandleAtprotoDid)
 	e.GET("/xrpc/com.atproto.server.describeServer", s.DescribeServerHandler)
 	e.GET("/xrpc/com.atproto.sync.subscribeRepos", s.HandleSubscribeRepos)
 	e.GET("/metrics", echo.WrapHandler(promhttp.Handler()))
-	e.GET("/generate", s.HandleStartGenerating)
-	e.GET("/stop", s.HandleStopGenerating)
 
 	port := cctx.Int("port")
 	if port == 0 {
@@ -259,8 +513,6 @@ func Supercollider(cctx *cli.Context) error {
 			port = 80
 		}
 	}
-
-	go s.EventGenerationLoop(ctx, cctx.String("postgres-url") != "")
 
 	listenAddress := fmt.Sprintf(":%d", port)
 	if cctx.Bool("use-ssl") {
@@ -292,34 +544,16 @@ func setupDb(p string) (*gorm.DB, error) {
 	return db, nil
 }
 
-// Configure a Postgres SqliteDB
-func setupPostgresDb(p string) (*gorm.DB, error) {
-	db, err := gorm.Open(postgres.Open(p), &gorm.Config{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to open db: %w", err)
-	}
-
-	return db, nil
-}
-
 // Stand up a Repo Manager with a Web DID Resolver
-func initSpeedyRepoMan(postgresString string) (*repomgr.RepoManager, *godid.PrivKey, error) {
+func initSpeedyRepoMan(key *godid.PrivKey) (*repomgr.RepoManager, *godid.PrivKey, error) {
 	dir, err := os.MkdirTemp("", "supercollider")
 	if err != nil {
 		return nil, nil, err
 	}
 
-	var cardb *gorm.DB
-	if postgresString != "" {
-		cardb, err = setupPostgresDb(postgresString)
-		if err != nil {
-			return nil, nil, err
-		}
-	} else {
-		cardb, err = setupDb("file::memory:?cache=shared")
-		if err != nil {
-			return nil, nil, err
-		}
+	cardb, err := setupDb("file::memory:?cache=shared")
+	if err != nil {
+		return nil, nil, err
 	}
 
 	cspath := filepath.Join(dir, "carstore")
@@ -338,11 +572,6 @@ func initSpeedyRepoMan(postgresString string) (*repomgr.RepoManager, *godid.Priv
 	})
 
 	cachedidr := plc.NewCachingDidResolver(mr, time.Minute*5, 1000)
-
-	key, err := godid.GeneratePrivKey(rand.Reader, godid.KeyTypeSecp256k1)
-	if err != nil {
-		return nil, nil, err
-	}
 
 	kmgr := indexer.NewKeyManager(cachedidr, key)
 
@@ -382,105 +611,43 @@ func (s *Server) HandleRepoEvent(ctx context.Context, evt *repomgr.RepoEvent) {
 	}
 }
 
-// Event Generation Loop and Control
-
 // EventGenerationLoop is the main loop for generating events
-func (s *Server) EventGenerationLoop(ctx context.Context, concurrent bool) {
-	running := false
-	totalEmittedEvents := 0
+func (s *Server) EventGenerationLoop(ctx context.Context) {
+	s.Logger.Infof("starting event generation for %d events", s.TotalDesiredEvents)
 
-	// We want to produce events at a maximum rate to prevent the buffer from overrunning
-	limiter := rate.NewLimiter(rate.Limit(s.MaxEventsPerSecond), 10)
-
-	s.Logger.Infof("starting event generation loop with %d desired events and %d evt/s maximum\n",
-		s.TotalDesiredEvents, s.MaxEventsPerSecond,
-	)
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case cmd := <-s.EventControl:
-			switch cmd {
-			case "start":
-				running = true
-			case "stop":
-				running = false
-				totalEmittedEvents = 0
-			}
-		default:
-			if !running {
-				time.Sleep(time.Second)
-				continue
-			}
-			for i, did := range s.Dids {
-				uid := models.Uid(i + 1)
-				if err := s.RepoManager.InitNewActor(ctx, uid, strings.TrimPrefix(did, "did:web:"), did, "catdog", "", ""); err != nil {
-					log.Fatalf("failed to init actor: %+v\n", err)
-				}
-			}
-
-			if concurrent {
-				recordsPerActor := s.TotalDesiredEvents / len(s.Dids)
-				wg := sync.WaitGroup{}
-				for i := 0; i < len(s.Dids); i++ {
-					wg.Add(1)
-					go func(i int) {
-						for j := 0; j < recordsPerActor; j++ {
-							limiter.Wait(ctx)
-							_, _, err := s.RepoManager.CreateRecord(ctx, models.Uid(i+1), "app.bsky.feed.post", &bsky.FeedPost{
-								Text: "cats",
-							})
-							if err != nil {
-								s.Logger.Errorf("failed to create record: %+v\n", err)
-							} else {
-								eventsGeneratedCounter.Inc()
-							}
-							select {
-							case <-ctx.Done():
-								return
-							default:
-							}
-						}
-					}(i)
-				}
-				wg.Wait()
-			} else {
-				for i := 0; i < s.TotalDesiredEvents; i++ {
-					limiter.Wait(ctx)
-					_, _, err := s.RepoManager.CreateRecord(ctx, models.Uid(i%len(s.Dids)+1), "app.bsky.feed.post", &bsky.FeedPost{
-						Text: "cats",
-					})
-					if err != nil {
-						s.Logger.Errorf("failed to create record: %+v\n", err)
-					} else {
-						eventsGeneratedCounter.Inc()
-					}
-					select {
-					case <-ctx.Done():
-						return
-					default:
-					}
-				}
-			}
-
-			s.Logger.Infof("emitted %d events, stopping\n", totalEmittedEvents)
-			s.EventControl <- "stop"
-			break
+	s.Logger.Infof("initializing %d fake users", len(s.Dids))
+	for i, did := range s.Dids {
+		uid := models.Uid(i + 1)
+		if err := s.RepoManager.InitNewActor(ctx, uid, strings.TrimPrefix(did, "did:web:"), did, "catdog", "", ""); err != nil {
+			log.Fatalf("failed to init actor: %+v\n", err)
 		}
 	}
-}
 
-// HandleStartGenerating starts the event generation loop
-func (s *Server) HandleStartGenerating(ctx echo.Context) error {
-	s.EventControl <- "start"
-	return ctx.String(200, "stream started")
-}
+	s.Logger.Infof("generating %d events", s.TotalDesiredEvents)
 
-// HandleStopGenerating stops the event generation loop
-func (s *Server) HandleStopGenerating(ctx echo.Context) error {
-	s.EventControl <- "stop"
-	return ctx.String(200, "stream stopped")
+	for i := 0; i < s.TotalDesiredEvents; i++ {
+		text := fake.SentencesN(3)
+		// Trim to 300 chars
+		if len(text) > 300 {
+			text = text[:300]
+		}
+		_, _, err := s.RepoManager.CreateRecord(ctx, models.Uid(i%len(s.Dids)+1), "app.bsky.feed.post", &bsky.FeedPost{
+			CreatedAt: time.Now().Format(util.ISO8601),
+			Text:      text,
+		})
+		if err != nil {
+			s.Logger.Errorf("failed to create record: %+v\n", err)
+		} else {
+			eventsGeneratedCounter.Inc()
+		}
+		select {
+		case <-ctx.Done():
+			s.Logger.Infof("shutting down event generation loop on context done")
+			return
+		default:
+		}
+	}
+	return
 }
 
 // ATProto Handlers for DID Web
@@ -534,75 +701,67 @@ func (s *Server) HandleSubscribeRepos(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-
-	var cursor *int64
-
-	if c.QueryParam("cursor") != "" {
-		cursorFromQuery, err := strconv.ParseInt(c.QueryParam("cursor"), 10, 64)
-		if err != nil {
-			return err
-		}
-		cursor = &cursorFromQuery
-	}
+	defer conn.Close()
 
 	ctx := c.Request().Context()
 
-	ident := c.Request().RemoteAddr + "-" + c.Request().UserAgent()
+	limiter := rate.NewLimiter(rate.Limit(s.MaxEventsPerSecond), 10)
 
-	evts, cancel, err := s.Events.Subscribe(ctx, ident, func(evt *events.XRPCStreamEvent) bool {
-		return true
-	}, cursor)
+	f, err := os.Open(s.PlaybackFile)
 	if err != nil {
+		s.Logger.Errorf("failed to open playback file: %+v\n", err)
 		return err
 	}
-	defer cancel()
+	defer f.Close()
 
-	header := events.EventHeader{Op: events.EvtKindMessage}
-	for evt := range evts {
+	header := events.EventHeader{}
+	for {
 		wc, err := conn.NextWriter(websocket.BinaryMessage)
 		if err != nil {
 			return err
 		}
 
-		var obj lexutil.CBOR
-
-		switch {
-		case evt.Error != nil:
-			header.Op = events.EvtKindErrorFrame
-			obj = evt.Error
-		case evt.RepoCommit != nil:
-			header.MsgType = "#commit"
-			obj = evt.RepoCommit
-		case evt.RepoHandle != nil:
-			header.MsgType = "#handle"
-			obj = evt.RepoHandle
-		case evt.RepoInfo != nil:
-			header.MsgType = "#info"
-			obj = evt.RepoInfo
-		case evt.RepoMigrate != nil:
-			header.MsgType = "#migrate"
-			obj = evt.RepoMigrate
-		case evt.RepoTombstone != nil:
-			header.MsgType = "#tombstone"
-			obj = evt.RepoTombstone
-		default:
-			return fmt.Errorf("unrecognized event kind")
+		limiter.Wait(ctx)
+		if err := header.UnmarshalCBOR(f); err != nil {
+			return fmt.Errorf("failed to read header: %w", err)
 		}
 
+		var obj lexutil.CBOR
+
+		switch header.Op {
+		case events.EvtKindMessage:
+			switch header.MsgType {
+			case "#commit":
+				obj = &comatproto.SyncSubscribeRepos_Commit{}
+			case "#handle":
+				obj = &comatproto.SyncSubscribeRepos_Handle{}
+			case "#info":
+				obj = &comatproto.SyncSubscribeRepos_Info{}
+			case "#migrate":
+				obj = &comatproto.SyncSubscribeRepos_Migrate{}
+			case "#tombstone":
+				obj = &comatproto.SyncSubscribeRepos_Tombstone{}
+			default:
+				return fmt.Errorf("unrecognized message type: %s", header.MsgType)
+			}
+		case events.EvtKindErrorFrame:
+			return fmt.Errorf("got error frame: %d", header.Op)
+		default:
+			return fmt.Errorf("unrecognized event kind: %d", header.Op)
+		}
+
+		if err := obj.UnmarshalCBOR(f); err != nil {
+			return fmt.Errorf("failed to read event: %w", err)
+		}
 		if err := header.MarshalCBOR(wc); err != nil {
 			return fmt.Errorf("failed to write header: %w", err)
 		}
-
 		if err := obj.MarshalCBOR(wc); err != nil {
 			return fmt.Errorf("failed to write event: %w", err)
 		}
-
 		if err := wc.Close(); err != nil {
 			return fmt.Errorf("failed to flush-close our event write: %w", err)
 		}
-
 		eventsSentCounter.Inc()
 	}
-
-	return nil
 }

--- a/cmd/supercollider/main.go
+++ b/cmd/supercollider/main.go
@@ -371,7 +371,7 @@ func Reload(cctx *cli.Context) error {
 	// Start the event generation loop
 	go func() {
 		time.Sleep(time.Second * 5)
-		s.EventGenerationLoop(ctx)
+		s.EventGenerationLoop(ctx, cancel)
 	}()
 
 	listenAddress := fmt.Sprintf(":%d", port)
@@ -614,7 +614,8 @@ func (s *Server) HandleRepoEvent(ctx context.Context, evt *repomgr.RepoEvent) {
 }
 
 // EventGenerationLoop is the main loop for generating events
-func (s *Server) EventGenerationLoop(ctx context.Context) {
+func (s *Server) EventGenerationLoop(ctx context.Context, cancel context.CancelFunc) {
+	defer cancel()
 	s.Logger.Infof("starting event generation for %d events", s.TotalDesiredEvents)
 
 	s.Logger.Infof("initializing %d fake users", len(s.Dids))
@@ -649,6 +650,8 @@ func (s *Server) EventGenerationLoop(ctx context.Context) {
 		default:
 		}
 	}
+
+	s.Logger.Infof("event generation complete, shutting down")
 	return
 }
 

--- a/events/metrics.go
+++ b/events/metrics.go
@@ -6,36 +6,36 @@ import (
 )
 
 var eventsFromStreamCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "repo_stream_events_received_total",
+	Name: "indigo_repo_stream_events_received_total",
 	Help: "Total number of events received from the stream",
 }, []string{"remote_addr"})
 
 var bytesFromStreamCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "repo_stream_bytes_total",
+	Name: "indigo_repo_stream_bytes_total",
 	Help: "Total bytes received from the stream",
 }, []string{"remote_addr"})
 
 var workItemsAdded = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "work_items_added_total",
+	Name: "indigo_work_items_added_total",
 	Help: "Total number of work items added to the consumer pool",
 }, []string{"pool"})
 
 var workItemsProcessed = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "work_items_processed_total",
+	Name: "indigo_work_items_processed_total",
 	Help: "Total number of work items processed by the consumer pool",
 }, []string{"pool"})
 
 var workItemsActive = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "work_items_active_total",
+	Name: "indigo_work_items_active_total",
 	Help: "Total number of work items passed into a worker",
 }, []string{"pool"})
 
 var eventsEnqueued = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "events_enqueued_for_broadcast_total",
+	Name: "indigo_events_enqueued_for_broadcast_total",
 	Help: "Total number of events enqueued to broadcast to subscribers",
 }, []string{"pool"})
 
 var eventsBroadcast = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "events_broadcast_total",
+	Name: "indigo_events_broadcast_total",
 	Help: "Total number of events broadcast to subscribers",
 }, []string{"pool"})

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/hashicorp/golang-lru v0.5.4
+	github.com/icrowley/fake v0.0.0-20221112152111-d7b7e2276db2
 	github.com/ipfs/go-block-format v0.1.2
 	github.com/ipfs/go-bs-sqlite3 v0.0.0-20221122195556-bfcee1be620d
 	github.com/ipfs/go-cid v0.4.1
@@ -64,6 +65,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/corpix/uarand v0.0.0-20170723150923-031be390f409 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/corpix/uarand v0.0.0-20170723150923-031be390f409 h1:9A+mfQmwzZ6KwUXPc8nHxFtKgn9VIvO3gXAOspIcE3s=
+github.com/corpix/uarand v0.0.0-20170723150923-031be390f409/go.mod h1:JSm890tOkDN+M1jqN8pUGDKnzJrsVbJwSMHBY4zwz7M=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -229,6 +231,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/huin/goupnp v1.0.3 h1:N8No57ls+MnjlB+JPiCVSOyy/ot7MJTqlo7rn+NYSqQ=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/icrowley/fake v0.0.0-20221112152111-d7b7e2276db2 h1:qU3v73XG4QAqCPHA4HOpfC1EfUvtLIDvQK4mNQ0LvgI=
+github.com/icrowley/fake v0.0.0-20221112152111-d7b7e2276db2/go.mod h1:dQ6TM/OGAe+cMws81eTe4Btv1dKxfPZ2CX+YaAFAPN4=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
 github.com/ipfs/go-bitfield v1.1.0 h1:fh7FIo8bSwaJEh6DdTWbCeZ1eqOaOkKFI74SCnsWbGA=


### PR DESCRIPTION
This change refactors Supercollider to support two different modes: Reload and Fire.

In Reload mode, Supercollider generates a specified number of events as quickly as it can and writes the CBOR to a file. It uses in-memory SQLite for the repo manager and I've benched it at around 2.2k evt/sec for generation.

The static file includes creation of the repos and all the repo appends for lots of Posts. 2 Million events takes around 16 minutes to produce. We call this a loaded magazine.

In Fire mode, Supercollider will fire the magazine of events at any client that connects to the subscribe repos endpoint. Since we're reading from a file, we can go as fast as the socket can handle, though we also accept a flag to limit emission rate if we want to for any reason.

This method allows us to get significantly higher rates (tested at >10k evt/sec) of event emission for benchmarking a repo stream consumer like the BGS.

You need to reload between firing only if the consumer has durable repo state, if you blow away the DB on the consumer between runs, you don't need to reload since we can play the repos over from creation again without issue.