### PR TITLE
Use a 4MiB buffer for event stream connections instead of 10KiB

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -517,7 +517,7 @@ func (bgs *BGS) EventsHandler(c echo.Context) error {
 	defer cancel()
 
 	// TODO: authhhh
-	conn, err := websocket.Upgrade(c.Response(), c.Request(), c.Response().Header(), 10<<10, 10<<10)
+	conn, err := websocket.Upgrade(c.Response(), c.Request(), c.Response().Header(), 4<<20, 4<<20)
 	if err != nil {
 		return fmt.Errorf("upgrading websocket: %w", err)
 	}


### PR DESCRIPTION
This change should improve performance of event playback to higher latency connections which have currently been limited in throughput because of bandwidth-delay-product issues.

https://linuxczar.net/blog/2016/09/18/bandwidth-delay-product/

Using a 4MiB buffer should allow for up to 16MiB/sec of throughput on a connection with a 250ms RTT.