### PR TITLE
Implement a selective cache flush interface for handle updates

### DIFF
--- a/api/plc.go
+++ b/api/plc.go
@@ -54,6 +54,10 @@ func (s *PLCServer) GetDocument(ctx context.Context, didstr string) (*did.Docume
 	return &doc, nil
 }
 
+func (s *PLCServer) FlushCacheFor(did string) {
+	return
+}
+
 type CreateOp struct {
 	Type        string  `json:"type" cborgen:"type"`
 	SigningKey  string  `json:"signingKey" cborgen:"signingKey"`

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -785,6 +785,8 @@ func (bgs *BGS) handleFedEvent(ctx context.Context, host *models.PDS, env *event
 
 		return nil
 	case env.RepoHandle != nil:
+		// Flush any cached DID documents for this user
+		bgs.didr.FlushCacheFor(env.RepoHandle.Did)
 
 		// TODO: ignoring the data in the message and just going out to the DID doc
 		act, err := bgs.createExternalUser(ctx, env.RepoHandle.Did)

--- a/did/multi.go
+++ b/did/multi.go
@@ -9,6 +9,7 @@ import (
 
 type Resolver interface {
 	GetDocument(ctx context.Context, didstr string) (*did.Document, error)
+	FlushCacheFor(did string)
 }
 
 type MultiResolver struct {
@@ -23,6 +24,22 @@ func NewMultiResolver() *MultiResolver {
 
 func (mr *MultiResolver) AddHandler(method string, res Resolver) {
 	mr.handlers[method] = res
+}
+
+func (mr *MultiResolver) FlushCacheFor(didstr string) {
+	pdid, err := did.ParseDID(didstr)
+	if err != nil {
+		return
+	}
+
+	method := pdid.Protocol()
+
+	res, ok := mr.handlers[method]
+	if !ok {
+		return
+	}
+
+	res.FlushCacheFor(didstr)
 }
 
 func (mr *MultiResolver) GetDocument(ctx context.Context, didstr string) (*did.Document, error) {

--- a/did/web.go
+++ b/did/web.go
@@ -63,6 +63,10 @@ var disallowedTlds = map[string]bool{
 	"internal": true,
 }
 
+func (wr *WebResolver) FlushCacheFor(did string) {
+	return
+}
+
 func checkValidDidWeb(val string) error {
 	// no ports or ipv6
 	if strings.Contains(val, ":") {

--- a/plc/caching.go
+++ b/plc/caching.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	did "github.com/bluesky-social/indigo/did"
+	"github.com/bluesky-social/indigo/did"
 	lru "github.com/hashicorp/golang-lru"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -32,6 +32,10 @@ func NewCachingDidResolver(res did.Resolver, maxAge time.Duration, size int) *Ca
 		cache:  c,
 		maxAge: maxAge,
 	}
+}
+
+func (r *CachingDidResolver) FlushCacheFor(didstr string) {
+	r.cache.Remove(didstr)
 }
 
 func (r *CachingDidResolver) tryCache(did string) (*did.Document, bool) {

--- a/plc/fakedid.go
+++ b/plc/fakedid.go
@@ -66,6 +66,10 @@ func (fd *FakeDid) GetDocument(ctx context.Context, udid string) (*did.Document,
 	}, nil
 }
 
+func (fd *FakeDid) FlushCacheFor(did string) {
+	return
+}
+
 func (fd *FakeDid) CreateDID(ctx context.Context, sigkey *did.PrivKey, recovery string, handle string, service string) (string, error) {
 	buf := make([]byte, 8)
 	rand.Read(buf)


### PR DESCRIPTION
When a handle update happens, we check the PLC entry to get the new handle, but if we've cached the did document for a user, we will have the old doc and fail to process the handle change.