### PR TITLE
autmod: bump interaction churn quota to 800

### DIFF
--- a/automod/rules/interaction.go
+++ b/automod/rules/interaction.go
@@ -5,7 +5,7 @@ import (
 	"github.com/bluesky-social/indigo/automod/countstore"
 )
 
-var interactionDailyThreshold = 500
+var interactionDailyThreshold = 800
 
 // looks for accounts which do frequent interaction churn, such as follow-unfollow.
 func InteractionChurnRule(evt *automod.RecordEvent) error {


### PR DESCRIPTION
A number of folks seem to end up doing manual follow/unfollow interaction pairs at around 550/day. The most obvious/suspicious automated actors do around 1000/day.

This is a trivial one-liner so intend to self-merge.