### PR TITLE
properly close websocket when we terminate the connection

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -522,6 +522,8 @@ func (bgs *BGS) EventsHandler(c echo.Context) error {
 		return fmt.Errorf("upgrading websocket: %w", err)
 	}
 
+	defer conn.Close()
+
 	lastWriteLk := sync.Mutex{}
 	lastWrite := time.Now()
 


### PR DESCRIPTION
We kick off slow consumers, but apparently forgot to actually close the connection. I think this oughta be all we need