### PR TITLE
license: change formatting so licensecheck detects better

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,8 @@
-Dual MIT/Apache-2.0 License
-
-Copyright (c) 2022-2023 Bluesky PBC, @whyrusleeping, and Contributors
-
 Except as otherwise noted in individual files, this software is licensed under the MIT license (<http://opensource.org/licenses/MIT>), or the Apache License, Version 2.0 (<http://www.apache.org/licenses/LICENSE-2.0>).
 
 Downstream projects and end users may chose either license individually, or both together, at their discretion. The motivation for this dual-licensing is the additional software patent assurance provided by Apache 2.0.
+
+Copyright (c) 2022-2023 Bluesky PBC, @whyrusleeping, and Contributors
+
+MIT: https://www.opensource.org/licenses/mit
+Apache-2.0: https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
The underlying motivation is that pkg.go.dev can't detect our license combination, and refuses to show docs w/o a known license.

This change is based on looking at how https://github.com/ipfs/kubo formats their license file, and checking with the 'licensecheck' golang package.