### PR TITLE
identity: add fallback DNS servers

### DIFF
--- a/atproto/identity/base_directory.go
+++ b/atproto/identity/base_directory.go
@@ -26,6 +26,8 @@ type BaseDirectory struct {
 	TryAuthoritativeDNS bool
 	// set of handle domain suffixes for for which DNS handle resolution will be skipped
 	SkipDNSDomainSuffixes []string
+	// set of fallback DNS servers (eg, domain registrars) to try as a fallback. each entry should be "ip:port", eg "8.8.8.8:53"
+	FallbackDNSServers []string
 }
 
 var _ Directory = (*BaseDirectory)(nil)

--- a/atproto/identity/live_test.go
+++ b/atproto/identity/live_test.go
@@ -117,6 +117,8 @@ func TestCacheCoalesce(t *testing.T) {
 }
 
 func TestFallbackDNS(t *testing.T) {
+	t.Skip("TODO: skipping live network test")
+
 	assert := assert.New(t)
 	ctx := context.Background()
 	handle := syntax.Handle("no-such-record.atproto.com")

--- a/atproto/identity/live_test.go
+++ b/atproto/identity/live_test.go
@@ -115,3 +115,23 @@ func TestCacheCoalesce(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestFallbackDNS(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+	handle := syntax.Handle("no-such-record.atproto.com")
+	dir := BaseDirectory{
+		FallbackDNSServers: []string{"1.1.1.1:53", "8.8.8.8:53"},
+	}
+
+	// valid DNS server
+	_, err := dir.LookupHandle(ctx, handle)
+	assert.Error(err)
+	assert.Equal(ErrHandleNotFound, err)
+
+	// invalid DNS server syntax
+	dir.FallbackDNSServers = []string{"_"}
+	_, err = dir.LookupHandle(ctx, handle)
+	assert.Error(err)
+	assert.NotEqual(ErrHandleNotFound, err)
+}


### PR DESCRIPTION
Quick addition to DNS handle resolution to allow configuring a set of fallback DNS servers which will be tried after regular DNS and (optional) authoritative DNS.

Haven't tested super carefully. Does seem kind of aggressive to do all these DNS queries for *every* failed DNS lookup, but we can tweak at larger scale if needed.