### PR TITLE
palomar: default q to '*' when there is only filter

### DIFF
--- a/search/parse_query.go
+++ b/search/parse_query.go
@@ -66,5 +66,8 @@ func ParseQuery(ctx context.Context, dir identity.Directory, raw string) (string
 			}
 		}
 	}
+	if out == "" && len(filters) >= 1 {
+		out = "*"
+	}
 	return out, filters
 }

--- a/search/parse_query_test.go
+++ b/search/parse_query_test.go
@@ -40,4 +40,9 @@ func TestParseQuery(t *testing.T) {
 	q, f = ParseQuery(ctx, &dir, p3)
 	assert.Equal("known", q)
 	assert.Equal(1, len(f))
+
+	p4 := "from:known.example.com"
+	q, f = ParseQuery(ctx, &dir, p4)
+	assert.Equal("*", q)
+	assert.Equal(1, len(f))
 }


### PR DESCRIPTION
I haven't tested against an actual index, but there is a parsing test, and i'm pretty confident this will resolve the `from:blah` issue.