### PR TITLE
Fix MST key validation to allow single-character rkeys

### DIFF
--- a/mst/mst_util.go
+++ b/mst/mst_util.go
@@ -226,7 +226,7 @@ func isValidMstKey(s string) bool {
 		return false
 	}
 	a, b, _ := strings.Cut(s, "/")
-	return len(b) > 1 &&
+	return len(b) > 0 &&
 		keyHasAllValidChars(a) &&
 		keyHasAllValidChars(b)
 }


### PR DESCRIPTION
Resolves this error we see in the BGS:
```
[error] failed to perform repo crawl of "did:plc:fdmcbkpwxxi35an4kji4om2m": importing fetched repo (curRev: 3kapejih6ae2p): process new repo (current rev: 3kapejih6ae2p): cb errored root: bafyreia65iivyzibvlcewb2mh3n5rzfcx7hxnkbbaeht2buveg7hd3ov4a, rev: 3kapejih6ae2p: diff trees (curhead: bafyreia7tzyuy3cxx42xuhfc3g2cownlgpydji6gvl6ux2cgri4m7mdhdu): Not a valid MST key: app.bsky.feed.generator/A:
```

We're not matching the Typescript logic quite right, this fixes it.