### PR TITLE
Implement some unimplemented Atproto Sync BGS Handlers

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -278,6 +278,8 @@ func (bgs *BGS) StartWithListener(listen net.Listener) error {
 	e.GET("/xrpc/com.atproto.sync.getBlocks", bgs.HandleComAtprotoSyncGetBlocks)
 	e.GET("/xrpc/com.atproto.sync.requestCrawl", bgs.HandleComAtprotoSyncRequestCrawl)
 	e.POST("/xrpc/com.atproto.sync.requestCrawl", bgs.HandleComAtprotoSyncRequestCrawl)
+	e.GET("/xrpc/com.atproto.sync.listRepos", bgs.HandleComAtprotoSyncListRepos)
+	e.GET("/xrpc/com.atproto.sync.getLatestCommit", bgs.HandleComAtprotoSyncGetLatestCommit)
 	e.GET("/xrpc/com.atproto.sync.notifyOfUpdate", bgs.HandleComAtprotoSyncNotifyOfUpdate)
 	e.GET("/xrpc/_health", bgs.HandleHealthCheck)
 

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -273,8 +273,6 @@ func (bgs *BGS) StartWithListener(listen net.Listener) error {
 	// TODO: this API is temporary until we formalize what we want here
 
 	e.GET("/xrpc/com.atproto.sync.subscribeRepos", bgs.EventsHandler)
-	e.GET("/xrpc/com.atproto.sync.getCheckout", bgs.HandleComAtprotoSyncGetCheckout)
-	e.GET("/xrpc/com.atproto.sync.getHead", bgs.HandleComAtprotoSyncGetHead)
 	e.GET("/xrpc/com.atproto.sync.getRecord", bgs.HandleComAtprotoSyncGetRecord)
 	e.GET("/xrpc/com.atproto.sync.getRepo", bgs.HandleComAtprotoSyncGetRepo)
 	e.GET("/xrpc/com.atproto.sync.getBlocks", bgs.HandleComAtprotoSyncGetBlocks)

--- a/bgs/handlers.go
+++ b/bgs/handlers.go
@@ -198,6 +198,10 @@ func (s *BGS) handleComAtprotoSyncListRepos(ctx context.Context, cursor string, 
 		return nil, fmt.Errorf("failed to get users: %w", err)
 	}
 
+	if len(users) == 0 {
+		return &comatprototypes.SyncListRepos_Output{}, nil
+	}
+
 	resp := &comatprototypes.SyncListRepos_Output{
 		Repos: []*comatprototypes.SyncListRepos_Repo{},
 	}

--- a/bgs/handlers.go
+++ b/bgs/handlers.go
@@ -140,10 +140,6 @@ func (s *BGS) handleComAtprotoSyncListBlobs(ctx context.Context, cursor string, 
 }
 
 func (s *BGS) handleComAtprotoSyncListRepos(ctx context.Context, cursor string, limit int) (*comatprototypes.SyncListRepos_Output, error) {
-	if limit > 1000 {
-		limit = 1000
-	}
-
 	// Use UIDs for the cursor
 	var err error
 	c := int64(0)

--- a/bgs/handlers.go
+++ b/bgs/handlers.go
@@ -155,7 +155,7 @@ func (s *BGS) handleComAtprotoSyncListRepos(ctx context.Context, cursor string, 
 	}
 
 	users := []User{}
-	if err := s.db.Model(&User{}).Where("uid > ?", c).Order("uid").Limit(limit).Find(&users).Error; err != nil {
+	if err := s.db.Model(&User{}).Where("id > ?", c).Order("id").Limit(limit).Find(&users).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return &comatprototypes.SyncListRepos_Output{}, nil
 		}

--- a/bgs/stubs.go
+++ b/bgs/stubs.go
@@ -16,8 +16,6 @@ func (s *BGS) RegisterHandlersAppBsky(e *echo.Echo) error {
 func (s *BGS) RegisterHandlersComAtproto(e *echo.Echo) error {
 	e.GET("/xrpc/com.atproto.sync.getBlob", s.HandleComAtprotoSyncGetBlob)
 	e.GET("/xrpc/com.atproto.sync.getBlocks", s.HandleComAtprotoSyncGetBlocks)
-	e.GET("/xrpc/com.atproto.sync.getCheckout", s.HandleComAtprotoSyncGetCheckout)
-	e.GET("/xrpc/com.atproto.sync.getHead", s.HandleComAtprotoSyncGetHead)
 	e.GET("/xrpc/com.atproto.sync.getLatestCommit", s.HandleComAtprotoSyncGetLatestCommit)
 	e.GET("/xrpc/com.atproto.sync.getRecord", s.HandleComAtprotoSyncGetRecord)
 	e.GET("/xrpc/com.atproto.sync.getRepo", s.HandleComAtprotoSyncGetRepo)
@@ -57,34 +55,6 @@ func (s *BGS) HandleComAtprotoSyncGetBlocks(c echo.Context) error {
 		return handleErr
 	}
 	return c.Stream(200, "application/vnd.ipld.car", out)
-}
-
-func (s *BGS) HandleComAtprotoSyncGetCheckout(c echo.Context) error {
-	ctx, span := otel.Tracer("server").Start(c.Request().Context(), "HandleComAtprotoSyncGetCheckout")
-	defer span.End()
-	did := c.QueryParam("did")
-	var out io.Reader
-	var handleErr error
-	// func (s *BGS) handleComAtprotoSyncGetCheckout(ctx context.Context,did string) (io.Reader, error)
-	out, handleErr = s.handleComAtprotoSyncGetCheckout(ctx, did)
-	if handleErr != nil {
-		return handleErr
-	}
-	return c.Stream(200, "application/vnd.ipld.car", out)
-}
-
-func (s *BGS) HandleComAtprotoSyncGetHead(c echo.Context) error {
-	ctx, span := otel.Tracer("server").Start(c.Request().Context(), "HandleComAtprotoSyncGetHead")
-	defer span.End()
-	did := c.QueryParam("did")
-	var out *comatprototypes.SyncGetHead_Output
-	var handleErr error
-	// func (s *BGS) handleComAtprotoSyncGetHead(ctx context.Context,did string) (*comatprototypes.SyncGetHead_Output, error)
-	out, handleErr = s.handleComAtprotoSyncGetHead(ctx, did)
-	if handleErr != nil {
-		return handleErr
-	}
-	return c.JSON(200, out)
 }
 
 func (s *BGS) HandleComAtprotoSyncGetLatestCommit(c echo.Context) error {


### PR DESCRIPTION
This change implements a few more `com.atproto.sync.*` endpoints in the BGS.

After this PR we'll need to figure out Blobs and the Listing endpoints.

For `ListRepos` we should just be able to walk through the DB in some consistent order (maybe by UIDs).