### PR TITLE
temporarily remove the did doc field from auth response

### DIFF
--- a/api/atproto/serverrefreshSession.go
+++ b/api/atproto/serverrefreshSession.go
@@ -7,17 +7,16 @@ package atproto
 import (
 	"context"
 
-	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // ServerRefreshSession_Output is the output of a com.atproto.server.refreshSession call.
 type ServerRefreshSession_Output struct {
-	AccessJwt  string                   `json:"accessJwt" cborgen:"accessJwt"`
-	Did        string                   `json:"did" cborgen:"did"`
-	DidDoc     *util.LexiconTypeDecoder `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
-	Handle     string                   `json:"handle" cborgen:"handle"`
-	RefreshJwt string                   `json:"refreshJwt" cborgen:"refreshJwt"`
+	AccessJwt string `json:"accessJwt" cborgen:"accessJwt"`
+	Did       string `json:"did" cborgen:"did"`
+	//DidDoc     *util.LexiconTypeDecoder `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
+	Handle     string `json:"handle" cborgen:"handle"`
+	RefreshJwt string `json:"refreshJwt" cborgen:"refreshJwt"`
 }
 
 // ServerRefreshSession calls the XRPC method "com.atproto.server.refreshSession".


### PR DESCRIPTION
this value is typed as "unknown" in lexicon, which we don't really know how to map into a go type here