### PR TITLE
Only ping a consumer if we haven't written _anything_ in a while

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -474,11 +474,12 @@ func (bgs *BGS) EventsHandler(c echo.Context) error {
 			select {
 			case <-ticker.C:
 				lastWriteLk.RLock()
-				if time.Since(lastWrite) < 30*time.Second {
-					lastWriteLk.RUnlock()
+				lw := lastWrite
+				lastWriteLk.RUnlock()
+
+				if time.Since(lw) < 30*time.Second {
 					continue
 				}
-				lastWriteLk.RUnlock()
 
 				if err := conn.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(5*time.Second)); err != nil {
 					log.Errorf("failed to ping client: %s", err)

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -478,7 +478,6 @@ func (bgs *BGS) EventsHandler(c echo.Context) error {
 				lastWriteLk.Unlock()
 
 				if time.Since(lw) < 30*time.Second {
-					log.Infof("client %s is still alive", c.RealIP())
 					continue
 				}
 


### PR DESCRIPTION
Consumer timeout checking is great but if we're playing back a TON of events, the ping ends up deep in a backlog and out 5 second timeout on the ping doesn't make sense so let's keep track of the last time we successfully wrote to the consumer and only try to ping if it's been 30 seconds since our last write.