### PR TITLE
Tell RobustHTTPClient to treat rate-limiting as non-retryable error

### DIFF
--- a/xrpc/xrpc.go
+++ b/xrpc/xrpc.go
@@ -19,8 +19,6 @@ import (
 
 type Client struct {
 	// Client is an HTTP client to use. If not set, defaults to http.RobustHTTPClient().
-	// Note that http.RobustHTTPClient() swallows retryable errors (including hitting a rate limit),
-	// not allowing your code to handle them differently.
 	Client     *http.Client
 	Auth       *AuthInfo
 	AdminToken *string


### PR DESCRIPTION
This is a simplest possible approach to pass through hitting a rate limit to the application that uses the default XRPC client.

It's a design question if this is what you want to have. Alternatives include:
* Gate this behaviour change behind a flag in `xrpc.Client` struct
* Allowing to specify a threshold for the duration until rate limit reset, below which the client would keep the current behaviour

FWIW, JS client seems to not have any retry logic in place.