### PR TITLE
Handle conflicts with handles

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -1019,8 +1019,9 @@ func (s *BGS) createExternalUser(ctx context.Context, did string) (*models.Actor
 			if err := s.db.Create(&u).Error; err != nil {
 				return nil, fmt.Errorf("failed to create user after handle conflict: %w", err)
 			}
+		} else {
+			return nil, fmt.Errorf("failed to create other pds user: %w", err)
 		}
-		return nil, fmt.Errorf("failed to create other pds user: %w", err)
 	}
 
 	// okay cool, its a user on a server we are peered with

--- a/models/models.go
+++ b/models/models.go
@@ -44,6 +44,7 @@ type ActorInfo struct {
 	Posts       int64
 	Type        string
 	PDS         uint
+	ValidHandle bool `gorm:"default:true"`
 }
 
 func (ai *ActorInfo) ActorRef() *bsky.ActorDefs_ProfileViewBasic {


### PR DESCRIPTION
Newer DIDs with valid handles invalidate existing DIDs with the same handle

We check for handle validity when creating an External User which means this handle _should_ be more recently valid than whatever we might have in our database.