### PR TITLE
Require bluesky-social/indigo for Container Build & Push

### DIFF
--- a/.github/workflows/container-beemo-ghcr.yaml
+++ b/.github/workflows/container-beemo-ghcr.yaml
@@ -1,4 +1,4 @@
-name: container-beemo-ghcr.yaml
+name: container-beemo-ghcr
 on:
   push:
     branches:
@@ -9,7 +9,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  container-beemo-ghcr:
     if: github.repository == 'bluesky-social/indigo'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/container-beemo-ghcr.yaml
+++ b/.github/workflows/container-beemo-ghcr.yaml
@@ -10,6 +10,7 @@ env:
 
 jobs:
   build:
+    if: github.repository == 'bluesky-social/indigo'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/container-bigsky-aws.yaml
+++ b/.github/workflows/container-bigsky-aws.yaml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   container-bigsky-aws:
+    if: github.repository == 'bluesky-social/indigo'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/container-bigsky-ghcr.yaml
+++ b/.github/workflows/container-bigsky-ghcr.yaml
@@ -10,6 +10,7 @@ env:
 
 jobs:
   container-bigsky-ghcr:
+    if: github.repository == 'bluesky-social/indigo'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/container-labelmaker-ghcr.yaml
+++ b/.github/workflows/container-labelmaker-ghcr.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    if: github.repository == 'bluesky-social/indigo'
+    if: github.repository == 'bluesky-social/indigo' || github.repository == 'bnewbold/indigo'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/container-labelmaker-ghcr.yaml
+++ b/.github/workflows/container-labelmaker-ghcr.yaml
@@ -1,4 +1,4 @@
-name: container-labelmaker-ghcr.yaml
+name: container-labelmaker-ghcr
 on:
   push:
     branches:
@@ -10,7 +10,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  container-labelmaker-ghcr:
     if: github.repository == 'bluesky-social/indigo' || github.repository == 'bnewbold/indigo'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/container-labelmaker-ghcr.yaml
+++ b/.github/workflows/container-labelmaker-ghcr.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   container-labelmaker-ghcr:
-    if: github.repository == 'bluesky-social/indigo' || github.repository == 'bnewbold/indigo'
+    if: github.repository == 'bluesky-social/indigo'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/container-labelmaker-ghcr.yaml
+++ b/.github/workflows/container-labelmaker-ghcr.yaml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build:
+    if: github.repository == 'bluesky-social/indigo'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/container-palomar-aws.yaml
+++ b/.github/workflows/container-palomar-aws.yaml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   container-palomar-aws:
+    if: github.repository == 'bluesky-social/indigo'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/container-palomar-ghcr.yaml
+++ b/.github/workflows/container-palomar-ghcr.yaml
@@ -10,6 +10,7 @@ env:
 
 jobs:
   container-palomar-ghcr:
+    if: github.repository == 'bluesky-social/indigo'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Counterpart: https://github.com/bluesky-social/atproto/pull/1460

This PR runs the actions only for the original `bluesky-social/indigo` repository on the `main` branch.

It also contains very minor workflow cleanup for consistency.

Do not merge if you wish to build and push main branches from other repositories.