### PR TITLE
drop consumers if their out buffer fills up

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -78,7 +78,7 @@ func (em *EventManager) broadcastEvent(evt *XRPCStreamEvent) {
 				log.Warnw("dropping slow consumer due to event overflow", "bufferSize", len(s.outgoing), "ident", s.ident)
 				go func(torem *Subscriber) {
 					select {
-					case s.outgoing <- &XRPCStreamEvent{
+					case torem.outgoing <- &XRPCStreamEvent{
 						Error: &ErrorFrame{
 							Error: "ConsumerTooSlow",
 						},

--- a/events/events.go
+++ b/events/events.go
@@ -77,7 +77,10 @@ func (em *EventManager) broadcastEvent(evt *XRPCStreamEvent) {
 					em.rmSubscriber(torem)
 				}(s)
 			default:
-				log.Warnf("event overflow (%d)", len(s.outgoing))
+				log.Warnw("event overflow", "bufferSize", len(s.outgoing), "ident", s.ident)
+				go func(torem *Subscriber) {
+					em.rmSubscriber(torem)
+				}(s)
 			}
 			s.broadcastCounter.Inc()
 		}

--- a/events/events.go
+++ b/events/events.go
@@ -73,13 +73,10 @@ func (em *EventManager) broadcastEvent(evt *XRPCStreamEvent) {
 			select {
 			case s.outgoing <- evt:
 			case <-s.done:
-				go func(torem *Subscriber) {
-					em.rmSubscriber(torem)
-				}(s)
 			default:
 				log.Warnw("event overflow", "bufferSize", len(s.outgoing), "ident", s.ident)
 				go func(torem *Subscriber) {
-					em.rmSubscriber(torem)
+					torem.cleanup()
 				}(s)
 			}
 			s.broadcastCounter.Inc()
@@ -102,6 +99,8 @@ type Subscriber struct {
 	filter func(*XRPCStreamEvent) bool
 
 	done chan struct{}
+
+	cleanup func()
 
 	ident            string
 	enqueuedCounter  prometheus.Counter
@@ -167,15 +166,15 @@ func (em *EventManager) Subscribe(ctx context.Context, ident string, filter func
 		broadcastCounter: eventsBroadcast.WithLabelValues(ident),
 	}
 
-	cleanup := func() {
+	sub.cleanup = sync.OnceFunc(func() {
 		close(done)
 		em.rmSubscriber(sub)
 		close(sub.outgoing)
-	}
+	})
 
 	if since == nil {
 		em.addSubscriber(sub)
-		return sub.outgoing, cleanup, nil
+		return sub.outgoing, sub.cleanup, nil
 	}
 
 	out := make(chan *XRPCStreamEvent, em.bufferSize)
@@ -246,7 +245,7 @@ func (em *EventManager) Subscribe(ctx context.Context, ident string, filter func
 		}
 	}()
 
-	return out, cleanup, nil
+	return out, sub.cleanup, nil
 }
 
 func sequenceForEvent(evt *XRPCStreamEvent) int64 {

--- a/events/events.go
+++ b/events/events.go
@@ -84,7 +84,7 @@ func (em *EventManager) broadcastEvent(evt *XRPCStreamEvent) {
 						},
 					}:
 					case <-time.After(time.Second * 5):
-						log.Warnw("failed to send error frame to backed up consumer", "ident", s.ident)
+						log.Warnw("failed to send error frame to backed up consumer", "ident", torem.ident)
 					}
 					torem.cleanup()
 				}(s)


### PR DESCRIPTION
right now if these buffers fill up we just start dropping events, and then when the buffers drain we just resume sending events. this seems quite wrong.

