### PR TITLE
Skip JWT middleware for `com.atproto.server.createSession` RPC in PDS

### DIFF
--- a/pds/server.go
+++ b/pds/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/whyrusleeping/go-did"
 	"gorm.io/gorm"
 )
 

--- a/pds/server.go
+++ b/pds/server.go
@@ -33,7 +33,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/lestrrat-go/jwx/v2/jwt"
-	"github.com/whyrusleeping/go-did"
 	"gorm.io/gorm"
 )
 
@@ -308,6 +307,8 @@ func (s *Server) RunAPIWithListener(listen net.Listener) error {
 			case "/xrpc/com.atproto.identity.resolveHandle":
 				return true
 			case "/xrpc/com.atproto.server.createAccount":
+				return true
+			case "/xrpc/com.atproto.server.createSession":
 				return true
 			case "/xrpc/com.atproto.server.describeServer":
 				return true


### PR DESCRIPTION
Hey there - I'm trying to build out an E2E test suite based on the PDS implementation included here.

It looks like `com.atproto.server.createSession` has the JWT Auth middleware running on it, which prevents me calling this RPC in order to log in. As far as I can tell, the handler has been implemented for this RPC correctly (`pds/Server.handleComAtprotoServerCreateSession`) - it's just not possible to call it.