### PR TITLE
improved compaction, minimize shard count while minimizing IO

### DIFF
--- a/bgs/admin.go
+++ b/bgs/admin.go
@@ -414,12 +414,14 @@ func (bgs *BGS) handleAdminCompactRepo(e echo.Context) error {
 		return fmt.Errorf("no such user: %w", err)
 	}
 
-	if err := bgs.repoman.CarStore().CompactUserShards(ctx, u.ID); err != nil {
+	stats, err := bgs.repoman.CarStore().CompactUserShards(ctx, u.ID)
+	if err != nil {
 		return fmt.Errorf("compaction failed: %w", err)
 	}
 
 	return e.JSON(200, map[string]any{
 		"success": "true",
+		"stats":   stats,
 	})
 }
 

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -1090,7 +1090,7 @@ func (bgs *BGS) runRepoCompaction(ctx context.Context) error {
 	}
 
 	for _, r := range repos {
-		if err := bgs.repoman.CarStore().CompactUserShards(ctx, r.Usr); err != nil {
+		if _, err := bgs.repoman.CarStore().CompactUserShards(ctx, r.Usr); err != nil {
 			log.Errorf("failed to compact shards for user %d: %s", r.Usr, err)
 			continue
 		}

--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -1275,14 +1275,8 @@ func (cs *CarStore) CompactUserShards(ctx context.Context, user models.Uid) (*Co
 	for _, b := range compactionQueue {
 		if !b.shouldCompact() {
 			stats.SkippedShards += len(b.shards)
-			for _, s := range b.shards {
-				fmt.Println("o: ", s.Total, s.dirtyFrac())
-
-			}
 			continue
 		}
-
-		fmt.Println("n: ", b.cleanBlocks)
 
 		if err := cs.compactBucket(ctx, user, b, shardsById, keep); err != nil {
 			return nil, err

--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -1150,11 +1150,11 @@ func (cs *CarStore) GetCompactionTargets(ctx context.Context) ([]CompactionTarge
 }
 
 type CompactionStats struct {
-	StartShards   int
-	NewShards     int
-	SkippedShards int
-	ShardsDeleted int
-	RefsDeleted   int
+	StartShards   int `json:"startShards"`
+	NewShards     int `json:"newShards"`
+	SkippedShards int `json:"skippedShards"`
+	ShardsDeleted int `json:"shardsDeleted"`
+	RefsDeleted   int `json:"refsDeleted"`
 }
 
 func (cs *CarStore) CompactUserShards(ctx context.Context, user models.Uid) (*CompactionStats, error) {

--- a/carstore/repo_test.go
+++ b/carstore/repo_test.go
@@ -140,7 +140,7 @@ func TestBasicOperation(t *testing.T) {
 	}
 	checkRepo(t, buf, recs)
 
-	if err := cs.CompactUserShards(ctx, 1); err != nil {
+	if _, err := cs.CompactUserShards(ctx, 1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -217,9 +217,12 @@ func TestRepeatedCompactions(t *testing.T) {
 			head = nroot
 		}
 		fmt.Println("Run compaction", loop)
-		if err := cs.CompactUserShards(ctx, 1); err != nil {
+		st, err := cs.CompactUserShards(ctx, 1)
+		if err != nil {
 			t.Fatal(err)
 		}
+
+		fmt.Printf("%#v\n", st)
 
 		buf := new(bytes.Buffer)
 		if err := cs.ReadUserCar(ctx, 1, "", true, buf); err != nil {
@@ -236,6 +239,7 @@ func TestRepeatedCompactions(t *testing.T) {
 }
 
 func checkRepo(t *testing.T, r io.Reader, expRecs []cid.Cid) {
+	t.Helper()
 	rep, err := repo.ReadRepoFromCar(context.TODO(), r)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The main idea here is to have each shard contain twice the number of blocks as the next shard, under the logic that older shards will need to be rewritten less and also accessed less in general.

still to discuss, should there be a max size on shards?
