### PR TITLE
Use a bigger write buffer for consumer websockets

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -514,6 +514,18 @@ func (bgs *BGS) EventsHandler(c echo.Context) error {
 		return err
 	})
 
+	// Start a goroutine to read messages from the client and discard them.
+	go func() {
+		for {
+			_, _, err := conn.ReadMessage()
+			if err != nil {
+				log.Errorf("failed to read message from client: %s", err)
+				cancel()
+				return
+			}
+		}
+	}()
+
 	ident := c.RealIP() + "-" + c.Request().UserAgent()
 
 	evts, cleanup, err := bgs.events.Subscribe(ctx, ident, func(evt *events.XRPCStreamEvent) bool { return true }, since)

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -467,7 +467,7 @@ func (bgs *BGS) EventsHandler(c echo.Context) error {
 	defer cancel()
 
 	// TODO: authhhh
-	conn, err := websocket.Upgrade(c.Response(), c.Request(), c.Response().Header(), 1<<20, 1<<20)
+	conn, err := websocket.Upgrade(c.Response(), c.Request(), c.Response().Header(), 10<<10, 10<<10)
 	if err != nil {
 		return fmt.Errorf("upgrading websocket: %w", err)
 	}

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -467,7 +467,7 @@ func (bgs *BGS) EventsHandler(c echo.Context) error {
 	defer cancel()
 
 	// TODO: authhhh
-	conn, err := websocket.Upgrade(c.Response(), c.Request(), c.Response().Header(), 10<<10, 10<<10)
+	conn, err := websocket.Upgrade(c.Response(), c.Request(), c.Response().Header(), 1<<20, 1<<20)
 	if err != nil {
 		return fmt.Errorf("upgrading websocket: %w", err)
 	}

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -467,7 +467,7 @@ func (bgs *BGS) EventsHandler(c echo.Context) error {
 	defer cancel()
 
 	// TODO: authhhh
-	conn, err := websocket.Upgrade(c.Response(), c.Request(), c.Response().Header(), 1<<10, 1<<10)
+	conn, err := websocket.Upgrade(c.Response(), c.Request(), c.Response().Header(), 10<<10, 10<<10)
 	if err != nil {
 		return fmt.Errorf("upgrading websocket: %w", err)
 	}

--- a/cmd/bigsky/main.go
+++ b/cmd/bigsky/main.go
@@ -120,6 +120,16 @@ func run(args []string) {
 			Name:    "handle-resolver-hosts",
 			EnvVars: []string{"HANDLE_RESOLVER_HOSTS"},
 		},
+		&cli.IntFlag{
+			Name:    "max-carstore-connections",
+			EnvVars: []string{"MAX_CARSTORE_CONNECTIONS"},
+			Value:   40,
+		},
+		&cli.IntFlag{
+			Name:    "max-metadb-connections",
+			EnvVars: []string{"MAX_METADB_CONNECTIONS"},
+			Value:   40,
+		},
 	}
 
 	app.Action = Bigsky
@@ -197,13 +207,13 @@ func Bigsky(cctx *cli.Context) error {
 	}
 
 	dburl := cctx.String("db-url")
-	db, err := cliutil.SetupDatabase(dburl)
+	db, err := cliutil.SetupDatabase(dburl, cctx.Int("max-metadb-connections"))
 	if err != nil {
 		return err
 	}
 
 	csdburl := cctx.String("carstore-db-url")
-	csdb, err := cliutil.SetupDatabase(csdburl)
+	csdb, err := cliutil.SetupDatabase(csdburl, cctx.Int("max-carstore-connections"))
 	if err != nil {
 		return err
 	}

--- a/cmd/labelmaker/main.go
+++ b/cmd/labelmaker/main.go
@@ -141,6 +141,16 @@ func run(args []string) error {
 			Usage:   "SQRL API endpoint (full URL)",
 			EnvVars: []string{"LABELMAKER_SQRL_URL"},
 		},
+		&cli.IntFlag{
+			Name:    "max-carstore-connections",
+			EnvVars: []string{"MAX_CARSTORE_CONNECTIONS"},
+			Value:   40,
+		},
+		&cli.IntFlag{
+			Name:    "max-metadb-connections",
+			EnvVars: []string{"MAX_METADB_CONNECTIONS"},
+			Value:   40,
+		},
 	}
 
 	app.Action = func(cctx *cli.Context) error {
@@ -152,13 +162,13 @@ func run(args []string) error {
 		repoKeyPath := filepath.Join(datadir, "labelmaker.key")
 
 		dburl := cctx.String("db-url")
-		db, err := cliutil.SetupDatabase(dburl)
+		db, err := cliutil.SetupDatabase(dburl, cctx.Int("max-metadb-connections"))
 		if err != nil {
 			return err
 		}
 
 		csdburl := cctx.String("carstore-db-url")
-		csdb, err := cliutil.SetupDatabase(csdburl)
+		csdb, err := cliutil.SetupDatabase(csdburl, cctx.Int("max-carstore-connections"))
 		if err != nil {
 			return err
 		}

--- a/cmd/laputa/main.go
+++ b/cmd/laputa/main.go
@@ -85,6 +85,16 @@ func run(args []string) {
 			Value:   ".test",
 			EnvVars: []string{"ATP_PDS_HANDLE_DOMAINS"},
 		},
+		&cli.IntFlag{
+			Name:    "max-carstore-connections",
+			EnvVars: []string{"MAX_CARSTORE_CONNECTIONS"},
+			Value:   40,
+		},
+		&cli.IntFlag{
+			Name:    "max-metadb-connections",
+			EnvVars: []string{"MAX_METADB_CONNECTIONS"},
+			Value:   40,
+		},
 	}
 
 	app.Commands = []*cli.Command{
@@ -128,13 +138,13 @@ func run(args []string) {
 		os.MkdirAll(csdir, os.ModePerm)
 
 		// default postgres setup: postgresql://postgres:password@localhost:5432/pdsdb?sslmode=disable
-		db, err := cliutil.SetupDatabase(cctx.String("db-url"))
+		db, err := cliutil.SetupDatabase(cctx.String("db-url"), cctx.Int("max-metadb-connections"))
 		if err != nil {
 			return err
 		}
 
 		// default postgres setup: postgresql://postgres:password@localhost:5432/cardb?sslmode=disable
-		csdb, err := cliutil.SetupDatabase(cctx.String("carstore-db-url"))
+		csdb, err := cliutil.SetupDatabase(cctx.String("carstore-db-url"), cctx.Int("max-carstore-connections"))
 		if err != nil {
 			return err
 		}

--- a/cmd/palomar/main.go
+++ b/cmd/palomar/main.go
@@ -90,6 +90,11 @@ func run(args []string) error {
 			Value:   "https://bsky.social",
 			EnvVars: []string{"ATP_PDS_HOST"},
 		},
+		&cli.IntFlag{
+			Name:    "max-metadb-connections",
+			EnvVars: []string{"MAX_METADB_CONNECTIONS"},
+			Value:   40,
+		},
 	}
 
 	app.Commands = []*cli.Command{
@@ -123,7 +128,7 @@ var runCmd = &cli.Command{
 		},
 	},
 	Action: func(cctx *cli.Context) error {
-		db, err := cliutil.SetupDatabase(cctx.String("database-url"))
+		db, err := cliutil.SetupDatabase(cctx.String("database-url"), cctx.Int("max-metadb-connections"))
 		if err != nil {
 			return err
 		}

--- a/pds/handlers_test.go
+++ b/pds/handlers_test.go
@@ -39,7 +39,7 @@ func testCarStore(t *testing.T, db *gorm.DB) (*carstore.CarStore, func()) {
 
 func newTestServer(t *testing.T) (*Server, func()) {
 	t.Helper()
-	db, err := cliutil.SetupDatabase("sqlite://:memory:")
+	db, err := cliutil.SetupDatabase("sqlite://:memory:", 40)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/util/cliutil/util.go
+++ b/util/cliutil/util.go
@@ -164,7 +164,7 @@ func SetupDatabase(dburl string) (*gorm.DB, error) {
 	// NOTE(bnewbold): might also handle file:// as sqlite, but let's keep it
 	// explicit for now
 
-	openConns := 99
+	openConns := 40
 	if strings.HasPrefix(dburl, "sqlite://") {
 		sqliteSuffix := dburl[len("sqlite://"):]
 		// if this isn't ":memory:", ensure that directory exists (eg, if db

--- a/util/cliutil/util.go
+++ b/util/cliutil/util.go
@@ -159,12 +159,12 @@ func ReadAuth(fname string) (*xrpc.AuthInfo, error) {
 // - "sqlite://file.sqlite"
 // - "postgres=host=localhost user=postgres password=password dbname=pdsdb port=5432 sslmode=disable"
 // - "postgresql://postgres:password@localhost:5432/pdsdb?sslmode=disable"
-func SetupDatabase(dburl string) (*gorm.DB, error) {
+func SetupDatabase(dburl string, maxConnections int) (*gorm.DB, error) {
 	var dial gorm.Dialector
 	// NOTE(bnewbold): might also handle file:// as sqlite, but let's keep it
 	// explicit for now
 
-	openConns := 40
+	openConns := maxConnections
 	if strings.HasPrefix(dburl, "sqlite://") {
 		sqliteSuffix := dburl[len("sqlite://"):]
 		// if this isn't ":memory:", ensure that directory exists (eg, if db


### PR DESCRIPTION
Network latency has a massively bad impact on subscribe throughput right now, we suspect it might be due to write buffer sizes on the websocket connection.