### PR TITLE
in the case of missing blocks, fall back to full repo fetch

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -765,7 +766,7 @@ func (bgs *BGS) handleFedEvent(ctx context.Context, host *models.PDS, env *event
 		if err := bgs.repoman.HandleExternalUserEvent(ctx, host.ID, u.ID, u.Did, evt.Since, evt.Rev, evt.Blocks, evt.Ops); err != nil {
 			log.Warnw("failed handling event", "err", err, "host", host.Host, "seq", evt.Seq, "repo", u.Did, "prev", stringLink(evt.Prev), "commit", evt.Commit.String())
 
-			if errors.Is(err, carstore.ErrRepoBaseMismatch) {
+			if errors.Is(err, carstore.ErrRepoBaseMismatch) || ipld.IsNotFound(err) {
 				ai, err := bgs.Index.LookupUser(ctx, u.ID)
 				if err != nil {
 					return err

--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -258,6 +258,7 @@ type DeltaSession struct {
 	seq      int
 	readonly bool
 	cs       *CarStore
+	lastRev  string
 }
 
 func (cs *CarStore) checkLastShardCache(user models.Uid) *CarShard {
@@ -332,6 +333,7 @@ func (cs *CarStore) NewDeltaSession(ctx context.Context, user models.Uid, since 
 		baseCid: lastShard.Root.CID,
 		cs:      cs,
 		seq:     lastShard.Seq + 1,
+		lastRev: lastShard.Rev,
 	}, nil
 }
 
@@ -880,7 +882,7 @@ func (cs *CarStore) ImportSlice(ctx context.Context, uid models.Uid, since *stri
 
 	rmcids, err := BlockDiff(ctx, ds, ds.baseCid, ds.blks)
 	if err != nil {
-		return cid.Undef, nil, fmt.Errorf("block diff failed (base=%s): %w", ds.baseCid, err)
+		return cid.Undef, nil, fmt.Errorf("block diff failed (base=%s,since=%v,rev=%s): %w", ds.baseCid, since, ds.lastRev, err)
 	}
 
 	ds.rmcids = rmcids


### PR DESCRIPTION
If for some reason we end up with missing data, add a multi-stage fallback to first fetch the missing revision range ( in the case of an event slice erroring) and then if data is still missing, fall back to fetching the entire repo.

also added a debug command to fetch and verify data in a repo.