### PR TITLE
mst: use sha256-simd for hashing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/labstack/echo/v4 v4.10.2
 	github.com/labstack/gommon v0.4.0
 	github.com/lestrrat-go/jwx/v2 v2.0.11
+	github.com/minio/sha256-simd v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multihash v0.2.1
 	github.com/opensearch-project/opensearch-go/v2 v2.2.0
@@ -111,7 +112,6 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-sqlite3 v1.14.15 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
-	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect

--- a/mst/mst_util.go
+++ b/mst/mst_util.go
@@ -4,13 +4,13 @@ package mst
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"strings"
 	"unsafe"
 
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
+	sha256 "github.com/minio/sha256-simd"
 )
 
 // Used to determine the "depth" of keys in an MST.


### PR DESCRIPTION
This was about a 2x gain for me on my laptop, using go v1.20, for the hot `BenchmarkLeadingZerosOnHash` method (called on every key inserted in to a MST):

```
bnewbold@snocat:~/code/indigo/mst$ go test -run '^$' -bench=. -run=^#
goos: linux
goarch: amd64
pkg: github.com/bluesky-social/indigo/mst
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
BenchmarkIsValidMstKey-8        	64364982	       17.11 ns/op	      0 B/op	      0 allocs/op
BenchmarkLeadingZerosOnHash-8   	6786610	      175.9 ns/op	      0 B/op	      0 allocs/op
BenchmarkDiffTrees-8            	     72	 18111121 ns/op	11194858 B/op	 121144 allocs/op
BenchmarkCountPrefixLen-8       	51624517	       21.88 ns/op	      0 B/op	      0 allocs/op

---

bnewbold@snocat:~/code/indigo/mst$ go test -run '^$' -bench=. -run=^#
goos: linux
goarch: amd64
pkg: github.com/bluesky-social/indigo/mst
cpu: 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
BenchmarkIsValidMstKey-8        	70019479	       16.57 ns/op	      0 B/op	      0 allocs/op
BenchmarkLeadingZerosOnHash-8   	18166948	       67.35 ns/op	      0 B/op	      0 allocs/op
BenchmarkDiffTrees-8            	     92	 18464875 ns/op	11196483 B/op	 121144 allocs/op
BenchmarkCountPrefixLen-8       	46568814	       26.81 ns/op	      0 B/op	      0 allocs/op
```

Newer golang has a speedup in the stdlib version, but not as much of a speedup as this.

I believe this helps significantly with repo mutation operations, and could help with deep verification of untrusted input if we were verifying hashes.

The package was already in our dependency tree.

cc: @ericvolp12 