### PR TITLE
if repo base has a 'prev', ignore block diff errors

### DIFF
--- a/backfill/backfill.go
+++ b/backfill/backfill.go
@@ -342,11 +342,13 @@ func (b *Backfiller) BackfillRepo(ctx context.Context, job Job) {
 	// Producer routine
 	go func() {
 		defer close(recordQueue)
-		r.ForEach(ctx, b.NSIDFilter, func(recordPath string, nodeCid cid.Cid) error {
+		if err := r.ForEach(ctx, b.NSIDFilter, func(recordPath string, nodeCid cid.Cid) error {
 			numRecords++
 			recordQueue <- recordQueueItem{recordPath: recordPath, nodeCid: nodeCid}
 			return nil
-		})
+		}); err != nil {
+			log.Error("failed to iterated records in repo", "err", err)
+		}
 	}()
 
 	// Consumer routines

--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -861,7 +861,7 @@ func setToSlice(s map[cid.Cid]bool) []cid.Cid {
 	return out
 }
 
-func BlockDiff(ctx context.Context, bs blockstore.Blockstore, oldroot cid.Cid, newcids map[cid.Cid]blockformat.Block) (map[cid.Cid]bool, error) {
+func BlockDiff(ctx context.Context, bs blockstore.Blockstore, oldroot cid.Cid, newcids map[cid.Cid]blockformat.Block, skipmissing bool) (map[cid.Cid]bool, error) {
 	ctx, span := otel.Tracer("repo").Start(ctx, "BlockDiff")
 	defer span.End()
 
@@ -901,7 +901,11 @@ func BlockDiff(ctx context.Context, bs blockstore.Blockstore, oldroot cid.Cid, n
 
 		oblk, err := bs.Get(ctx, c)
 		if err != nil {
-			return nil, fmt.Errorf("get failed in old tree: %w", err)
+			if skipmissing && ipld.IsNotFound(err) {
+				log.Warnw("missing block in old tree", "root", oldroot, "missing", c)
+			} else {
+				return nil, fmt.Errorf("get failed in old tree: %w", err)
+			}
 		}
 
 		if err := cbg.ScanForLinks(bytes.NewReader(oblk.RawData()), func(lnk cid.Cid) {
@@ -956,20 +960,13 @@ func (cs *CarStore) ImportSlice(ctx context.Context, uid models.Uid, since *stri
 		}
 	}
 
-	rmcids, err := BlockDiff(ctx, ds, ds.baseCid, ds.blks)
-	if err != nil {
-		return cid.Undef, nil, fmt.Errorf("block diff failed (base=%s,since=%v,rev=%s): %w", ds.baseCid, since, ds.lastRev, err)
-	}
-
-	ds.rmcids = rmcids
-
 	return carr.Header.Roots[0], ds, nil
 }
 
-func (ds *DeltaSession) CalcDiff(ctx context.Context, nroot cid.Cid) error {
-	rmcids, err := BlockDiff(ctx, ds, ds.baseCid, ds.blks)
+func (ds *DeltaSession) CalcDiff(ctx context.Context, skipmissing bool) error {
+	rmcids, err := BlockDiff(ctx, ds, ds.baseCid, ds.blks, skipmissing)
 	if err != nil {
-		return fmt.Errorf("block diff failed: %w", err)
+		return fmt.Errorf("block diff failed (base=%s,rev=%s): %w", ds.baseCid, ds.lastRev, err)
 	}
 
 	ds.rmcids = rmcids

--- a/carstore/repo_test.go
+++ b/carstore/repo_test.go
@@ -103,7 +103,7 @@ func TestBasicOperation(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		rr, err := repo.OpenRepo(ctx, ds, head, true)
+		rr, err := repo.OpenRepo(ctx, ds, head)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -125,7 +125,7 @@ func TestBasicOperation(t *testing.T) {
 
 		rev = nrev
 
-		if err := ds.CalcDiff(ctx, nroot); err != nil {
+		if err := ds.CalcDiff(ctx, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -188,7 +188,7 @@ func TestRepeatedCompactions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			rr, err := repo.OpenRepo(ctx, ds, head, true)
+			rr, err := repo.OpenRepo(ctx, ds, head)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -217,7 +217,7 @@ func TestRepeatedCompactions(t *testing.T) {
 
 			rev = nrev
 
-			if err := ds.CalcDiff(ctx, nroot); err != nil {
+			if err := ds.CalcDiff(ctx, false); err != nil {
 				t.Fatal(err)
 			}
 
@@ -338,7 +338,7 @@ func BenchmarkRepoWritesCarstore(b *testing.B) {
 			b.Fatal(err)
 		}
 
-		rr, err := repo.OpenRepo(ctx, ds, head, true)
+		rr, err := repo.OpenRepo(ctx, ds, head)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -356,7 +356,7 @@ func BenchmarkRepoWritesCarstore(b *testing.B) {
 		}
 
 		rev = nrev
-		if err := ds.CalcDiff(ctx, nroot); err != nil {
+		if err := ds.CalcDiff(ctx, false); err != nil {
 			b.Fatal(err)
 		}
 
@@ -386,7 +386,7 @@ func BenchmarkRepoWritesFlatfs(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 
-		rr, err := repo.OpenRepo(ctx, bs, head, true)
+		rr, err := repo.OpenRepo(ctx, bs, head)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -424,7 +424,7 @@ func BenchmarkRepoWritesSqlite(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 
-		rr, err := repo.OpenRepo(ctx, bs, head, true)
+		rr, err := repo.OpenRepo(ctx, bs, head)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/carstore/repo_test.go
+++ b/carstore/repo_test.go
@@ -125,7 +125,7 @@ func TestBasicOperation(t *testing.T) {
 
 		rev = nrev
 
-		if err := ds.CalcDiff(ctx, false); err != nil {
+		if err := ds.CalcDiff(ctx, nil); err != nil {
 			t.Fatal(err)
 		}
 
@@ -217,7 +217,7 @@ func TestRepeatedCompactions(t *testing.T) {
 
 			rev = nrev
 
-			if err := ds.CalcDiff(ctx, false); err != nil {
+			if err := ds.CalcDiff(ctx, nil); err != nil {
 				t.Fatal(err)
 			}
 
@@ -356,7 +356,7 @@ func BenchmarkRepoWritesCarstore(b *testing.B) {
 		}
 
 		rev = nrev
-		if err := ds.CalcDiff(ctx, false); err != nil {
+		if err := ds.CalcDiff(ctx, nil); err != nil {
 			b.Fatal(err)
 		}
 

--- a/cmd/gosky/main.go
+++ b/cmd/gosky/main.go
@@ -363,7 +363,7 @@ func unpackRecords(blks []byte, ops []*atproto.SyncSubscribeRepos_RepoOp) ([]any
 		}
 	}
 
-	r, err := repo.OpenRepo(ctx, bstore, carr.Header.Roots[0], false)
+	r, err := repo.OpenRepo(ctx, bstore, carr.Header.Roots[0])
 	if err != nil {
 		return nil, err
 	}

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -107,7 +107,7 @@ func ReadRepoFromCar(ctx context.Context, r io.Reader) (*Repo, error) {
 		return nil, err
 	}
 
-	return OpenRepo(ctx, bs, root, false)
+	return OpenRepo(ctx, bs, root)
 }
 
 func NewRepo(ctx context.Context, did string, bs blockstore.Blockstore) *Repo {
@@ -128,7 +128,7 @@ func NewRepo(ctx context.Context, did string, bs blockstore.Blockstore) *Repo {
 	}
 }
 
-func OpenRepo(ctx context.Context, bs blockstore.Blockstore, root cid.Cid, fullRepo bool) (*Repo, error) {
+func OpenRepo(ctx context.Context, bs blockstore.Blockstore, root cid.Cid) (*Repo, error) {
 	cst := util.CborStore(bs)
 
 	var sc SignedCommit
@@ -363,7 +363,7 @@ func (r *Repo) DiffSince(ctx context.Context, oldrepo cid.Cid) ([]*mst.DiffOp, e
 
 	var oldTree cid.Cid
 	if oldrepo.Defined() {
-		otherRepo, err := OpenRepo(ctx, r.bs, oldrepo, true)
+		otherRepo, err := OpenRepo(ctx, r.bs, oldrepo)
 		if err != nil {
 			return nil, err
 		}

--- a/repomgr/repomgr.go
+++ b/repomgr/repomgr.go
@@ -552,7 +552,7 @@ func (rm *RepoManager) HandleExternalUserEvent(ctx context.Context, pdsid uint, 
 		return err
 	}
 
-	var badPrev bool
+	var skipcids map[cid.Cid]bool
 	if ds.BaseCid().Defined() {
 		oldrepo, err := repo.OpenRepo(ctx, ds, ds.BaseCid())
 		if err != nil {
@@ -565,11 +565,13 @@ func (rm *RepoManager) HandleExternalUserEvent(ctx context.Context, pdsid uint, 
 		// and this becomes no longer an issue
 		prev, _ := oldrepo.PrevCommit(ctx)
 		if prev != nil {
-			badPrev = true
+			skipcids = map[cid.Cid]bool{
+				*prev: true,
+			}
 		}
 	}
 
-	if err := ds.CalcDiff(ctx, badPrev); err != nil {
+	if err := ds.CalcDiff(ctx, skipcids); err != nil {
 		return fmt.Errorf("failed while calculating mst diff (since=%v): %w", since, err)
 
 	}

--- a/testing/sig_test.go
+++ b/testing/sig_test.go
@@ -33,7 +33,7 @@ func TestVerification(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := repo.OpenRepo(ctx, bs, c, true)
+	r, err := repo.OpenRepo(ctx, bs, c)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The slightly more correct approach would be to ignore specifically the prev cid failure in CalcDiff, but doing so would require a bunch of plumbing that will quickly become irrelevant.