### PR TITLE
atproto/crypto: add test fixtures

### DIFF
--- a/atproto/crypto/testdata/signature-fixtures.json
+++ b/atproto/crypto/testdata/signature-fixtures.json
@@ -1,38 +1,68 @@
-[                                                                                                        
+[
   {
+    "comment": "valid P-256 key and signature, with low-S signature",
     "messageBase64": "oWVoZWxsb2V3b3JsZA",
     "algorithm": "ES256",
     "didDocSuite": "EcdsaSecp256r1VerificationKey2019",
     "publicKeyDid": "did:key:zDnaembgSGUhZULN2Caob4HLJPaxBh92N7rtH21TErzqf8HQo",
     "publicKeyMultibase": "zxdM8dSstjrpZaRUwBmDvjGXweKuEMVN95A9oJBFjkWMh",
     "signatureBase64": "2vZNsG3UKvvO/CDlrdvyZRISOFylinBh0Jupc6KcWoJWExHptCfduPleDbG3rko3YZnn9Lw0IjpixVmexJDegg",
-    "validSignature": true
+    "validSignature": true,
+    "tags": []
   },
   {
+    "comment": "valid K-256 key and signature, with low-S signature",
     "messageBase64": "oWVoZWxsb2V3b3JsZA",
     "algorithm": "ES256K",
     "didDocSuite": "EcdsaSecp256k1VerificationKey2019",
     "publicKeyDid": "did:key:zQ3shqwJEJyMBsBXCWyCBpUBMqxcon9oHB7mCvx4sSpMdLJwc",
     "publicKeyMultibase": "z25z9DTpsiYYJKGsWmSPJK2NFN8PcJtZig12K59UgW7q5t",
     "signatureBase64": "5WpdIuEUUfVUYaozsi8G0B3cWO09cgZbIIwg1t2YKdUn/FEznOndsz/qgiYb89zwxYCbB71f7yQK5Lr7NasfoA",
-    "validSignature": true
+    "validSignature": true,
+    "tags": []
   },
   {
+    "comment": "P-256 key and signature, with non-low-S signature which is invalid in atproto",
     "messageBase64": "oWVoZWxsb2V3b3JsZA",
     "algorithm": "ES256",
     "didDocSuite": "EcdsaSecp256r1VerificationKey2019",
     "publicKeyDid": "did:key:zDnaembgSGUhZULN2Caob4HLJPaxBh92N7rtH21TErzqf8HQo",
     "publicKeyMultibase": "zxdM8dSstjrpZaRUwBmDvjGXweKuEMVN95A9oJBFjkWMh",
     "signatureBase64": "2vZNsG3UKvvO/CDlrdvyZRISOFylinBh0Jupc6KcWoKp7O4VS9giSAah8k5IUbXIW00SuOrjfEqQ9HEkN9JGzw",
-    "validSignature": false
+    "validSignature": false,
+    "tags": ["high-s"]
   },
   {
+    "comment": "K-256 key and signature, with non-low-S signature which is invalid in atproto",
     "messageBase64": "oWVoZWxsb2V3b3JsZA",
     "algorithm": "ES256K",
     "didDocSuite": "EcdsaSecp256k1VerificationKey2019",
     "publicKeyDid": "did:key:zQ3shqwJEJyMBsBXCWyCBpUBMqxcon9oHB7mCvx4sSpMdLJwc",
     "publicKeyMultibase": "z25z9DTpsiYYJKGsWmSPJK2NFN8PcJtZig12K59UgW7q5t",
     "signatureBase64": "5WpdIuEUUfVUYaozsi8G0B3cWO09cgZbIIwg1t2YKdXYA67MYxYiTMAVfdnkDCMN9S5B3vHosRe07aORmoshoQ",
-    "validSignature": false
+    "validSignature": false,
+    "tags": ["high-s"]
+  },
+  {
+    "comment": "P-256 key and signature, with DER-encoded signature which is invalid in atproto",
+    "messageBase64": "oWVoZWxsb2V3b3JsZA",
+    "algorithm": "ES256",
+    "didDocSuite": "EcdsaSecp256r1VerificationKey2019",
+    "publicKeyDid": "did:key:zDnaeT6hL2RnTdUhAPLij1QBkhYZnmuKyM7puQLW1tkF4Zkt8",
+    "publicKeyMultibase": "ze8N2PPxnu19hmBQ58t5P3E9Yj6CqakJmTVCaKvf9Byq2",
+    "signatureBase64": "MEQCIFxYelWJ9lNcAVt+jK0y/T+DC/X4ohFZ+m8f9SEItkY1AiACX7eXz5sgtaRrz/SdPR8kprnbHMQVde0T2R8yOTBweA",
+    "validSignature": false,
+    "tags": ["der-encoded"]
+  },
+  {
+    "comment": "K-256 key and signature, with DER-encoded signature which is invalid in atproto",
+    "messageBase64": "oWVoZWxsb2V3b3JsZA",
+    "algorithm": "ES256K",
+    "didDocSuite": "EcdsaSecp256k1VerificationKey2019",
+    "publicKeyDid": "did:key:zQ3shnriYMXc8wvkbJqfNWh5GXn2bVAeqTC92YuNbek4npqGF",
+    "publicKeyMultibase": "z22uZXWP8fdHXi4jyx8cCDiBf9qQTsAe6VcycoMQPfcMQX",
+    "signatureBase64": "MEUCIQCWumUqJqOCqInXF7AzhIRg2MhwRz2rWZcOEsOjPmNItgIgXJH7RnqfYY6M0eg33wU0sFYDlprwdOcpRn78Sz5ePgk",
+    "validSignature": false,
+    "tags": ["der-encoded"]
   }
 ]


### PR DESCRIPTION
This tests for DER-encoded signatures, which we don't want to allow. The typescript implementation was accepting these, but now doesn't, which is why there are new test entries.