### PR TITLE
Fix request crawl from BGS Admin Dash

### DIFF
--- a/ts/bgs-dash/src/components/Dash/Dash.tsx
+++ b/ts/bgs-dash/src/components/Dash/Dash.tsx
@@ -186,9 +186,15 @@ const Dash: FC<{}> = () => {
   };
 
   const requestCrawlHost = (host: string) => {
-    fetch(
-      `${BGS_HOST}/xrpc/com.atproto.sync.requestCrawl?hostname=${host}`
-    ).then((res) => {
+    fetch(`${BGS_HOST}/xrpc/com.atproto.sync.requestCrawl`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        hostname: host,
+      }),
+    }).then((res) => {
       if (res.status !== 200) {
         setAlertWithTimeout(
           "failure",


### PR DESCRIPTION
We only support this route via POST now so I'm updating the admin dash to work properly with it.