### PR TITLE
disallow invalid handle TLDs

### DIFF
--- a/atproto/identity/base_directory.go
+++ b/atproto/identity/base_directory.go
@@ -73,7 +73,7 @@ func (d *BaseDirectory) LookupDID(ctx context.Context, did syntax.DID) (*Identit
 	if err != nil && err != ErrHandleNotFound {
 		return nil, err
 	} else if ErrHandleNotFound == err || resolvedDID != did {
-		ident.Handle = syntax.Handle("handle.invalid")
+		ident.Handle = syntax.HandleInvalid
 	} else {
 		ident.Handle = declared
 	}

--- a/atproto/identity/handle.go
+++ b/atproto/identity/handle.go
@@ -164,6 +164,10 @@ func (d *BaseDirectory) ResolveHandle(ctx context.Context, handle syntax.Handle)
 	var dnsErr error
 	var did syntax.DID
 
+	if !handle.AllowedTLD() {
+		return "", ErrHandleReservedTLD
+	}
+
 	tryDNS := true
 	for _, suffix := range d.SkipDNSDomainSuffixes {
 		if strings.HasSuffix(handle.String(), suffix) {

--- a/atproto/identity/identity.go
+++ b/atproto/identity/identity.go
@@ -40,6 +40,9 @@ var ErrHandleNotFound = errors.New("handle not found")
 // Indicates that handle and DID resolved, but handle points to a DID with a different handle. This is only returned when looking up a handle, not when looking up a DID.
 var ErrHandleNotValid = errors.New("handle resolves to DID with different handle")
 
+// Handle top-level domain (TLD) is one of the special "Reserved" suffixes, and not allowed for atproto use
+var ErrHandleReservedTLD = errors.New("handle top-level domain is disallowed")
+
 // Indicates that resolution process completed successfully, but the DID does not exist.
 var ErrDIDNotFound = errors.New("DID not found")
 

--- a/atproto/identity/live_test.go
+++ b/atproto/identity/live_test.go
@@ -50,7 +50,7 @@ func testDirectoryLive(t *testing.T, d Directory) {
 	_, err = d.LookupDID(ctx, syntax.DID("did:plc:fake-dummy-no-resolve.atproto.com"))
 	assert.Equal(ErrDIDNotFound, err)
 
-	_, err = d.LookupHandle(ctx, syntax.Handle("handle.invalid"))
+	_, err = d.LookupHandle(ctx, syntax.HandleInvalid)
 	assert.Error(err)
 }
 

--- a/atproto/identity/mock_directory_test.go
+++ b/atproto/identity/mock_directory_test.go
@@ -20,7 +20,7 @@ func TestMockDirectory(t *testing.T) {
 	}
 	id2 := Identity{
 		DID:    syntax.DID("did:plc:abc222"),
-		Handle: syntax.Handle("handle.invalid"),
+		Handle: syntax.HandleInvalid,
 	}
 	id3 := Identity{
 		DID:    syntax.DID("did:plc:abc333"),
@@ -48,7 +48,7 @@ func TestMockDirectory(t *testing.T) {
 	assert.NoError(err)
 	assert.True(out.Handle.IsInvalidHandle())
 
-	_, err = c.LookupHandle(ctx, syntax.Handle("handle.invalid"))
+	_, err = c.LookupHandle(ctx, syntax.HandleInvalid)
 	assert.Equal(ErrHandleNotFound, err)
 	out, err = c.LookupDID(ctx, syntax.DID("did:plc:abc999"))
 	assert.Equal(ErrDIDNotFound, err)

--- a/atproto/syntax/handle.go
+++ b/atproto/syntax/handle.go
@@ -31,6 +31,8 @@ func ParseHandle(raw string) (Handle, error) {
 }
 
 // Some top-level domains (TLDs) are disallowed for registration across the atproto ecosystem. The *syntax* is valid, but these should never be considered acceptable handles for account registration or linking.
+//
+// The reserved '.test' TLD is allowed, for testing and development. It is expected that '.test' domain resolution will fail in a real-world network.
 func (h Handle) AllowedTLD() bool {
 	switch h.TLD() {
 	case "local",
@@ -38,7 +40,9 @@ func (h Handle) AllowedTLD() bool {
 		"invalid",
 		"localhost",
 		"internal",
-		"onion":
+		"example",
+		"onion",
+		"alt":
 		return false
 	}
 	return true

--- a/atproto/syntax/handle.go
+++ b/atproto/syntax/handle.go
@@ -6,7 +6,12 @@ import (
 	"strings"
 )
 
-var handleRegex = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
+var (
+	handleRegex = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$`)
+
+	// special handle string constant indicating that handle resolution failed
+	HandleInvalid = Handle("handle.invalid")
+)
 
 // String type which represents a syntaxtually valid handle identifier, as would pass Lexicon syntax validation.
 //


### PR DESCRIPTION
Realized this wasn't being enforced at resolution time like it should be. These are allowed in *syntax* but not at resolution time.

Also adds the `.example` and `.alt` TLDs, and defines invalid handle as a constant (requested earlier). (updating spec doc and typescript impl in parallel)

closes: https://github.com/bluesky-social/indigo/issues/306