### PR TITLE
palomar: revert 'and' in a query

### DIFF
--- a/search/query.go
+++ b/search/query.go
@@ -133,8 +133,8 @@ func DoSearchProfilesTypeahead(ctx context.Context, escli *es.Client, index, q s
 	query := map[string]interface{}{
 		"query": map[string]interface{}{
 			"multi_match": map[string]interface{}{
-				"query":    q,
-				"type":     "bool_prefix",
+				"query": q,
+				"type":  "bool_prefix",
 				"fields": []string{
 					// adding handle here improves relevency but may be too expensive in prod
 					//"handle^2",

--- a/search/query.go
+++ b/search/query.go
@@ -135,7 +135,6 @@ func DoSearchProfilesTypeahead(ctx context.Context, escli *es.Client, index, q s
 			"multi_match": map[string]interface{}{
 				"query":    q,
 				"type":     "bool_prefix",
-				"operator": "and",
 				"fields": []string{
 					// adding handle here improves relevency but may be too expensive in prod
 					//"handle^2",


### PR DESCRIPTION
This is on top of https://github.com/bluesky-social/indigo/pull/392, and removes the "and" in query as well