### PR TITLE
only traverse cbor blocks when running mst diff

### DIFF
--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -905,6 +905,10 @@ func BlockDiff(ctx context.Context, bs blockstore.Blockstore, oldroot cid.Cid, n
 		}
 
 		if err := cbg.ScanForLinks(bytes.NewReader(oblk.RawData()), func(lnk cid.Cid) {
+			if lnk.Prefix().Codec != cid.DagCBOR {
+				return
+			}
+
 			if !keepset[lnk] {
 				dropset[lnk] = true
 				queue = append(queue, lnk)


### PR DESCRIPTION
I spaced the fact that we include proper dag-cbor cid links to images which are not actually included in the car slices. In the case where someone drops a reference to an image (deletes an image post, or updates their profile picture) then we would hit this 'ipld not found' error on the image cid (since we never got it in the first place).

Here, we skip any CID that isnt CBOR, This is a reasonable assumption to make for now, unless we start dangling random cbor graphs off of the MST, at which point ill probably need to get more clever (I'd really rather not).