### PR TITLE
Allow crawling repos that have invalid handles

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -2,6 +2,7 @@ package bgs
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -436,7 +437,7 @@ type User struct {
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 	DeletedAt   gorm.DeletedAt `gorm:"index"`
-	Handle      string         `gorm:"uniqueIndex"`
+	Handle      sql.NullString `gorm:"uniqueIndex"`
 	Did         string         `gorm:"uniqueIndex"`
 	PDS         uint
 	ValidHandle bool `gorm:"default:true"`
@@ -826,7 +827,7 @@ func (bgs *BGS) handleFedEvent(ctx context.Context, host *models.PDS, env *event
 			return err
 		}
 
-		if act.Handle != env.RepoHandle.Handle {
+		if act.Handle.String != env.RepoHandle.Handle {
 			log.Warnw("handle update did not update handle to asserted value", "did", env.RepoHandle.Did, "expected", env.RepoHandle.Handle, "actual", act.Handle)
 		}
 
@@ -1002,7 +1003,7 @@ func (s *BGS) createExternalUser(ctx context.Context, did string) (*models.Actor
 
 		}
 
-		if exu.Handle != handle {
+		if exu.Handle.String != handle {
 			// Users handle has changed, update
 			if err := s.db.Model(User{}).Where("id = ?", exu.Uid).Update("handle", handle).Error; err != nil {
 				return nil, fmt.Errorf("failed to update users handle: %w", err)
@@ -1013,7 +1014,7 @@ func (s *BGS) createExternalUser(ctx context.Context, did string) (*models.Actor
 				return nil, fmt.Errorf("failed to update actorInfos handle: %w", err)
 			}
 
-			exu.Handle = handle
+			exu.Handle = sql.NullString{String: handle, Valid: true}
 		}
 		return exu, nil
 	}
@@ -1029,7 +1030,7 @@ func (s *BGS) createExternalUser(ctx context.Context, did string) (*models.Actor
 		ValidHandle: validHandle,
 	}
 	if validHandle {
-		u.Handle = handle
+		u.Handle = sql.NullString{String: handle, Valid: true}
 	}
 
 	if err := s.db.Create(&u).Error; err != nil {
@@ -1075,7 +1076,7 @@ func (s *BGS) createExternalUser(ctx context.Context, did string) (*models.Actor
 		ValidHandle: validHandle,
 	}
 	if validHandle {
-		subj.Handle = handle
+		subj.Handle = sql.NullString{String: handle, Valid: true}
 	}
 	if err := s.db.Create(subj).Error; err != nil {
 		return nil, err

--- a/events/diskpersist_test.go
+++ b/events/diskpersist_test.go
@@ -2,6 +2,7 @@ package events_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -423,7 +424,7 @@ func runTakedownTest(t *testing.T, cs *carstore.CarStore, db *gorm.DB, p events.
 		users[i-1] = &models.ActorInfo{
 			Uid:    i,
 			Did:    did,
-			Handle: handle,
+			Handle: sql.NullString{String: handle, Valid: true},
 		}
 		if err := db.Create(&users[i-1]).Error; err != nil {
 			t.Fatal(err)

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"sync"
@@ -377,7 +378,7 @@ func (ix *Indexer) handleInitActor(ctx context.Context, evt *repomgr.RepoEvent, 
 		UpdateAll: true,
 	}).Create(&models.ActorInfo{
 		Uid:         evt.User,
-		Handle:      ai.Handle,
+		Handle:      sql.NullString{String: ai.Handle, Valid: true},
 		Did:         ai.Did,
 		DisplayName: ai.DisplayName,
 		Type:        ai.Type,

--- a/models/models.go
+++ b/models/models.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"database/sql"
 	"time"
 
 	"gorm.io/gorm"
@@ -35,8 +36,8 @@ type RepostRecord struct {
 
 type ActorInfo struct {
 	gorm.Model
-	Uid         Uid    `gorm:"uniqueindex"`
-	Handle      string `gorm:"uniqueindex"`
+	Uid         Uid            `gorm:"uniqueindex"`
+	Handle      sql.NullString `gorm:"uniqueindex"`
 	DisplayName string
 	Did         string `gorm:"uniqueindex"`
 	Following   int64
@@ -50,7 +51,7 @@ type ActorInfo struct {
 func (ai *ActorInfo) ActorRef() *bsky.ActorDefs_ProfileViewBasic {
 	return &bsky.ActorDefs_ProfileViewBasic{
 		Did:         ai.Did,
-		Handle:      ai.Handle,
+		Handle:      ai.Handle.String,
 		DisplayName: &ai.DisplayName,
 	}
 }
@@ -59,7 +60,7 @@ func (ai *ActorInfo) ActorRef() *bsky.ActorDefs_ProfileViewBasic {
 func (ai *ActorInfo) ActorView() *bsky.ActorDefs_ProfileView {
 	return &bsky.ActorDefs_ProfileView{
 		Did:         ai.Did,
-		Handle:      ai.Handle,
+		Handle:      ai.Handle.String,
 		DisplayName: &ai.DisplayName,
 	}
 }

--- a/pds/handlers.go
+++ b/pds/handlers.go
@@ -3,6 +3,7 @@ package pds
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"fmt"
 	"io"
 	"time"
@@ -27,7 +28,7 @@ func (s *Server) handleAppBskyActorGetProfile(ctx context.Context, actor string)
 		Description:    nil,
 		PostsCount:     &profile.Posts,
 		FollowsCount:   &profile.Following,
-		Handle:         profile.Handle,
+		Handle:         profile.Handle.String,
 		DisplayName:    &profile.DisplayName,
 		FollowersCount: &profile.Followers,
 	}, nil
@@ -326,7 +327,7 @@ func (s *Server) handleComAtprotoServerCreateAccount(ctx context.Context, body *
 	ai := &models.ActorInfo{
 		Uid:    u.ID,
 		Did:    d,
-		Handle: body.Handle,
+		Handle: sql.NullString{String: body.Handle, Valid: true},
 	}
 	if err := s.db.Create(ai).Error; err != nil {
 		return nil, err

--- a/pds/server.go
+++ b/pds/server.go
@@ -2,6 +2,7 @@ package pds
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -224,7 +225,7 @@ func (s *Server) createExternalUser(ctx context.Context, did string) (*models.Ac
 	// lets make a local record of that user for the future
 	subj := &models.ActorInfo{
 		Uid:         u.ID,
-		Handle:      handle,
+		Handle:      sql.NullString{String: handle, Valid: true},
 		DisplayName: *profile.DisplayName,
 		Did:         did,
 		Type:        "",

--- a/repomgr/repomgr.go
+++ b/repomgr/repomgr.go
@@ -885,10 +885,17 @@ func (rm *RepoManager) processNewRepo(ctx context.Context, user models.Uid, r io
 	}
 
 	if err := cb(ctx, root, finish, ds); err != nil {
-		return fmt.Errorf("cb errored root: %s, rev: %s: %w", root, *rev, err)
+		return fmt.Errorf("cb errored root: %s, rev: %s: %w", root, stringOrNil(rev), err)
 	}
 
 	return nil
+}
+
+func stringOrNil(s *string) string {
+	if s == nil {
+		return "nil"
+	}
+	return *s
 }
 
 // walkTree returns all cids linked recursively by the root, skipping any cids


### PR DESCRIPTION
We still want to index repos with invalid handles, it should be the downstream consumer's responsibility to validate a handle, especially cause it can change and become invalid without a new HandleChange event being emitted. These events are just hints that you should go grab the DID doc for this user cause it may have changed.