### PR TITLE
Coalesce requests for the same DID or Handle in Directory

### DIFF
--- a/atproto/identity/cache_directory.go
+++ b/atproto/identity/cache_directory.go
@@ -148,7 +148,9 @@ func (d *CacheDirectory) coalescedResolveHandle(ctx context.Context, handle synt
 		if err != nil {
 			errC <- err
 		} else {
-			did = entry.DID
+			if entry != nil {
+				did = entry.DID
+			}
 			resC <- did
 		}
 		// Cleanup after sending result or error
@@ -230,7 +232,9 @@ func (d *CacheDirectory) coalescedResolveDID(ctx context.Context, did syntax.DID
 		if err != nil {
 			errC <- err
 		} else {
-			doc = entry.Identity
+			if entry != nil {
+				doc = entry.Identity
+			}
 			resC <- doc
 		}
 		// Cleanup after sending result or error

--- a/atproto/identity/live_test.go
+++ b/atproto/identity/live_test.go
@@ -87,6 +87,7 @@ func TestCacheCoalesce(t *testing.T) {
 		SkipDNSDomainSuffixes: []string{".bsky.social"},
 	}
 	dir := NewCacheDirectory(&base, 1000, time.Hour*1, time.Hour*1)
+	// All 60 routines launch at the same time, so they should all miss the cache initially
 	routines := 60
 	wg := sync.WaitGroup{}
 

--- a/atproto/identity/live_test.go
+++ b/atproto/identity/live_test.go
@@ -70,8 +70,9 @@ func TestCacheDirectory(t *testing.T) {
 }
 
 func TestCacheCoalesce(t *testing.T) {
-	assert := assert.New(t)
+	t.Skip("TODO: skipping live network test")
 
+	assert := assert.New(t)
 	handle := syntax.Handle("atproto.com")
 	did := syntax.DID("did:plc:ewvi7nxzyoun6zhxrhs64oiz")
 

--- a/search/firehose.go
+++ b/search/firehose.go
@@ -239,6 +239,9 @@ func (s *Server) handleCreateOrUpdate(ctx context.Context, rawDID string, path s
 	if err != nil {
 		return fmt.Errorf("resolving identity: %w", err)
 	}
+	if ident == nil {
+		return fmt.Errorf("identity not found for did: %s", did.String())
+	}
 	rec := *recP
 
 	switch rec := rec.(type) {
@@ -273,6 +276,9 @@ func (s *Server) handleDelete(ctx context.Context, rawDID, path string) error {
 	ident, err := s.dir.LookupDID(ctx, did)
 	if err != nil {
 		return err
+	}
+	if ident == nil {
+		return fmt.Errorf("identity not found for did: %s", did.String())
 	}
 
 	switch {
@@ -365,6 +371,9 @@ func (s *Server) processTooBigCommit(ctx context.Context, evt *comatproto.SyncSu
 	ident, err := s.dir.LookupDID(ctx, did)
 	if err != nil {
 		return err
+	}
+	if ident == nil {
+		return fmt.Errorf("identity not found for did: %s", did.String())
 	}
 
 	return r.ForEach(ctx, "", func(k string, v cid.Cid) error {


### PR DESCRIPTION
This change uses a `sync.Map` to coalesce requests for the same DID or Handle during a lookup to prevent lots of requests for the same content from going out before the first one comes back to get cached.