### PR TITLE
Cache failures while crawling for an hour to prevent BGS-based DOS

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -934,7 +934,7 @@ func (s *BGS) createExternalUser(ctx context.Context, did string) (*models.Actor
 	defer s.extUserLk.Unlock()
 
 	exu, err := s.Index.LookupUserByDid(ctx, did)
-	if err == nil {
+	if err == nil && exu.FailedAt == nil {
 		log.Infow("lost the race to create a new user", "did", did, "handle", handle)
 		if exu.PDS != peering.ID {
 			// User is now on a different PDS, update

--- a/models/models.go
+++ b/models/models.go
@@ -35,15 +35,18 @@ type RepostRecord struct {
 
 type ActorInfo struct {
 	gorm.Model
-	Uid         Uid    `gorm:"uniqueindex"`
-	Handle      string `gorm:"uniqueindex"`
-	DisplayName string
-	Did         string `gorm:"uniqueindex"`
-	Following   int64
-	Followers   int64
-	Posts       int64
-	Type        string
-	PDS         uint
+	Uid          Uid    `gorm:"uniqueindex"`
+	Handle       string `gorm:"uniqueindex"`
+	DisplayName  string
+	Did          string `gorm:"uniqueindex"`
+	Following    int64
+	Followers    int64
+	Posts        int64
+	Type         string
+	PDS          uint
+	FailedAt     *time.Time
+	FailedReason *string
+	FailureCount int64
 }
 
 func (ai *ActorInfo) ActorRef() *bsky.ActorDefs_ProfileViewBasic {


### PR DESCRIPTION
This change updates the Indexer to cache the failure state of a failed crawl for a given actor.

If we fail in crawling a referenced actor, we still add them to the DB but mark the time when we last failed crawling them.

We set a TTL for when it is okay to crawl again, returning the cached failure reason any time we try crawling from now until the TTL expires.

Since this only affects repos that are crawled through reference (via the indexer), active users that are posting on their PDS will not trigger this code path and will not have failures cached, preventing temporary outages from degrading their experience with the BGS for longer than the outage lasts.