### PR TITLE
Add verbose logging to palomar handle updates

### DIFF
--- a/search/firehose.go
+++ b/search/firehose.go
@@ -153,7 +153,12 @@ func (s *Server) RunIndexer(ctx context.Context) error {
 
 		},
 		RepoHandle: func(evt *comatproto.SyncSubscribeRepos_Handle) error {
-			if err := s.updateUserHandle(ctx, evt.Did, evt.Handle); err != nil {
+			did, err := syntax.ParseDID(evt.Did)
+			if err != nil {
+				s.logger.Error("bad DID in RepoHandle event", "did", evt.Did, "handle", evt.Handle, "seq", evt.Seq, "err", err)
+				return nil
+			}
+			if err := s.updateUserHandle(ctx, did, evt.Handle); err != nil {
 				// TODO: handle this case (instead of return nil)
 				s.logger.Error("failed to update user handle", "did", evt.Did, "handle", evt.Handle, "seq", evt.Seq, "err", err)
 			}

--- a/search/indexing.go
+++ b/search/indexing.go
@@ -136,8 +136,7 @@ func (s *Server) indexProfile(ctx context.Context, ident *identity.Identity, rec
 func (s *Server) updateUserHandle(ctx context.Context, did syntax.DID, handle string) error {
 	log := s.logger.With("repo", did.String(), "op", "updateUserHandle", "handle_from_event", handle)
 
-	didID := syntax.AtIdentifier{Inner: did}
-	err := s.dir.Purge(ctx, didID)
+	err := s.dir.Purge(ctx, did.AtIdentifier())
 	if err != nil {
 		log.Warn("failed to purge DID from directory", "err", err)
 		return err

--- a/search/indexing.go
+++ b/search/indexing.go
@@ -133,22 +133,17 @@ func (s *Server) indexProfile(ctx context.Context, ident *identity.Identity, rec
 	return nil
 }
 
-func (s *Server) updateUserHandle(ctx context.Context, didStr, handle string) error {
-	log := s.logger.With("repo", didStr, "op", "updateUserHandle", "handle_from_event", handle)
+func (s *Server) updateUserHandle(ctx context.Context, did syntax.DID, handle string) error {
+	log := s.logger.With("repo", did.String(), "op", "updateUserHandle", "handle_from_event", handle)
 
-	did, err := syntax.ParseAtIdentifier(didStr)
-	if err != nil || did == nil {
-		log.Warn("failed to parse DID", "err", err)
-		return err
-	}
-
-	err = s.dir.Purge(ctx, *did)
+	didID := syntax.AtIdentifier{Inner: did}
+	err := s.dir.Purge(ctx, didID)
 	if err != nil {
 		log.Warn("failed to purge DID from directory", "err", err)
 		return err
 	}
 
-	ident, err := s.dir.LookupDID(ctx, syntax.DID(didStr))
+	ident, err := s.dir.LookupDID(ctx, did)
 	if err != nil {
 		log.Warn("failed to lookup DID in directory", "err", err)
 		return err
@@ -172,7 +167,7 @@ func (s *Server) updateUserHandle(ctx context.Context, didStr, handle string) er
 
 	req := esapi.UpdateRequest{
 		Index:      s.profileIndex,
-		DocumentID: didStr,
+		DocumentID: did.String(),
 		Body:       bytes.NewReader(b),
 	}
 


### PR DESCRIPTION
This change adds verbose logging to Palomar handle updates and resolves handles from PLC when seeing an update instead of trusting the handle from the event.