### PR TITLE
split up createInvite batch calls

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -100,8 +100,7 @@ func NewBGS(db *gorm.DB, ix *indexer.Indexer, repoman *repomgr.RepoManager, evtm
 		events:  evtman,
 		didr:    didr,
 		blobs:   blobs,
-
-		ssl: ssl,
+		ssl:     ssl,
 
 		consumersLk: sync.RWMutex{},
 		consumers:   make(map[uint64]*SocketConsumer),

--- a/cmd/gosky/main.go
+++ b/cmd/gosky/main.go
@@ -1287,13 +1287,20 @@ var createInviteCmd = &cli.Command{
 				}
 			}
 
-			_, err = comatproto.ServerCreateInviteCodes(context.TODO(), xrpcc, &comatproto.ServerCreateInviteCodes_Input{
-				UseCount:    int64(count),
-				ForAccounts: dids,
-				CodeCount:   int64(num),
-			})
-			if err != nil {
-				return err
+			for n := 0; n < len(dids); n += 500 {
+				slice := dids
+				if len(slice) > 500 {
+					slice = slice[:500]
+				}
+
+				_, err = comatproto.ServerCreateInviteCodes(context.TODO(), xrpcc, &comatproto.ServerCreateInviteCodes_Input{
+					UseCount:    int64(count),
+					ForAccounts: slice,
+					CodeCount:   int64(num),
+				})
+				if err != nil {
+					return err
+				}
 			}
 
 			return nil


### PR DESCRIPTION
if we try to gift invite codes to more than a few hundred users at a time, it fails because the request body is too big.