### PR TITLE
automod: action limits; create reports for interaction churn

### DIFF
--- a/automod/action_dedupe_test.go
+++ b/automod/action_dedupe_test.go
@@ -1,0 +1,45 @@
+package automod
+
+import (
+	"context"
+	"testing"
+
+	appbsky "github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func alwaysReportAccountRule(evt *RecordEvent) error {
+	evt.ReportAccount(ReportReasonOther, "test report")
+	return nil
+}
+
+func TestAccountReportDedupe(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+	engine := engineFixture()
+	engine.Rules = RuleSet{
+		RecordRules: []RecordRuleFunc{
+			alwaysReportAccountRule,
+		},
+	}
+
+	path := "app.bsky.feed.post/abc123"
+	cid1 := "cid123"
+	p1 := appbsky.FeedPost{Text: "some post blah"}
+	id1 := identity.Identity{
+		DID:    syntax.DID("did:plc:abc111"),
+		Handle: syntax.Handle("handle.example.com"),
+	}
+
+	// exact same event multiple times; should only report once
+	for i := 0; i < 5; i++ {
+		assert.NoError(engine.ProcessRecord(ctx, id1.DID, path, cid1, &p1))
+	}
+
+	reports, err := engine.GetCount("automod-quota", "report", PeriodDay)
+	assert.NoError(err)
+	assert.Equal(1, reports)
+}

--- a/automod/circuit_breaker_test.go
+++ b/automod/circuit_breaker_test.go
@@ -1,0 +1,94 @@
+package automod
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	appbsky "github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func alwaysTakedownRecordRule(evt *RecordEvent) error {
+	evt.TakedownRecord()
+	return nil
+}
+
+func alwaysReportRecordRule(evt *RecordEvent) error {
+	evt.ReportRecord(ReportReasonOther, "test report")
+	return nil
+}
+
+func TestTakedownCircuitBreaker(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+	engine := engineFixture()
+	dir := identity.NewMockDirectory()
+	engine.Directory = &dir
+	// note that this is a record-level action, not account-level
+	engine.Rules = RuleSet{
+		RecordRules: []RecordRuleFunc{
+			alwaysTakedownRecordRule,
+		},
+	}
+
+	path := "app.bsky.feed.post/abc123"
+	cid1 := "cid123"
+	p1 := appbsky.FeedPost{Text: "some post blah"}
+
+	// generate double the quote of events; expect to only count the quote worth of actions
+	for i := 0; i < 2*QuotaModTakedownDay; i++ {
+		ident := identity.Identity{
+			DID:    syntax.DID(fmt.Sprintf("did:plc:abc%d", i)),
+			Handle: syntax.Handle("handle.example.com"),
+		}
+		dir.Insert(ident)
+		assert.NoError(engine.ProcessRecord(ctx, ident.DID, path, cid1, &p1))
+	}
+
+	takedowns, err := engine.GetCount("automod-quota", "takedown", PeriodDay)
+	assert.NoError(err)
+	assert.Equal(QuotaModTakedownDay, takedowns)
+
+	reports, err := engine.GetCount("automod-quota", "report", PeriodDay)
+	assert.NoError(err)
+	assert.Equal(0, reports)
+}
+
+func TestReportCircuitBreaker(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+	engine := engineFixture()
+	dir := identity.NewMockDirectory()
+	engine.Directory = &dir
+	engine.Rules = RuleSet{
+		RecordRules: []RecordRuleFunc{
+			alwaysReportRecordRule,
+		},
+	}
+
+	path := "app.bsky.feed.post/abc123"
+	cid1 := "cid123"
+	p1 := appbsky.FeedPost{Text: "some post blah"}
+
+	// generate double the quote of events; expect to only count the quote worth of actions
+	for i := 0; i < 2*QuotaModReportDay; i++ {
+		ident := identity.Identity{
+			DID:    syntax.DID(fmt.Sprintf("did:plc:abc%d", i)),
+			Handle: syntax.Handle("handle.example.com"),
+		}
+		dir.Insert(ident)
+		assert.NoError(engine.ProcessRecord(ctx, ident.DID, path, cid1, &p1))
+	}
+
+	takedowns, err := engine.GetCount("automod-quota", "takedown", PeriodDay)
+	assert.NoError(err)
+	assert.Equal(0, takedowns)
+
+	reports, err := engine.GetCount("automod-quota", "report", PeriodDay)
+	assert.NoError(err)
+	assert.Equal(QuotaModReportDay, reports)
+}

--- a/automod/circuit_breaker_test.go
+++ b/automod/circuit_breaker_test.go
@@ -74,7 +74,7 @@ func TestReportCircuitBreaker(t *testing.T) {
 	cid1 := "cid123"
 	p1 := appbsky.FeedPost{Text: "some post blah"}
 
-	// generate double the quote of events; expect to only count the quote worth of actions
+	// generate double the quota of events; expect to only count the quota worth of actions
 	for i := 0; i < 2*QuotaModReportDay; i++ {
 		ident := identity.Identity{
 			DID:    syntax.DID(fmt.Sprintf("did:plc:abc%d", i)),

--- a/automod/countstore/countstore_test.go
+++ b/automod/countstore/countstore_test.go
@@ -20,9 +20,12 @@ func TestMemCountStoreBasics(t *testing.T) {
 	assert.Equal(0, c)
 	assert.NoError(cs.Increment(ctx, "test1", "val1"))
 	assert.NoError(cs.Increment(ctx, "test1", "val1"))
-	c, err = cs.GetCount(ctx, "test1", "val1", PeriodTotal)
-	assert.NoError(err)
-	assert.Equal(2, c)
+
+	for _, period := range []string{PeriodTotal, PeriodDay, PeriodHour} {
+		c, err = cs.GetCount(ctx, "test1", "val1", period)
+		assert.NoError(err)
+		assert.Equal(2, c)
+	}
 
 	c, err = cs.GetCountDistinct(ctx, "test2", "val2", PeriodTotal)
 	assert.NoError(err)
@@ -36,9 +39,12 @@ func TestMemCountStoreBasics(t *testing.T) {
 
 	assert.NoError(cs.IncrementDistinct(ctx, "test2", "val2", "two"))
 	assert.NoError(cs.IncrementDistinct(ctx, "test2", "val2", "three"))
-	c, err = cs.GetCountDistinct(ctx, "test2", "val2", PeriodTotal)
-	assert.NoError(err)
-	assert.Equal(3, c)
+
+	for _, period := range []string{PeriodTotal, PeriodDay, PeriodHour} {
+		c, err = cs.GetCountDistinct(ctx, "test2", "val2", period)
+		assert.NoError(err)
+		assert.Equal(3, c)
+	}
 }
 
 func TestMemCountStoreConcurrent(t *testing.T) {

--- a/automod/engine.go
+++ b/automod/engine.go
@@ -72,6 +72,10 @@ func (e *Engine) ProcessIdentityEvent(ctx context.Context, t string, did syntax.
 	if err := evt.PersistCounters(ctx); err != nil {
 		return err
 	}
+	// check for any new errors during persist
+	if evt.Err != nil {
+		return evt.Err
+	}
 	return nil
 }
 
@@ -113,6 +117,10 @@ func (e *Engine) ProcessRecord(ctx context.Context, did syntax.DID, path, recCID
 	}
 	if err := evt.PersistCounters(ctx); err != nil {
 		return err
+	}
+	// check for any new errors during persist
+	if evt.Err != nil {
+		return evt.Err
 	}
 	return nil
 }

--- a/automod/event.go
+++ b/automod/event.go
@@ -131,10 +131,9 @@ func (e *RepoEvent) AddAccountFlag(val string) {
 // Enqueues a moderation report to be filed against the account at the end of rule processing.
 func (e *RepoEvent) ReportAccount(reason, comment string) {
 	if comment == "" {
-		comment = "(automod)"
-	} else {
-		comment = "automod: " + comment
+		comment = "(no comment)"
 	}
+	comment = "automod: " + comment
 	e.AccountReports = append(e.AccountReports, ModReport{ReasonType: reason, Comment: comment})
 }
 

--- a/automod/event.go
+++ b/automod/event.go
@@ -249,6 +249,7 @@ func (e *RepoEvent) PersistAccountActions(ctx context.Context) error {
 	needsPurge := false
 	xrpcc := e.Engine.AdminClient
 	if len(newLabels) > 0 {
+		e.Logger.Info("labeling record", "newLabels", newLabels)
 		comment := "automod"
 		_, err := comatproto.AdminEmitModerationEvent(ctx, xrpcc, &comatproto.AdminEmitModerationEvent_Input{
 			CreatedBy: xrpcc.Auth.Did,
@@ -320,6 +321,7 @@ func (e *RepoEvent) PersistAccountActions(ctx context.Context) error {
 		}
 	}
 	if newTakedown {
+		e.Logger.Warn("account-takedown")
 		comment := "automod"
 		_, err := comatproto.AdminEmitModerationEvent(ctx, xrpcc, &comatproto.AdminEmitModerationEvent_Input{
 			CreatedBy: xrpcc.Auth.Did,
@@ -490,6 +492,7 @@ func (e *RecordEvent) PersistRecordActions(ctx context.Context) error {
 	}
 	xrpcc := e.Engine.AdminClient
 	if len(newLabels) > 0 {
+		e.Logger.Info("labeling record", "newLabels", newLabels)
 		comment := "automod"
 		_, err := comatproto.AdminEmitModerationEvent(ctx, xrpcc, &comatproto.AdminEmitModerationEvent_Input{
 			CreatedBy: xrpcc.Auth.Did,
@@ -512,6 +515,7 @@ func (e *RecordEvent) PersistRecordActions(ctx context.Context) error {
 		e.Engine.Flags.Add(ctx, atURI, newFlags)
 	}
 	for _, mr := range newReports {
+		e.Logger.Info("reporting record", "reasonType", mr.ReasonType, "comment", mr.Comment)
 		_, err := comatproto.ModerationCreateReport(ctx, xrpcc, &comatproto.ModerationCreateReport_Input{
 			ReasonType: &mr.ReasonType,
 			Reason:     &mr.Comment,
@@ -524,6 +528,7 @@ func (e *RecordEvent) PersistRecordActions(ctx context.Context) error {
 		}
 	}
 	if newTakedown {
+		e.Logger.Warn("record-takedown")
 		comment := "automod"
 		_, err := comatproto.AdminEmitModerationEvent(ctx, xrpcc, &comatproto.AdminEmitModerationEvent_Input{
 			CreatedBy: xrpcc.Auth.Did,

--- a/automod/event.go
+++ b/automod/event.go
@@ -126,6 +126,11 @@ func (e *RepoEvent) AddAccountFlag(val string) {
 
 // Enqueues a moderation report to be filed against the account at the end of rule processing.
 func (e *RepoEvent) ReportAccount(reason, comment string) {
+	if comment == "" {
+		comment = "(automod)"
+	} else {
+		comment = "automod: " + comment
+	}
 	e.AccountReports = append(e.AccountReports, ModReport{ReasonType: reason, Comment: comment})
 }
 
@@ -400,6 +405,11 @@ func (e *RecordEvent) AddRecordFlag(val string) {
 
 // Enqueues a moderation report to be filed against the record at the end of rule processing.
 func (e *RecordEvent) ReportRecord(reason, comment string) {
+	if comment == "" {
+		comment = "(automod)"
+	} else {
+		comment = "automod: " + comment
+	}
 	e.RecordReports = append(e.RecordReports, ModReport{ReasonType: reason, Comment: comment})
 }
 

--- a/automod/report.go
+++ b/automod/report.go
@@ -1,0 +1,34 @@
+package automod
+
+type ModReport struct {
+	ReasonType string
+	Comment    string
+}
+
+var (
+	ReportReasonSpam       = "com.atproto.moderation.defs#reasonSpam"
+	ReportReasonViolation  = "com.atproto.moderation.defs#reasonViolation"
+	ReportReasonMisleading = "com.atproto.moderation.defs#reasonMisleading"
+	ReportReasonSexual     = "com.atproto.moderation.defs#reasonSexual"
+	ReportReasonRude       = "com.atproto.moderation.defs#reasonRude"
+	ReportReasonOther      = "com.atproto.moderation.defs#reasonOther"
+)
+
+func reasonShortName(reason string) string {
+	switch reason {
+	case ReportReasonSpam:
+		return "spam"
+	case ReportReasonViolation:
+		return "violation"
+	case ReportReasonMisleading:
+		return "misleading"
+	case ReportReasonSexual:
+		return "sexual"
+	case ReportReasonRude:
+		return "rude"
+	case ReportReasonOther:
+		return "other"
+	default:
+		return "unknown"
+	}
+}

--- a/automod/rules/interaction.go
+++ b/automod/rules/interaction.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"fmt"
+
 	"github.com/bluesky-social/indigo/automod"
 	"github.com/bluesky-social/indigo/automod/countstore"
 )
@@ -19,6 +21,7 @@ func InteractionChurnRule(evt *automod.RecordEvent) error {
 		if created > interactionDailyThreshold && deleted > interactionDailyThreshold && ratio > 0.5 {
 			evt.Logger.Info("high-like-churn", "created-today", created, "deleted-today", deleted)
 			evt.AddAccountFlag("high-like-churn")
+			evt.ReportAccount(automod.ReportReasonSpam, fmt.Sprintf("interaction churn: %d likes, %d unlikes today (so far)", created, deleted))
 		}
 	case "app.bsky.graph.follow":
 		evt.Increment("follow", did)
@@ -28,6 +31,7 @@ func InteractionChurnRule(evt *automod.RecordEvent) error {
 		if created > interactionDailyThreshold && deleted > interactionDailyThreshold && ratio > 0.5 {
 			evt.Logger.Info("high-follow-churn", "created-today", created, "deleted-today", deleted)
 			evt.AddAccountFlag("high-follow-churn")
+			evt.ReportAccount(automod.ReportReasonSpam, fmt.Sprintf("interaction churn: %d follows, %d unfollows today (so far)", created, deleted))
 		}
 	}
 	return nil


### PR DESCRIPTION
The motivation here is to start auto-reporting in production based on specific rules. Specifically, this PR would start reporting on interactions churn (follow/unfollow), letting human mods confirm before taking action on an account.

Before we do that, need to de-duplicate reports. For example, if an account creates thousands of spammy posts, only want to report the account once. Generally want to prevent run-away rules from creating millions of reports, or doing thousands of automated account takedowns (for example).

This PR prevents re-reporting based on daily counters (fast checks), as well as double-checking against the mod service API just before filing a report (slower, but reliable).

This PR also adds "quotas" for mod actions, implemented using the counter system. This isn't perfect (the counter system itself might be buggy or broken (causing duplicate actions), but seems like a good start. If quotas are exceeded, automod will log and skip taking additional actions until the next day. 