### PR TITLE
atproto/syntax: hotfix for ATURI String()

### DIFF
--- a/atproto/syntax/aturi.go
+++ b/atproto/syntax/aturi.go
@@ -102,6 +102,10 @@ func (n ATURI) Normalize() ATURI {
 	return ATURI("at://" + auth.Normalize().String() + "/" + coll.Normalize().String() + "/" + rkey.String())
 }
 
+func (n ATURI) String() string {
+	return string(n)
+}
+
 func (a ATURI) MarshalText() ([]byte, error) {
 	return []byte(a.String()), nil
 }

--- a/atproto/syntax/aturi_test.go
+++ b/atproto/syntax/aturi_test.go
@@ -76,7 +76,7 @@ func TestATURINormalize(t *testing.T) {
 
 	testVec := [][]string{
 		{"at://did:abc:123/io.NsId.someFunc/record-KEY", "at://did:abc:123/io.nsid.someFunc/record-KEY"},
-		// XXX: { "at://E.com", "at://e.com" },
+		{"at://E.com", "at://e.com"},
 	}
 
 	for _, parts := range testVec {

--- a/atproto/syntax/aturi_test.go
+++ b/atproto/syntax/aturi_test.go
@@ -93,9 +93,6 @@ func TestATURINoPanic(t *testing.T) {
 		_, _ = bad.Collection()
 		_, _ = bad.RecordKey()
 		_ = bad.Normalize()
+		_ = bad.String()
 	}
-}
-
-func (u ATURI) String() string {
-	return string(u)
 }


### PR DESCRIPTION
Somehow had the `String()` method defined in the test file instead of `aturi.go` by mistake.