### PR TITLE
relay: return explicit empty array, not nil, for sync.listRepos

### DIFF
--- a/bgs/handlers.go
+++ b/bgs/handlers.go
@@ -202,6 +202,10 @@ func (s *BGS) handleComAtprotoSyncListRepos(ctx context.Context, cursor string, 
 		}
 	}
 
+	resp := &comatprototypes.SyncListRepos_Output{
+		Repos: []*comatprototypes.SyncListRepos_Repo{},
+	}
+
 	users := []User{}
 	if err := s.db.Model(&User{}).Where("id > ? AND NOT tombstoned AND NOT taken_down", c).Order("id").Limit(limit).Find(&users).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
@@ -212,11 +216,8 @@ func (s *BGS) handleComAtprotoSyncListRepos(ctx context.Context, cursor string, 
 	}
 
 	if len(users) == 0 {
-		return &comatprototypes.SyncListRepos_Output{}, nil
-	}
-
-	resp := &comatprototypes.SyncListRepos_Output{
-		Repos: []*comatprototypes.SyncListRepos_Repo{},
+		// resp.Repos is an explicit empty array, not just 'nil'
+		return resp, nil
 	}
 
 	for i := range users {


### PR DESCRIPTION
This is a work-around for the specific situation in: https://github.com/bluesky-social/atproto/issues/1949

We may need to have lexgen stubs ensure that any required array types in Output types are set to an explicit empty array, instead of nil? I haven't dug in to the details of JSON marshaling and CBOR marshaling to understand the scope of this issue yet, but the root of the issue is that the typescript code is being more strict about "empty" types than golang is. The typescript strictness seems both correct and reasonable to me, FWIW.