### PR TITLE
identity: support skipping DNS resolution for some domain suffixes

### DIFF
--- a/atproto/identity/base_directory.go
+++ b/atproto/identity/base_directory.go
@@ -19,6 +19,8 @@ type BaseDirectory struct {
 	Resolver net.Resolver
 	// when doing DNS handle resolution, should this resolver attempt re-try against an authoritative nameserver if the first TXT lookup fails?
 	TryAuthoritativeDNS bool
+	// set of handle domain suffixes for for which DNS handle resolution will be skipped
+	SkipDNSDomainSuffixes []string
 }
 
 var _ Directory = (*BaseDirectory)(nil)

--- a/atproto/identity/identity.go
+++ b/atproto/identity/identity.go
@@ -61,6 +61,8 @@ func DefaultDirectory() Directory {
 			},
 		},
 		TryAuthoritativeDNS: true,
+		// primary Bluesky PDS instance only supports HTTP resolution method
+		SkipDNSDomainSuffixes: []string{".bsky.social"},
 	}
 	cached := NewCacheDirectory(&base, 10000, time.Hour*24, time.Minute*2)
 	return &cached


### PR DESCRIPTION
And specifically, skip it by default for `.bsky.social` (we only do HTTP resolution). This reduces unnecessary DNS traffic, especially with higher concurrency/parallelism.