### PR TITLE
more trace attributes and some tweaks

### DIFF
--- a/bgs/metrics.go
+++ b/bgs/metrics.go
@@ -16,6 +16,12 @@ var eventsReceivedCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help: "The total number of events received",
 }, []string{"pds"})
 
+var eventsHandleDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "events_handle_duration",
+	Help:    "A histogram of handleFedEvent latencies",
+	Buckets: prometheus.ExponentialBuckets(0.001, 2, 15),
+}, []string{"pds"})
+
 var repoCommitsReceivedCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "repo_commits_received_counter",
 	Help: "The total number of events received",

--- a/cmd/gosky/main.go
+++ b/cmd/gosky/main.go
@@ -199,7 +199,7 @@ var postCmd = &cli.Command{
 			Repo:       auth.Did,
 			Record: &lexutil.LexiconTypeDecoder{&appbsky.FeedPost{
 				Text:      text,
-				CreatedAt: time.Now().Format(util.ISO8601),
+				CreatedAt: time.Now().UTC().Format(util.ISO8601),
 			}},
 		})
 		if err != nil {

--- a/repomgr/repomgr.go
+++ b/repomgr/repomgr.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ipld/go-car"
 	cbg "github.com/whyrusleeping/cbor-gen"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"gorm.io/gorm"
 )
 
@@ -489,6 +490,8 @@ func (rm *RepoManager) CheckRepoSig(ctx context.Context, r *repo.Repo, expdid st
 func (rm *RepoManager) HandleExternalUserEvent(ctx context.Context, pdsid uint, uid models.Uid, did string, since *string, nrev string, carslice []byte, ops []*atproto.SyncSubscribeRepos_RepoOp) error {
 	ctx, span := otel.Tracer("repoman").Start(ctx, "HandleExternalUserEvent")
 	defer span.End()
+
+	span.SetAttributes(attribute.Int64("uid", int64(uid)))
 
 	log.Infow("HandleExternalUserEvent", "pds", pdsid, "uid", uid, "since", since, "nrev", nrev)
 


### PR DESCRIPTION
a small grab-bag of changes, most things are either tweaking a batch size or adding an attribute to a trace.
The one 'real' change here is falling back to an individual block read instead of a prefetch if the shard in question is over a size limit.