### PR TITLE
drop unique constraint on handles

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -455,7 +455,7 @@ type User struct {
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 	DeletedAt   gorm.DeletedAt `gorm:"index"`
-	Handle      sql.NullString `gorm:"uniqueIndex"`
+	Handle      sql.NullString `gorm:"index"`
 	Did         string         `gorm:"uniqueIndex"`
 	PDS         uint
 	ValidHandle bool `gorm:"default:true"`

--- a/models/models.go
+++ b/models/models.go
@@ -37,7 +37,7 @@ type RepostRecord struct {
 type ActorInfo struct {
 	gorm.Model
 	Uid         Uid            `gorm:"uniqueindex"`
-	Handle      sql.NullString `gorm:"uniqueindex"`
+	Handle      sql.NullString `gorm:"index"`
 	DisplayName string
 	Did         string `gorm:"uniqueindex"`
 	Following   int64


### PR DESCRIPTION
When users change their handles, that change doesnt necessarily propagate through the whole world consistently. The big issue this causes for us is if a user changes their handle from X to Y, and we arent able to validate it, we dont update our accounting of that change. Then if a new user creates an account with handle X, we fail to correctly initialize that user because of the uniqueness constraint.


I think I'll have to manually do these migrations, i doubt gorm will correctly swap the indexes from unique to not-unique.

I read through all the code referencing unique conflicts and handle setting and I believe this should work just fine.