### PR TITLE
BGS: allow non-SSL BGS with SSL PDS

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -1026,7 +1026,7 @@ func (s *BGS) createExternalUser(ctx context.Context, did string) (*models.Actor
 		peering.Host = durl.Host
 		peering.SSL = (durl.Scheme == "https")
 
-		if s.ssl != peering.SSL {
+		if s.ssl && !peering.SSL {
 			return nil, fmt.Errorf("did references non-ssl PDS, this is disallowed in prod: %q %q", did, svc.ServiceEndpoint)
 		}
 


### PR DESCRIPTION
seems like this should hopefully be allowed for testing, and the main combination we want to prevent is SSL (ie prod) BGS with non-SSL PDS...?