### PR TITLE
track no longer referenced blocks, delete refs

### DIFF
--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -802,6 +802,10 @@ func BlockDiff(ctx context.Context, bs blockstore.Blockstore, oldroot cid.Cid, n
 	ctx, span := otel.Tracer("repo").Start(ctx, "BlockDiff")
 	defer span.End()
 
+	if !oldroot.Defined() {
+		return map[cid.Cid]bool{}, nil
+	}
+
 	// walk the entire 'new' portion of the tree, marking all referenced cids as 'keep'
 	keepset := make(map[cid.Cid]bool)
 	for _, c := range newcids {

--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -81,6 +81,7 @@ type blockRef struct {
 	Cid    models.DbCID `gorm:"index"`
 	Shard  uint
 	Offset int64
+	Dirty  bool
 	//User   uint `gorm:"index"`
 }
 
@@ -676,7 +677,7 @@ func (ds *DeltaSession) putShard(ctx context.Context, shard *CarShard, brefs []m
 		}
 
 		subq := ds.cs.meta.Model(&blockRef{}).Joins("left join car_shards cs on cs.id = block_refs.shard").Where("cid in (?) AND usr = ?", torm, ds.user).Select("block_refs.id")
-		if err := tx.Delete(&blockRef{}, "id in (?)", subq).Error; err != nil {
+		if err := tx.Model(&blockRef{}).Where("id in (?)", subq).UpdateColumn("dirty", true).Error; err != nil {
 			return err
 		}
 	}

--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ipfs/go-libipfs/blocks"
 	car "github.com/ipld/go-car"
 	carutil "github.com/ipld/go-car/util"
+	cbg "github.com/whyrusleeping/cbor-gen"
 	"go.opentelemetry.io/otel"
 	"gorm.io/gorm"
 )
@@ -238,6 +239,7 @@ func (uv *userView) GetSize(ctx context.Context, k cid.Cid) (int, error) {
 type DeltaSession struct {
 	fresh    blockstore.Blockstore
 	blks     map[cid.Cid]blockformat.Block
+	rmcids   map[cid.Cid]bool
 	base     blockstore.Blockstore
 	user     models.Uid
 	seq      int
@@ -631,7 +633,6 @@ func (ds *DeltaSession) closeWithRoot(ctx context.Context, root cid.Cid, rebase 
 		return nil, fmt.Errorf("failed to write shard file: %w", err)
 	}
 
-	// TODO: all this database work needs to be in a single transaction
 	shard := CarShard{
 		Root:      models.DbCID{root},
 		DataStart: hnw,
@@ -666,6 +667,18 @@ func (ds *DeltaSession) putShard(ctx context.Context, shard *CarShard, brefs []m
 
 	if err := createBlockRefs(ctx, tx, brefs); err != nil {
 		return fmt.Errorf("failed to create block refs: %w", err)
+	}
+
+	if len(ds.rmcids) > 0 {
+		var torm []models.DbCID
+		for c := range ds.rmcids {
+			torm = append(torm, models.DbCID{c})
+		}
+
+		subq := ds.cs.meta.Model(&blockRef{}).Joins("left join car_shards cs on cs.id = block_refs.shard").Where("cid in (?) AND usr = ?", torm, ds.user).Select("block_refs.id")
+		if err := tx.Delete(&blockRef{}, "id in (?)", subq).Error; err != nil {
+			return err
+		}
 	}
 
 	err := tx.WithContext(ctx).Commit().Error
@@ -776,6 +789,67 @@ func LdWrite(w io.Writer, d ...[]byte) (int64, error) {
 	return int64(nw), nil
 }
 
+func setToSlice(s map[cid.Cid]bool) []cid.Cid {
+	out := make([]cid.Cid, 0, len(s))
+	for c := range s {
+		out = append(out, c)
+	}
+
+	return out
+}
+
+func BlockDiff(ctx context.Context, bs blockstore.Blockstore, oldroot cid.Cid, newcids []cid.Cid) (map[cid.Cid]bool, error) {
+	ctx, span := otel.Tracer("repo").Start(ctx, "BlockDiff")
+	defer span.End()
+
+	// walk the entire 'new' portion of the tree, marking all referenced cids as 'keep'
+	keepset := make(map[cid.Cid]bool)
+	for _, c := range newcids {
+		keepset[c] = true
+		oblk, err := bs.Get(ctx, c)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := cbg.ScanForLinks(bytes.NewReader(oblk.RawData()), func(lnk cid.Cid) {
+			keepset[lnk] = true
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	if keepset[oldroot] {
+		// this should probably never happen, but is technically correct
+		return nil, nil
+	}
+
+	// next, walk the old tree from the root, recursing on cids *not* in the keepset.
+	dropset := make(map[cid.Cid]bool)
+	dropset[oldroot] = true
+	queue := []cid.Cid{oldroot}
+
+	for len(queue) > 0 {
+		c := queue[0]
+		queue = queue[1:]
+
+		oblk, err := bs.Get(ctx, c)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := cbg.ScanForLinks(bytes.NewReader(oblk.RawData()), func(lnk cid.Cid) {
+			if !keepset[lnk] {
+				dropset[lnk] = true
+				queue = append(queue, lnk)
+			}
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	return dropset, nil
+}
+
 func (cs *CarStore) ImportSlice(ctx context.Context, uid models.Uid, prev *cid.Cid, carslice []byte) (cid.Cid, *DeltaSession, error) {
 	ctx, span := otel.Tracer("carstore").Start(ctx, "ImportSlice")
 	defer span.End()
@@ -794,6 +868,7 @@ func (cs *CarStore) ImportSlice(ctx context.Context, uid models.Uid, prev *cid.C
 		return cid.Undef, nil, err
 	}
 
+	var cids []cid.Cid
 	for {
 		blk, err := carr.Next()
 		if err != nil {
@@ -803,10 +878,24 @@ func (cs *CarStore) ImportSlice(ctx context.Context, uid models.Uid, prev *cid.C
 			return cid.Undef, nil, err
 		}
 
+		cids = append(cids, blk.Cid())
+
 		if err := ds.Put(ctx, blk); err != nil {
 			return cid.Undef, nil, err
 		}
 	}
+
+	base := cid.Undef
+	if prev != nil {
+		base = *prev
+	}
+
+	rmcids, err := BlockDiff(ctx, ds, base, cids)
+	if err != nil {
+		return cid.Undef, nil, err
+	}
+
+	ds.rmcids = rmcids
 
 	return carr.Header.Roots[0], ds, nil
 }

--- a/repo/cbor_gen.go
+++ b/repo/cbor_gen.go
@@ -25,8 +25,13 @@ func (t *SignedCommit) MarshalCBOR(w io.Writer) error {
 	}
 
 	cw := cbg.NewCborWriter(w)
+	fieldCount := 6
 
-	if _, err := cw.Write([]byte{165}); err != nil {
+	if t.Rev == "" {
+		fieldCount--
+	}
+
+	if _, err := cw.Write(cbg.CborEncodeMajorType(cbg.MajMap, uint64(fieldCount))); err != nil {
 		return err
 	}
 
@@ -51,6 +56,32 @@ func (t *SignedCommit) MarshalCBOR(w io.Writer) error {
 	}
 	if _, err := io.WriteString(w, string(t.Did)); err != nil {
 		return err
+	}
+
+	// t.Rev (string) (string)
+	if t.Rev != "" {
+
+		if len("rev") > cbg.MaxLength {
+			return xerrors.Errorf("Value in field \"rev\" was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("rev"))); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(w, string("rev")); err != nil {
+			return err
+		}
+
+		if len(t.Rev) > cbg.MaxLength {
+			return xerrors.Errorf("Value in field t.Rev was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Rev))); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(w, string(t.Rev)); err != nil {
+			return err
+		}
 	}
 
 	// t.Sig ([]uint8) (slice)
@@ -188,6 +219,17 @@ func (t *SignedCommit) UnmarshalCBOR(r io.Reader) (err error) {
 
 				t.Did = string(sval)
 			}
+			// t.Rev (string) (string)
+		case "rev":
+
+			{
+				sval, err := cbg.ReadString(cr)
+				if err != nil {
+					return err
+				}
+
+				t.Rev = string(sval)
+			}
 			// t.Sig ([]uint8) (slice)
 		case "sig":
 
@@ -288,8 +330,13 @@ func (t *UnsignedCommit) MarshalCBOR(w io.Writer) error {
 	}
 
 	cw := cbg.NewCborWriter(w)
+	fieldCount := 5
 
-	if _, err := cw.Write([]byte{164}); err != nil {
+	if t.Rev == "" {
+		fieldCount--
+	}
+
+	if _, err := cw.Write(cbg.CborEncodeMajorType(cbg.MajMap, uint64(fieldCount))); err != nil {
 		return err
 	}
 
@@ -314,6 +361,32 @@ func (t *UnsignedCommit) MarshalCBOR(w io.Writer) error {
 	}
 	if _, err := io.WriteString(w, string(t.Did)); err != nil {
 		return err
+	}
+
+	// t.Rev (string) (string)
+	if t.Rev != "" {
+
+		if len("rev") > cbg.MaxLength {
+			return xerrors.Errorf("Value in field \"rev\" was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("rev"))); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(w, string("rev")); err != nil {
+			return err
+		}
+
+		if len(t.Rev) > cbg.MaxLength {
+			return xerrors.Errorf("Value in field t.Rev was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Rev))); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(w, string(t.Rev)); err != nil {
+			return err
+		}
 	}
 
 	// t.Data (cid.Cid) (struct)
@@ -426,6 +499,17 @@ func (t *UnsignedCommit) UnmarshalCBOR(r io.Reader) (err error) {
 				}
 
 				t.Did = string(sval)
+			}
+			// t.Rev (string) (string)
+		case "rev":
+
+			{
+				sval, err := cbg.ReadString(cr)
+				if err != nil {
+					return err
+				}
+
+				t.Rev = string(sval)
 			}
 			// t.Data (cid.Cid) (struct)
 		case "data":

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -29,7 +29,7 @@ type SignedCommit struct {
 	Prev    *cid.Cid `cborgen:"prev"`
 	Data    cid.Cid  `cborgen:"data"`
 	Sig     []byte   `cborgen:"sig"`
-	Rev     string   `cborgen:"rev"`
+	Rev     string   `cborgen:"rev,omitempty"`
 }
 
 type UnsignedCommit struct {
@@ -37,7 +37,7 @@ type UnsignedCommit struct {
 	Version int64    `cborgen:"version"`
 	Prev    *cid.Cid `cborgen:"prev"`
 	Data    cid.Cid  `cborgen:"data"`
-	Rev     string   `cborgen:"rev"`
+	Rev     string   `cborgen:"rev,omitempty"`
 }
 
 type Repo struct {

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -19,7 +19,9 @@ import (
 )
 
 // current version of repo currently implemented
-const ATP_REPO_VERSION int64 = 2
+const ATP_REPO_VERSION int64 = 3
+
+const ATP_REPO_VERSION_2 int64 = 2
 
 type SignedCommit struct {
 	Did     string   `cborgen:"did"`
@@ -27,6 +29,7 @@ type SignedCommit struct {
 	Prev    *cid.Cid `cborgen:"prev"`
 	Data    cid.Cid  `cborgen:"data"`
 	Sig     []byte   `cborgen:"sig"`
+	Rev     string   `cborgen:"rev"`
 }
 
 type UnsignedCommit struct {
@@ -34,6 +37,7 @@ type UnsignedCommit struct {
 	Version int64    `cborgen:"version"`
 	Prev    *cid.Cid `cborgen:"prev"`
 	Data    cid.Cid  `cborgen:"data"`
+	Rev     string   `cborgen:"rev"`
 }
 
 type Repo struct {
@@ -55,6 +59,7 @@ func (sc *SignedCommit) Unsigned() *UnsignedCommit {
 		Version: sc.Version,
 		Prev:    sc.Prev,
 		Data:    sc.Data,
+		Rev:     sc.Rev,
 	}
 }
 
@@ -131,7 +136,7 @@ func OpenRepo(ctx context.Context, bs blockstore.Blockstore, root cid.Cid, fullR
 		return nil, fmt.Errorf("loading root from blockstore: %w", err)
 	}
 
-	if sc.Version != ATP_REPO_VERSION {
+	if sc.Version != ATP_REPO_VERSION && sc.Version != ATP_REPO_VERSION_2 {
 		return nil, fmt.Errorf("unsupported repo version: %d", sc.Version)
 	}
 
@@ -262,16 +267,11 @@ func (r *Repo) Commit(ctx context.Context, signer func(context.Context, string, 
 		return cid.Undef, err
 	}
 
-	var nprev *cid.Cid
-	if r.repoCid.Defined() {
-		nprev = &r.repoCid
-	}
-
 	ncom := UnsignedCommit{
 		Did:     r.RepoDid(),
 		Version: ATP_REPO_VERSION,
-		Prev:    nprev,
 		Data:    rcid,
+		Rev:     NextTID(),
 	}
 
 	sb, err := ncom.BytesForSigning()
@@ -289,6 +289,7 @@ func (r *Repo) Commit(ctx context.Context, signer func(context.Context, string, 
 		Version: ncom.Version,
 		Prev:    ncom.Prev,
 		Data:    ncom.Data,
+		Rev:     ncom.Rev,
 	}
 
 	nsccid, err := r.cst.Put(ctx, &nsc)

--- a/repomgr/repomgr.go
+++ b/repomgr/repomgr.go
@@ -624,7 +624,7 @@ func (rm *RepoManager) HandleExternalUserEvent(ctx context.Context, pdsid uint, 
 	unlock := rm.lockUser(ctx, uid)
 	defer unlock()
 
-	root, ncids, ds, err := rm.cs.ImportSlice(ctx, uid, prev, carslice)
+	root, ds, err := rm.cs.ImportSlice(ctx, uid, prev, carslice)
 	if err != nil {
 		return fmt.Errorf("importing external carslice: %w", err)
 	}
@@ -636,15 +636,6 @@ func (rm *RepoManager) HandleExternalUserEvent(ctx context.Context, pdsid uint, 
 
 	if err := rm.CheckRepoSig(ctx, r, did); err != nil {
 		return err
-	}
-
-	base := cid.Undef
-	if prev != nil {
-		base = *prev
-	}
-	rmcids, err := repo.BlockDiff(ctx, ds, base, ncids)
-	if err != nil {
-		return fmt.Errorf("failed to process block-level repo diff: %w", err)
 	}
 
 	var evtops []RepoOp

--- a/repomgr/repomgr.go
+++ b/repomgr/repomgr.go
@@ -624,7 +624,7 @@ func (rm *RepoManager) HandleExternalUserEvent(ctx context.Context, pdsid uint, 
 	unlock := rm.lockUser(ctx, uid)
 	defer unlock()
 
-	root, ds, err := rm.cs.ImportSlice(ctx, uid, prev, carslice)
+	root, ncids, ds, err := rm.cs.ImportSlice(ctx, uid, prev, carslice)
 	if err != nil {
 		return fmt.Errorf("importing external carslice: %w", err)
 	}
@@ -636,6 +636,15 @@ func (rm *RepoManager) HandleExternalUserEvent(ctx context.Context, pdsid uint, 
 
 	if err := rm.CheckRepoSig(ctx, r, did); err != nil {
 		return err
+	}
+
+	base := cid.Undef
+	if prev != nil {
+		base = *prev
+	}
+	rmcids, err := repo.BlockDiff(ctx, ds, base, ncids)
+	if err != nil {
+		return fmt.Errorf("failed to process block-level repo diff: %w", err)
 	}
 
 	var evtops []RepoOp


### PR DESCRIPTION
We won't need this until the sync changes that remove history land.

This adds tracking of which blocks are no longer referenced during processing of a new commit. We then delete the carstore references for those blocks when accepting that commit.
Work still to be done is figuring out how we want to compact old shard files.

It seems relatively straightforward to do the compaction as a post-process step that queries recently changed repos and checks if enough block references have been dropped to make it worth running a repo compaction. (in writing this, im thinking we might want a 'stale' flag on blockRefs that we set to true instead of deleting them).
When compacting, to make the read paths more efficient, we should leave the most recent several car slices alone and only compact the oldest N shards. For efficiency on the write path it is advantageous to not have individual files be too big, so that when reading data for making edits, we can read a small number of shards whole.