### PR TITLE
clean up labeler

### DIFF
--- a/labeler/commit.go
+++ b/labeler/commit.go
@@ -3,7 +3,6 @@ package labeler
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	label "github.com/bluesky-social/indigo/api/label"
@@ -24,21 +23,12 @@ func (s *Server) CommitLabels(ctx context.Context, labels []*label.Label, negate
 	for _, l := range labels {
 		l.Cts = nowStr
 
-		path, _, err := s.repoman.CreateRecord(ctx, s.user.UserId, "com.atproto.label.label", l)
-		if err != nil {
-			return fmt.Errorf("failed to persist label in local repo: %w", err)
-		}
-		labelUri := "at://" + s.user.Did + "/" + path
-		log.Infof("persisted label in repo: %s", labelUri)
-
-		rkey := strings.SplitN(path, "/", 2)[1]
 		lr := models.Label{
 			Uri:       l.Uri,
 			SourceDid: l.Src,
 			Cid:       l.Cid,
 			Val:       l.Val,
 			Neg:       nil,
-			RepoRKey:  &rkey,
 			CreatedAt: now,
 		}
 		if negate {

--- a/labeler/service_test.go
+++ b/labeler/service_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/bluesky-social/indigo/carstore"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -16,17 +15,8 @@ func testLabelMaker(t *testing.T) *Server {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sharddir := filepath.Join(tempdir, "shards")
-	if err := os.MkdirAll(sharddir, 0775); err != nil {
-		t.Fatal(err)
-	}
 
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{SkipDefaultTransaction: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cs, err := carstore.NewCarStore(db, sharddir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +39,7 @@ func testLabelMaker(t *testing.T) *Server {
 		UserId:     1,
 	}
 
-	lm, err := NewServer(db, cs, repoUser, plcURL, blobPdsURL, xrpcProxyURL, xrpcProxyAdminPassword, false)
+	lm, err := NewServer(db, repoUser, plcURL, blobPdsURL, xrpcProxyURL, xrpcProxyAdminPassword, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -135,7 +135,6 @@ type Label struct {
 	Val       string  `gorm:"uniqueIndex:idx_uri_src_val_cid;not null"`
 	Cid       *string `gorm:"uniqueIndex:idx_uri_src_val_cid"`
 	Neg       *bool
-	RepoRKey  *string `gorm:"uniqueIndex:idx_src_rkey"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/testing/labelmaker_fakedata_test.go
+++ b/testing/labelmaker_fakedata_test.go
@@ -11,7 +11,6 @@ import (
 
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	label "github.com/bluesky-social/indigo/api/label"
-	"github.com/bluesky-social/indigo/carstore"
 	"github.com/bluesky-social/indigo/events"
 	"github.com/bluesky-social/indigo/events/schedulers/sequential"
 	"github.com/bluesky-social/indigo/labeler"
@@ -30,17 +29,8 @@ func testLabelMaker(t *testing.T) *labeler.Server {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sharddir := filepath.Join(tempdir, "shards")
-	if err := os.MkdirAll(sharddir, 0775); err != nil {
-		t.Fatal(err)
-	}
 
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{SkipDefaultTransaction: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cs, err := carstore.NewCarStore(db, sharddir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +53,7 @@ func testLabelMaker(t *testing.T) *labeler.Server {
 	xrpcProxyURL := "http://proxy-test.dummy"
 	xrpcProxyAdminPassword := "test-dummy-password"
 
-	lm, err := labeler.NewServer(db, cs, repoUser, plcURL, blobPdsURL, xrpcProxyURL, xrpcProxyAdminPassword, false)
+	lm, err := labeler.NewServer(db, repoUser, plcURL, blobPdsURL, xrpcProxyURL, xrpcProxyAdminPassword, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- [x] remove the old concept of persisting labels in a local repo in addition to database
- [ ] incorporate syntax SDK types (if needed)
- [ ] switch to identity SDK for PLC, etc
- [ ] fetch blobs from actual PDS, not just configured PDS