### PR TITLE
Add error handling for listInviteTreeCmd

### DIFF
--- a/cmd/gosky/admin.go
+++ b/cmd/gosky/admin.go
@@ -595,7 +595,8 @@ var listInviteTreeCmd = &cli.Command{
 
 			rep, err := atproto.AdminGetRepo(ctx, xrpcc, next)
 			if err != nil {
-				return fmt.Errorf("getRepo %s: %w", did, err)
+				fmt.Printf("Failed to getRepo for DID %s: %s\n", next, err.Error())
+				continue
 			}
 			fmt.Print(next)
 


### PR DESCRIPTION
Adds error handling so we can iterate through an entire invite tree even if it contains accounts that have been taken down or otherwise error out on getRepo.