### PR TITLE
Palomar profile search improvements

### DIFF
--- a/cmd/palomar/main.go
+++ b/cmd/palomar/main.go
@@ -219,12 +219,8 @@ var runCmd = &cli.Command{
 }
 
 var elasticCheckCmd = &cli.Command{
-	Name: "elastic-check",
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name: "elastic-cert",
-		},
-	},
+	Name:  "elastic-check",
+	Flags: []cli.Flag{},
 	Action: func(cctx *cli.Context) error {
 		escli, err := createEsClient(cctx)
 		if err != nil {

--- a/cmd/palomar/main.go
+++ b/cmd/palomar/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -42,6 +43,11 @@ func run(args []string) error {
 			Name:    "elastic-cert-file",
 			Usage:   "certificate file path",
 			EnvVars: []string{"ES_CERT_FILE", "ELASTIC_CERT_FILE"},
+		},
+		&cli.BoolFlag{
+			Name:    "elastic-insecure-ssl",
+			Usage:   "if true, disable SSL cert validation",
+			EnvVars: []string{"ES_INSECURE_SSL"},
 		},
 		&cli.StringFlag{
 			Name:    "elastic-username",
@@ -349,6 +355,8 @@ func createEsClient(cctx *cli.Context) (*es.Client, error) {
 		cert = b
 	}
 
+	insecure := cctx.Bool("elastic-insecure-ssl")
+
 	cfg := es.Config{
 		Addresses: addrs,
 		Username:  cctx.String("elastic-username"),
@@ -356,6 +364,9 @@ func createEsClient(cctx *cli.Context) (*es.Client, error) {
 		CACert:    cert,
 		Transport: &http.Transport{
 			MaxIdleConnsPerHost: 20,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: insecure,
+			},
 		},
 	}
 

--- a/search/query.go
+++ b/search/query.go
@@ -228,7 +228,10 @@ func doSearch(ctx context.Context, escli *es.Client, index string, query interfa
 	}
 	defer res.Body.Close()
 	if res.IsError() {
-		ioutil.ReadAll(res.Body)
+		raw, err := ioutil.ReadAll(res.Body)
+		if nil == err {
+			slog.Warn("search query error", "resp", string(raw), "status_code", res.StatusCode)
+		}
 		return nil, fmt.Errorf("search query error, code=%d", res.StatusCode)
 	}
 


### PR DESCRIPTION
These are tweaks to search quality, mostly typeahead, with no change to index schema (so no reindexing needed). A couple basic fixes, and then some boosting and rescoring hacks.

I tested these by having local palomar query the prod search index over an SSH tunnel. I didn't check query latencies, but nothing was crazy slow, and based on the changes i'm fairly confident there won't be a significant latency hit for typeahead. Profile search may get a bit slower.

There are some remaining quality issues we will probably want to revisit, but would probably require re-indexing. Eg, we are not doing any stemming at all on fulltext fields (my bad!). This will impact profile descriptions, but in particular posts.