### PR TITLE
lexgen: slightly more robust 'unkown' handling (hack)

### DIFF
--- a/api/atproto/repodescribeRepo.go
+++ b/api/atproto/repodescribeRepo.go
@@ -7,17 +7,16 @@ package atproto
 import (
 	"context"
 
-	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // RepoDescribeRepo_Output is the output of a com.atproto.repo.describeRepo call.
 type RepoDescribeRepo_Output struct {
-	Collections     []string                 `json:"collections" cborgen:"collections"`
-	Did             string                   `json:"did" cborgen:"did"`
-	DidDoc          *util.LexiconTypeDecoder `json:"didDoc" cborgen:"didDoc"`
-	Handle          string                   `json:"handle" cborgen:"handle"`
-	HandleIsCorrect bool                     `json:"handleIsCorrect" cborgen:"handleIsCorrect"`
+	Collections     []string    `json:"collections" cborgen:"collections"`
+	Did             string      `json:"did" cborgen:"did"`
+	DidDoc          interface{} `json:"didDoc" cborgen:"didDoc"`
+	Handle          string      `json:"handle" cborgen:"handle"`
+	HandleIsCorrect bool        `json:"handleIsCorrect" cborgen:"handleIsCorrect"`
 }
 
 // RepoDescribeRepo calls the XRPC method "com.atproto.repo.describeRepo".

--- a/api/atproto/servercreateAccount.go
+++ b/api/atproto/servercreateAccount.go
@@ -7,28 +7,27 @@ package atproto
 import (
 	"context"
 
-	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // ServerCreateAccount_Input is the input argument to a com.atproto.server.createAccount call.
 type ServerCreateAccount_Input struct {
-	Did         *string                  `json:"did,omitempty" cborgen:"did,omitempty"`
-	Email       *string                  `json:"email,omitempty" cborgen:"email,omitempty"`
-	Handle      string                   `json:"handle" cborgen:"handle"`
-	InviteCode  *string                  `json:"inviteCode,omitempty" cborgen:"inviteCode,omitempty"`
-	Password    *string                  `json:"password,omitempty" cborgen:"password,omitempty"`
-	PlcOp       *util.LexiconTypeDecoder `json:"plcOp,omitempty" cborgen:"plcOp,omitempty"`
-	RecoveryKey *string                  `json:"recoveryKey,omitempty" cborgen:"recoveryKey,omitempty"`
+	Did         *string      `json:"did,omitempty" cborgen:"did,omitempty"`
+	Email       *string      `json:"email,omitempty" cborgen:"email,omitempty"`
+	Handle      string       `json:"handle" cborgen:"handle"`
+	InviteCode  *string      `json:"inviteCode,omitempty" cborgen:"inviteCode,omitempty"`
+	Password    *string      `json:"password,omitempty" cborgen:"password,omitempty"`
+	PlcOp       *interface{} `json:"plcOp,omitempty" cborgen:"plcOp,omitempty"`
+	RecoveryKey *string      `json:"recoveryKey,omitempty" cborgen:"recoveryKey,omitempty"`
 }
 
 // ServerCreateAccount_Output is the output of a com.atproto.server.createAccount call.
 type ServerCreateAccount_Output struct {
-	AccessJwt  string                   `json:"accessJwt" cborgen:"accessJwt"`
-	Did        string                   `json:"did" cborgen:"did"`
-	DidDoc     *util.LexiconTypeDecoder `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
-	Handle     string                   `json:"handle" cborgen:"handle"`
-	RefreshJwt string                   `json:"refreshJwt" cborgen:"refreshJwt"`
+	AccessJwt  string       `json:"accessJwt" cborgen:"accessJwt"`
+	Did        string       `json:"did" cborgen:"did"`
+	DidDoc     *interface{} `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
+	Handle     string       `json:"handle" cborgen:"handle"`
+	RefreshJwt string       `json:"refreshJwt" cborgen:"refreshJwt"`
 }
 
 // ServerCreateAccount calls the XRPC method "com.atproto.server.createAccount".

--- a/api/atproto/servercreateSession.go
+++ b/api/atproto/servercreateSession.go
@@ -19,13 +19,13 @@ type ServerCreateSession_Input struct {
 
 // ServerCreateSession_Output is the output of a com.atproto.server.createSession call.
 type ServerCreateSession_Output struct {
-	AccessJwt string `json:"accessJwt" cborgen:"accessJwt"`
-	Did       string `json:"did" cborgen:"did"`
-	//DidDoc         *util.LexiconTypeDecoder `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
-	Email          *string `json:"email,omitempty" cborgen:"email,omitempty"`
-	EmailConfirmed *bool   `json:"emailConfirmed,omitempty" cborgen:"emailConfirmed,omitempty"`
-	Handle         string  `json:"handle" cborgen:"handle"`
-	RefreshJwt     string  `json:"refreshJwt" cborgen:"refreshJwt"`
+	AccessJwt      string       `json:"accessJwt" cborgen:"accessJwt"`
+	Did            string       `json:"did" cborgen:"did"`
+	DidDoc         *interface{} `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
+	Email          *string      `json:"email,omitempty" cborgen:"email,omitempty"`
+	EmailConfirmed *bool        `json:"emailConfirmed,omitempty" cborgen:"emailConfirmed,omitempty"`
+	Handle         string       `json:"handle" cborgen:"handle"`
+	RefreshJwt     string       `json:"refreshJwt" cborgen:"refreshJwt"`
 }
 
 // ServerCreateSession calls the XRPC method "com.atproto.server.createSession".

--- a/api/atproto/servergetSession.go
+++ b/api/atproto/servergetSession.go
@@ -7,17 +7,16 @@ package atproto
 import (
 	"context"
 
-	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // ServerGetSession_Output is the output of a com.atproto.server.getSession call.
 type ServerGetSession_Output struct {
-	Did            string                   `json:"did" cborgen:"did"`
-	DidDoc         *util.LexiconTypeDecoder `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
-	Email          *string                  `json:"email,omitempty" cborgen:"email,omitempty"`
-	EmailConfirmed *bool                    `json:"emailConfirmed,omitempty" cborgen:"emailConfirmed,omitempty"`
-	Handle         string                   `json:"handle" cborgen:"handle"`
+	Did            string       `json:"did" cborgen:"did"`
+	DidDoc         *interface{} `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
+	Email          *string      `json:"email,omitempty" cborgen:"email,omitempty"`
+	EmailConfirmed *bool        `json:"emailConfirmed,omitempty" cborgen:"emailConfirmed,omitempty"`
+	Handle         string       `json:"handle" cborgen:"handle"`
 }
 
 // ServerGetSession calls the XRPC method "com.atproto.server.getSession".

--- a/api/atproto/serverrefreshSession.go
+++ b/api/atproto/serverrefreshSession.go
@@ -12,11 +12,11 @@ import (
 
 // ServerRefreshSession_Output is the output of a com.atproto.server.refreshSession call.
 type ServerRefreshSession_Output struct {
-	AccessJwt string `json:"accessJwt" cborgen:"accessJwt"`
-	Did       string `json:"did" cborgen:"did"`
-	//DidDoc     *util.LexiconTypeDecoder `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
-	Handle     string `json:"handle" cborgen:"handle"`
-	RefreshJwt string `json:"refreshJwt" cborgen:"refreshJwt"`
+	AccessJwt  string       `json:"accessJwt" cborgen:"accessJwt"`
+	Did        string       `json:"did" cborgen:"did"`
+	DidDoc     *interface{} `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
+	Handle     string       `json:"handle" cborgen:"handle"`
+	RefreshJwt string       `json:"refreshJwt" cborgen:"refreshJwt"`
 }
 
 // ServerRefreshSession calls the XRPC method "com.atproto.server.refreshSession".

--- a/lex/gen.go
+++ b/lex/gen.go
@@ -1119,7 +1119,12 @@ func (s *TypeSchema) typeNameForField(name, k string, v TypeSchema) (string, err
 		// TODO: maybe do a native type?
 		return "string", nil
 	case "unknown":
-		return "*util.LexiconTypeDecoder", nil
+		// NOTE: sometimes a record, for which we want LexiconTypeDecoder, sometimes any object
+		if k == "didDoc" || k == "plcOp" {
+			return "interface{}", nil
+		} else {
+			return "*util.LexiconTypeDecoder", nil
+		}
 	case "union":
 		return "*" + name + "_" + strings.Title(k), nil
 	case "blob":


### PR DESCRIPTION
This is a bit more robust than the current situation where we manually comment things out.

Just looks for the specific field names `didDoc` or `plcOp` and plops in an `*interface{]` type instead for those.

Could also have done `*map[string]interface{}` but I was worried not initializing that datatype; maybe unwarranted. 

My assumption is that `json.RawMessage` would be best here for JSON stuff, but that causes problems for CBOR stuff.