### PR TITLE
identity: small improvements

### DIFF
--- a/atproto/identity/base_directory.go
+++ b/atproto/identity/base_directory.go
@@ -33,6 +33,7 @@ type BaseDirectory struct {
 var _ Directory = (*BaseDirectory)(nil)
 
 func (d *BaseDirectory) LookupHandle(ctx context.Context, h syntax.Handle) (*Identity, error) {
+	h = h.Normalize()
 	did, err := d.ResolveHandle(ctx, h)
 	if err != nil {
 		return nil, err

--- a/atproto/identity/cache_directory.go
+++ b/atproto/identity/cache_directory.go
@@ -226,6 +226,7 @@ func (d *CacheDirectory) LookupDID(ctx context.Context, did syntax.DID) (*Identi
 }
 
 func (d *CacheDirectory) LookupHandle(ctx context.Context, h syntax.Handle) (*Identity, error) {
+	h = h.Normalize()
 	did, err := d.ResolveHandle(ctx, h)
 	if err != nil {
 		return nil, err
@@ -260,6 +261,7 @@ func (d *CacheDirectory) Lookup(ctx context.Context, a syntax.AtIdentifier) (*Id
 func (d *CacheDirectory) Purge(ctx context.Context, a syntax.AtIdentifier) error {
 	handle, err := a.AsHandle()
 	if nil == err { // if not an error, is a handle
+		handle = handle.Normalize()
 		d.handleCache.Remove(handle)
 		return nil
 	}

--- a/atproto/identity/cache_directory.go
+++ b/atproto/identity/cache_directory.go
@@ -181,7 +181,7 @@ func (d *CacheDirectory) updateDID(ctx context.Context, did syntax.DID) (*Identi
 	if he != nil {
 		d.handleCache.Add(ident.Handle, *he)
 	}
-	return &entry, nil
+	return &entry, err
 }
 
 func (d *CacheDirectory) LookupDID(ctx context.Context, did syntax.DID) (*Identity, error) {

--- a/atproto/identity/mock_directory.go
+++ b/atproto/identity/mock_directory.go
@@ -30,6 +30,7 @@ func (d *MockDirectory) Insert(ident Identity) {
 }
 
 func (d *MockDirectory) LookupHandle(ctx context.Context, h syntax.Handle) (*Identity, error) {
+	h = h.Normalize()
 	did, ok := d.Handles[h]
 	if !ok {
 		return nil, ErrHandleNotFound


### PR DESCRIPTION
I'm not sure why the error wasn't getting returned; might have been a typo? Probably worth re-reading that function again in review. I hit a nil de-reference pointer in automod caused by that function returning `nil, nil`.