### PR TITLE
if catching up on buffered jobs fails, fallback to getRepo

### DIFF
--- a/bgs/admin.go
+++ b/bgs/admin.go
@@ -349,10 +349,7 @@ func (bgs *BGS) handleAdminChangePDSRateLimit(e echo.Context) error {
 	}
 
 	// Update the rate limit in the limiter
-	limiter := bgs.slurper.GetLimiter(pds.ID)
-	if limiter == nil {
-		limiter = rate.NewLimiter(rate.Limit(limit), 1)
-	}
+	limiter := bgs.slurper.GetOrCreateLimiter(pds.ID, limit)
 	limiter.SetLimit(rate.Limit(limit))
 
 	return e.JSON(200, map[string]any{
@@ -390,10 +387,7 @@ func (bgs *BGS) handleAdminChangePDSCrawlLimit(e echo.Context) error {
 	}
 
 	// Update the crawl limit in the limiter
-	limiter := bgs.Index.GetLimiter(pds.ID)
-	if limiter != nil {
-		limiter = rate.NewLimiter(rate.Limit(limit), 1)
-	}
+	limiter := bgs.Index.GetOrCreateLimiter(pds.ID, limit)
 	limiter.SetLimit(rate.Limit(limit))
 
 	return e.JSON(200, map[string]any{

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -478,8 +478,6 @@ func (ix *Indexer) FetchAndIndexRepo(ctx context.Context, job *crawlWork) error 
 		return err
 	}
 
-	// this process will send individual indexing events back to the indexer, doing a 'fast forward' of the users entire history
-	// we probably want alternative ways of doing this for 'very large' or 'very old' repos, but this works for now
 	if err := ix.repomgr.ImportNewRepo(ctx, ai.Uid, ai.Did, bytes.NewReader(repo), &rev); err != nil {
 		span.RecordError(err)
 
@@ -493,12 +491,11 @@ func (ix *Indexer) FetchAndIndexRepo(ctx context.Context, job *crawlWork) error 
 				span.RecordError(err)
 				return fmt.Errorf("failed to import backup repo (%s): %w", ai.Did, err)
 			}
+
+			return nil
 		}
 		return fmt.Errorf("importing fetched repo (curRev: %s): %w", rev, err)
 	}
-
-	// TODO: this is currently doing too much work, allowing us to ignore the catchup events we've gotten
-	// need to do 'just enough' work...
 
 	return nil
 }


### PR DESCRIPTION
im not entirely happy with the flow here, feels kinda jank. The main thing we want to do is just keep trying if the event sync fails instead of returning an error (which results in the users repo getting behind until they send another event).
