### PR TITLE
syntax: ATURI ergonomics

### DIFF
--- a/atproto/syntax/atidentifier.go
+++ b/atproto/syntax/atidentifier.go
@@ -24,12 +24,22 @@ func ParseAtIdentifier(raw string) (*AtIdentifier, error) {
 	return &AtIdentifier{Inner: handle}, nil
 }
 
+func (n AtIdentifier) IsHandle() bool {
+	_, ok := n.Inner.(Handle)
+	return ok
+}
+
 func (n AtIdentifier) AsHandle() (Handle, error) {
 	handle, ok := n.Inner.(Handle)
 	if ok {
 		return handle, nil
 	}
 	return "", fmt.Errorf("AT Identifier is not a Handle")
+}
+
+func (n AtIdentifier) IsDID() bool {
+	_, ok := n.Inner.(DID)
+	return ok
 }
 
 func (n AtIdentifier) AsDID() (DID, error) {

--- a/atproto/syntax/atidentifier_test.go
+++ b/atproto/syntax/atidentifier_test.go
@@ -48,3 +48,38 @@ func TestInteropAtIdentifiersInvalid(t *testing.T) {
 	}
 	assert.NoError(scanner.Err())
 }
+
+func TestDowncase(t *testing.T) {
+	assert := assert.New(t)
+
+	aidh, err := ParseAtIdentifier("example.com")
+	assert.NoError(err)
+	assert.True(aidh.IsHandle())
+	assert.False(aidh.IsDID())
+	_, err = aidh.AsHandle()
+	assert.NoError(err)
+	_, err = aidh.AsDID()
+	assert.Error(err)
+
+	aidd, err := ParseAtIdentifier("did:web:example.com")
+	assert.NoError(err)
+	assert.False(aidd.IsHandle())
+	assert.True(aidd.IsDID())
+	_, err = aidd.AsHandle()
+	assert.Error(err)
+	_, err = aidd.AsDID()
+	assert.NoError(err)
+}
+
+func TestEmtpy(t *testing.T) {
+	assert := assert.New(t)
+
+	atid := AtIdentifier{}
+
+	assert.False(atid.IsHandle())
+	assert.False(atid.IsDID())
+	assert.Equal(atid, atid.Normalize())
+	atid.AsHandle()
+	atid.AsDID()
+	assert.Empty(atid.String())
+}

--- a/atproto/syntax/aturi_test.go
+++ b/atproto/syntax/aturi_test.go
@@ -60,12 +60,11 @@ func TestATURIParts(t *testing.T) {
 	for _, parts := range testVec {
 		uri, err := ParseATURI(parts[0])
 		assert.NoError(err)
-		auth, _ := uri.Authority()
+		auth := uri.Authority()
 		assert.Equal(parts[1], auth.String())
-		col, _ := uri.Collection()
+		col := uri.Collection()
 		assert.Equal(parts[2], col.String())
-		rkey, _ := uri.RecordKey()
-		assert.NoError(err)
+		rkey := uri.RecordKey()
 		assert.Equal(parts[3], rkey.String())
 	}
 
@@ -89,9 +88,9 @@ func TestATURINormalize(t *testing.T) {
 func TestATURINoPanic(t *testing.T) {
 	for _, s := range []string{"", ".", "at://", "at:///", "at://e.com", "at://e.com/", "at://e.com//"} {
 		bad := ATURI(s)
-		_, _ = bad.Authority()
-		_, _ = bad.Collection()
-		_, _ = bad.RecordKey()
+		_ = bad.Authority()
+		_ = bad.Collection()
+		_ = bad.RecordKey()
 		_ = bad.Normalize()
 		_ = bad.String()
 	}


### PR DESCRIPTION
This was something we discussed a couple weeks back: making access to sub-fields of ATURI more ergonomic.

This embraces the reality of "empty" values in golang and will return empty values instead of a `nil` pointer and error when the field doesn't exist, or if it fails to parse. I'm not really sure how I feel about it; feels vaguely unsafe? Maybe we need "IsEmpty()" helpers on all these, or something?

Still open to a `ATURIParts` or similarly named `struct` version of URI, with the various components as accessible fields; that could be in addition to this PR.