### PR TITLE
for now, add duplicate stale refs to the keep set

### DIFF
--- a/bgs/admin.go
+++ b/bgs/admin.go
@@ -506,5 +506,7 @@ func (bgs *BGS) handleAdminResetRepo(e echo.Context) error {
 		return err
 	}
 
-	return nil
+	return e.JSON(200, map[string]any{
+		"success": true,
+	})
 }

--- a/bgs/admin.go
+++ b/bgs/admin.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bluesky-social/indigo/models"
 	"github.com/labstack/echo/v4"
 	dto "github.com/prometheus/client_model/go"
+	"go.opentelemetry.io/otel"
 	"golang.org/x/time/rate"
 	"gorm.io/gorm"
 )
@@ -397,7 +398,8 @@ func (bgs *BGS) handleAdminChangePDSCrawlLimit(e echo.Context) error {
 }
 
 func (bgs *BGS) handleAdminCompactRepo(e echo.Context) error {
-	ctx := e.Request().Context()
+	ctx, span := otel.Tracer("bgs").Start(context.Background(), "adminCompactRepo")
+	defer span.End()
 
 	did := e.QueryParam("did")
 	if did == "" {
@@ -421,7 +423,8 @@ func (bgs *BGS) handleAdminCompactRepo(e echo.Context) error {
 }
 
 func (bgs *BGS) handleAdminCompactAllRepos(e echo.Context) error {
-	ctx := e.Request().Context()
+	ctx, span := otel.Tracer("bgs").Start(context.Background(), "adminCompactAllRepos")
+	defer span.End()
 
 	if err := bgs.runRepoCompaction(ctx); err != nil {
 		return fmt.Errorf("compaction run failed: %w", err)

--- a/bgs/admin.go
+++ b/bgs/admin.go
@@ -484,3 +484,27 @@ func (bgs *BGS) handleAdminGetResyncPDS(e echo.Context) error {
 		"resync": resync,
 	})
 }
+
+func (bgs *BGS) handleAdminResetRepo(e echo.Context) error {
+	ctx := e.Request().Context()
+
+	did := e.QueryParam("did")
+	if did == "" {
+		return fmt.Errorf("must pass a did")
+	}
+
+	ai, err := bgs.Index.LookupUserByDid(ctx, did)
+	if err != nil {
+		return fmt.Errorf("no such user: %w", err)
+	}
+
+	if err := bgs.repoman.ResetRepo(ctx, ai.Uid); err != nil {
+		return err
+	}
+
+	if err := bgs.Index.Crawler.Crawl(ctx, ai); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -281,6 +281,13 @@ func (bgs *BGS) StartWithListener(listen net.Listener) error {
 				sendHeader = false
 			}
 
+			if strings.HasPrefix(ctx.Path(), "/admin/") {
+				ctx.JSON(500, map[string]any{
+					"error": err.Error(),
+				})
+				return
+			}
+
 			log.Warnf("HANDLER ERROR: (%s) %s", ctx.Path(), err)
 
 			if sendHeader {

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -333,6 +333,7 @@ func (bgs *BGS) StartWithListener(listen net.Listener) error {
 	admin.POST("/repo/reverseTakedown", bgs.handleAdminReverseTakedown)
 	admin.POST("/repo/compact", bgs.handleAdminCompactRepo)
 	admin.POST("/repo/compactAll", bgs.handleAdminCompactAllRepos)
+	admin.POST("/repo/reset", bgs.handleAdminResetRepo)
 
 	// PDS-related Admin API
 	admin.GET("/pds/list", bgs.handleListPDSs)

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -281,14 +281,14 @@ func (bgs *BGS) StartWithListener(listen net.Listener) error {
 				sendHeader = false
 			}
 
+			log.Warnf("HANDLER ERROR: (%s) %s", ctx.Path(), err)
+
 			if strings.HasPrefix(ctx.Path(), "/admin/") {
 				ctx.JSON(500, map[string]any{
 					"error": err.Error(),
 				})
 				return
 			}
-
-			log.Warnf("HANDLER ERROR: (%s) %s", ctx.Path(), err)
 
 			if sendHeader {
 				ctx.Response().WriteHeader(500)

--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -276,6 +276,13 @@ func (cs *CarStore) checkLastShardCache(user models.Uid) *CarShard {
 	return nil
 }
 
+func (cs *CarStore) removeLastShardCache(user models.Uid) {
+	cs.lscLk.Lock()
+	defer cs.lscLk.Unlock()
+
+	delete(cs.lastShardCache, user)
+}
+
 func (cs *CarStore) putLastShardCache(ls *CarShard) {
 	cs.lscLk.Lock()
 	defer cs.lscLk.Unlock()
@@ -962,6 +969,8 @@ func (cs *CarStore) WipeUserData(ctx context.Context, user models.Uid) error {
 			return err
 		}
 	}
+
+	cs.removeLastShardCache(user)
 
 	return nil
 }

--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -1447,6 +1447,13 @@ func (cs *CarStore) compactBucket(ctx context.Context, user models.Uid, b *compB
 	}
 
 	if err := cs.putShard(ctx, &shard, nbrefs, nil, true); err != nil {
+		// if writing the shard fails, we should also delete the file
+		_ = fi.Close()
+
+		if err2 := os.Remove(fi.Name()); err2 != nil {
+			log.Errorf("failed to remove shard file (%s) after failed db transaction: %w", fi.Name(), err2)
+		}
+
 		return err
 	}
 	return nil

--- a/carstore/repo_test.go
+++ b/carstore/repo_test.go
@@ -3,6 +3,7 @@ package carstore
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"github.com/ipfs/go-cid"
 	flatfs "github.com/ipfs/go-ds-flatfs"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	ipld "github.com/ipfs/go-ipld-format"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -138,7 +140,7 @@ func TestBasicOperation(t *testing.T) {
 	if err := cs.ReadUserCar(ctx, 1, "", true, buf); err != nil {
 		t.Fatal(err)
 	}
-	checkRepo(t, buf, recs)
+	checkRepo(t, cs, buf, recs)
 
 	if _, err := cs.CompactUserShards(ctx, 1); err != nil {
 		t.Fatal(err)
@@ -148,7 +150,7 @@ func TestBasicOperation(t *testing.T) {
 	if err := cs.ReadUserCar(ctx, 1, "", true, buf); err != nil {
 		t.Fatal(err)
 	}
-	checkRepo(t, buf, recs)
+	checkRepo(t, cs, buf, recs)
 }
 
 func TestRepeatedCompactions(t *testing.T) {
@@ -177,8 +179,10 @@ func TestRepeatedCompactions(t *testing.T) {
 	var recs []cid.Cid
 	head := ncid
 
+	var lastRec string
+
 	for loop := 0; loop < 50; loop++ {
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 20; i++ {
 			ds, err := cs.NewDeltaSession(ctx, 1, &rev)
 			if err != nil {
 				t.Fatal(err)
@@ -188,15 +192,22 @@ func TestRepeatedCompactions(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			if i%4 == 3 {
+				if err := rr.DeleteRecord(ctx, lastRec); err != nil {
+					t.Fatal(err)
+				}
+				recs = recs[:len(recs)-1]
+			} else {
+				rc, tid, err := rr.CreateRecord(ctx, "app.bsky.feed.post", &appbsky.FeedPost{
+					Text: fmt.Sprintf("hey look its a tweet %d", time.Now().UnixNano()),
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
 
-			rc, _, err := rr.CreateRecord(ctx, "app.bsky.feed.post", &appbsky.FeedPost{
-				Text: fmt.Sprintf("hey look its a tweet %d", time.Now().UnixNano()),
-			})
-			if err != nil {
-				t.Fatal(err)
+				recs = append(recs, rc)
+				lastRec = "app.bsky.feed.post/" + tid
 			}
-
-			recs = append(recs, rc)
 
 			kmgr := &util.FakeKeyManager{}
 			nroot, nrev, err := rr.Commit(ctx, kmgr.SignForUser)
@@ -228,21 +239,21 @@ func TestRepeatedCompactions(t *testing.T) {
 		if err := cs.ReadUserCar(ctx, 1, "", true, buf); err != nil {
 			t.Fatal(err)
 		}
-		checkRepo(t, buf, recs)
+		checkRepo(t, cs, buf, recs)
 	}
 
 	buf := new(bytes.Buffer)
 	if err := cs.ReadUserCar(ctx, 1, "", true, buf); err != nil {
 		t.Fatal(err)
 	}
-	checkRepo(t, buf, recs)
+	checkRepo(t, cs, buf, recs)
 }
 
-func checkRepo(t *testing.T, r io.Reader, expRecs []cid.Cid) {
+func checkRepo(t *testing.T, cs *CarStore, r io.Reader, expRecs []cid.Cid) {
 	t.Helper()
 	rep, err := repo.ReadRepoFromCar(context.TODO(), r)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal("Reading repo: ", err)
 	}
 
 	set := make(map[cid.Cid]bool)
@@ -259,7 +270,23 @@ func checkRepo(t *testing.T, r io.Reader, expRecs []cid.Cid) {
 		return nil
 
 	}); err != nil {
-		t.Fatal(err)
+		var ierr ipld.ErrNotFound
+		if errors.As(err, &ierr) {
+			fmt.Println("matched error")
+			bs, err := cs.ReadOnlySession(1)
+			if err != nil {
+				fmt.Println("couldnt read session: ", err)
+			}
+
+			blk, err := bs.Get(context.TODO(), ierr.Cid)
+			if err != nil {
+				fmt.Println("also failed the local get: ", err)
+			} else {
+				fmt.Println("LOCAL GET SUCCESS", len(blk.RawData()))
+			}
+		}
+
+		t.Fatal("walking repo: ", err)
 	}
 
 	if len(set) > 0 {

--- a/cmd/gosky/bgs.go
+++ b/cmd/gosky/bgs.go
@@ -33,6 +33,7 @@ var bgsAdminCmd = &cli.Command{
 		bgsSetNewSubsEnabledCmd,
 		bgsCompactRepo,
 		bgsCompactAll,
+		bgsResetRepo,
 	},
 }
 
@@ -348,6 +349,47 @@ var bgsCompactAll = &cli.Command{
 	Name: "compact-all",
 	Action: func(cctx *cli.Context) error {
 		url := cctx.String("bgs") + "/admin/repo/compactAll"
+
+		req, err := http.NewRequest("POST", url, nil)
+		if err != nil {
+			return err
+		}
+
+		auth := cctx.String("key")
+		req.Header.Set("Authorization", "Bearer "+auth)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode != 200 {
+			var e xrpc.XRPCError
+			if err := json.NewDecoder(resp.Body).Decode(&e); err != nil {
+				return err
+			}
+
+			return &e
+		}
+
+		var out map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			return err
+		}
+
+		fmt.Println(out)
+
+		return nil
+	},
+}
+
+var bgsResetRepo = &cli.Command{
+	Name: "reset-repo",
+	Action: func(cctx *cli.Context) error {
+		url := cctx.String("bgs") + "/admin/repo/reset"
+
+		did := cctx.Args().First()
+		url += fmt.Sprintf("?did=%s", did)
 
 		req, err := http.NewRequest("POST", url, nil)
 		if err != nil {

--- a/cmd/gosky/debug.go
+++ b/cmd/gosky/debug.go
@@ -775,7 +775,7 @@ var debugGetRepoCmd = &cli.Command{
 		if err := rep.ForEach(ctx, "", func(k string, v cid.Cid) error {
 			rec, err := rep.Blockstore().Get(ctx, v)
 			if err != nil {
-				return err
+				return fmt.Errorf("getting record %q: %w", k, err)
 			}
 
 			count++

--- a/mst/mst.go
+++ b/mst/mst.go
@@ -944,26 +944,26 @@ func (mst *MerkleSearchTree) WalkLeavesFrom(ctx context.Context, from string, cb
 
 	entries, err := mst.getEntries(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("get entries: %w", err)
 	}
 
 	if index > 0 {
 		prev := entries[index-1]
 		if !prev.isUndefined() && prev.isTree() {
 			if err := prev.Tree.WalkLeavesFrom(ctx, from, cb); err != nil {
-				return err
+				return fmt.Errorf("walk leaves %d: %w", index, err)
 			}
 		}
 	}
 
-	for _, e := range entries[index:] {
+	for i, e := range entries[index:] {
 		if e.isLeaf() {
 			if err := cb(e.Key, e.Val); err != nil {
 				return err
 			}
 		} else {
 			if err := e.Tree.WalkLeavesFrom(ctx, from, cb); err != nil {
-				return err
+				return fmt.Errorf("walk leaves from (%d): %w", i, err)
 			}
 		}
 	}

--- a/repomgr/repomgr.go
+++ b/repomgr/repomgr.go
@@ -731,7 +731,7 @@ func (rm *RepoManager) ImportNewRepo(ctx context.Context, user models.Uid, repoD
 
 		diffops, err := r.DiffSince(ctx, curhead)
 		if err != nil {
-			return fmt.Errorf("diff trees: %w", err)
+			return fmt.Errorf("diff trees (curhead: %s): %w", curhead, err)
 		}
 
 		var ops []RepoOp

--- a/repomgr/repomgr.go
+++ b/repomgr/repomgr.go
@@ -951,5 +951,13 @@ func (rm *RepoManager) TakeDownRepo(ctx context.Context, uid models.Uid) error {
 	unlock := rm.lockUser(ctx, uid)
 	defer unlock()
 
-	return rm.cs.TakeDownRepo(ctx, uid)
+	return rm.cs.WipeUserData(ctx, uid)
+}
+
+// technically identical to TakeDownRepo, for now
+func (rm *RepoManager) ResetRepo(ctx context.Context, uid models.Uid) error {
+	unlock := rm.lockUser(ctx, uid)
+	defer unlock()
+
+	return rm.cs.WipeUserData(ctx, uid)
 }


### PR DESCRIPTION
if a deleted block matches multiple blockRefs in a given repo, we can't safely assume its no longer referenced. The 'correct' way to move forward is to do a full repo traversal to enumerate the 'correct' set of blocks referenced in the MST, but that requires more thought and is actually something that needs to be done at the repo manager level (and involves extra locking and other shenanigans that i dont want to implement just yet).

So for now, we add duplicate blocks to the keep set and just assume they are still being referenced somewhere.