### PR TITLE
ensure 'blocks' field is set in tooBig events

### DIFF
--- a/events/dbpersist.go
+++ b/events/dbpersist.go
@@ -549,6 +549,7 @@ func (p *DbPersistence) hydrateCommit(ctx context.Context, rer *RepoEventRecord)
 
 	if len(cs) > carstore.MaxSliceLength {
 		out.TooBig = true
+		out.Blocks = []byte{}
 	} else {
 		out.Blocks = cs
 	}

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -148,7 +148,7 @@ func (ix *Indexer) HandleRepoEvent(ctx context.Context, evt *repomgr.RepoEvent) 
 	toobig := false
 	slice := evt.RepoSlice
 	if len(slice) > MaxEventSliceLength || len(outops) > MaxOpsSliceLength {
-		slice = nil
+		slice = []byte{}
 		outops = nil
 		toobig = true
 	}


### PR DESCRIPTION
The `blocks` field is required to be present in order to pass validation in the typescript code.