### PR TITLE
Fix TID generator to avoid duplicates

### DIFF
--- a/repo/tid.go
+++ b/repo/tid.go
@@ -30,8 +30,8 @@ func NextTID() string {
 	t := uint64(time.Now().UnixMicro())
 
 	ltLock.Lock()
-	if lastTime == t {
-		t++
+	if lastTime >= t {
+		t = lastTime + 1
 	}
 
 	lastTime = t


### PR DESCRIPTION
Third call on the same microsecond would not match the `if` condition and would return the same value as the first call.