### PR TITLE
identity: refactor error hierarchy and error handling

### DIFF
--- a/atproto/identity/cache_directory.go
+++ b/atproto/identity/cache_directory.go
@@ -247,7 +247,7 @@ func (d *CacheDirectory) LookupHandle(ctx context.Context, h syntax.Handle) (*Id
 		return nil, err
 	}
 	if declared != h {
-		return nil, fmt.Errorf("handle does not match that declared in DID document")
+		return nil, ErrHandleMismatch
 	}
 	return ident, nil
 }

--- a/atproto/identity/did_test.go
+++ b/atproto/identity/did_test.go
@@ -68,7 +68,7 @@ func TestDIDDocFeedGenParse(t *testing.T) {
 	assert.Equal([]string{}, id.AlsoKnownAs)
 	pk, err := id.PublicKey()
 	assert.Error(err)
-	assert.Equal(ErrKeyNotFound, err)
+	assert.ErrorIs(err, ErrKeyNotDeclared)
 	assert.Nil(pk)
 	assert.Equal("", id.PDSEndpoint())
 	hdl, err := id.DeclaredHandle()

--- a/atproto/identity/handle.go
+++ b/atproto/identity/handle.go
@@ -141,26 +141,22 @@ func (d *BaseDirectory) ResolveHandleWellKnown(ctx context.Context, handle synta
 				return "", fmt.Errorf("%w: DNS NXDOMAIN for %s", ErrHandleNotFound, handle)
 			}
 		}
-		slog.Info("HTTP request failed for well-known handle resolution", "handle", handle, "err", err)
-		return "", fmt.Errorf("%w: HTTP request error: %w", ErrHandleResolutionFailed, err)
+		return "", fmt.Errorf("%w: HTTP well-known request error: %w", ErrHandleResolutionFailed, err)
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		return "", fmt.Errorf("%w: HTTP 404 for %s", ErrHandleNotFound, handle)
 	}
 	if resp.StatusCode != http.StatusOK {
-		slog.Info("non-success HTTP response for well-known handle resolution", "handle", handle, "status_code", resp.StatusCode)
-		return "", fmt.Errorf("%w: HTTP status %d for %s", ErrHandleResolutionFailed, resp.StatusCode, handle)
+		return "", fmt.Errorf("%w: HTTP well-known status %d for %s", ErrHandleResolutionFailed, resp.StatusCode, handle)
 	}
 
 	if resp.ContentLength > 2048 {
-		slog.Warn("too much data reading handle HTTP well-known response", "handle", handle)
-		return "", fmt.Errorf("%w: HTTP body too large for %s", ErrHandleResolutionFailed, handle)
+		return "", fmt.Errorf("%w: HTTP well-known body too large for %s", ErrHandleResolutionFailed, handle)
 	}
 
 	b, err := io.ReadAll(io.LimitReader(resp.Body, 2048))
 	if err != nil {
-		slog.Warn("error reading HTTP well-known response", "handle", handle, "err", err)
-		return "", fmt.Errorf("%w: HTTP read for %s: %w", ErrHandleResolutionFailed, handle, err)
+		return "", fmt.Errorf("%w: HTTP well-known body read for %s: %w", ErrHandleResolutionFailed, handle, err)
 	}
 	line := strings.TrimSpace(string(b))
 	return syntax.ParseDID(line)

--- a/atproto/identity/live_test.go
+++ b/atproto/identity/live_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -21,13 +22,13 @@ func testDirectoryLive(t *testing.T, d Directory) {
 
 	handle := syntax.Handle("atproto.com")
 	did := syntax.DID("did:plc:ewvi7nxzyoun6zhxrhs64oiz")
-	pds := "https://bsky.social"
+	pdsSuffix := "host.bsky.network"
 
 	resp, err := d.LookupHandle(ctx, handle)
 	assert.NoError(err)
 	assert.Equal(handle, resp.Handle)
 	assert.Equal(did, resp.DID)
-	assert.Equal(pds, resp.PDSEndpoint())
+	assert.True(strings.HasSuffix(resp.PDSEndpoint(), pdsSuffix))
 	dh, err := resp.DeclaredHandle()
 	assert.NoError(err)
 	assert.Equal(handle, dh)
@@ -39,7 +40,7 @@ func testDirectoryLive(t *testing.T, d Directory) {
 	assert.NoError(err)
 	assert.Equal(handle, resp.Handle)
 	assert.Equal(did, resp.DID)
-	assert.Equal(pds, resp.PDSEndpoint())
+	assert.True(strings.HasSuffix(resp.PDSEndpoint(), pdsSuffix))
 
 	_, err = d.LookupHandle(ctx, syntax.Handle("fake-dummy-no-resolve.atproto.com"))
 	assert.ErrorIs(err, ErrHandleNotFound)
@@ -135,5 +136,5 @@ func TestFallbackDNS(t *testing.T) {
 	dir.FallbackDNSServers = []string{"_"}
 	_, err = dir.LookupHandle(ctx, handle)
 	assert.Error(err)
-	assert.ErrorIs(err, ErrHandleNotFound)
+	assert.ErrorIs(err, ErrHandleResolutionFailed)
 }

--- a/atproto/identity/live_test.go
+++ b/atproto/identity/live_test.go
@@ -42,13 +42,13 @@ func testDirectoryLive(t *testing.T, d Directory) {
 	assert.Equal(pds, resp.PDSEndpoint())
 
 	_, err = d.LookupHandle(ctx, syntax.Handle("fake-dummy-no-resolve.atproto.com"))
-	assert.Equal(ErrHandleNotFound, err)
+	assert.ErrorIs(err, ErrHandleNotFound)
 
 	_, err = d.LookupDID(ctx, syntax.DID("did:web:fake-dummy-no-resolve.atproto.com"))
-	assert.Equal(ErrDIDNotFound, err)
+	assert.ErrorIs(err, ErrDIDNotFound)
 
 	_, err = d.LookupDID(ctx, syntax.DID("did:plc:fake-dummy-no-resolve.atproto.com"))
-	assert.Equal(ErrDIDNotFound, err)
+	assert.ErrorIs(err, ErrDIDNotFound)
 
 	_, err = d.LookupHandle(ctx, syntax.HandleInvalid)
 	assert.Error(err)
@@ -129,11 +129,11 @@ func TestFallbackDNS(t *testing.T) {
 	// valid DNS server
 	_, err := dir.LookupHandle(ctx, handle)
 	assert.Error(err)
-	assert.Equal(ErrHandleNotFound, err)
+	assert.ErrorIs(err, ErrHandleNotFound)
 
 	// invalid DNS server syntax
 	dir.FallbackDNSServers = []string{"_"}
 	_, err = dir.LookupHandle(ctx, handle)
 	assert.Error(err)
-	assert.NotEqual(ErrHandleNotFound, err)
+	assert.ErrorIs(err, ErrHandleNotFound)
 }

--- a/atproto/identity/mock_directory_test.go
+++ b/atproto/identity/mock_directory_test.go
@@ -29,9 +29,9 @@ func TestMockDirectory(t *testing.T) {
 
 	// first, empty directory
 	_, err = c.LookupHandle(ctx, syntax.Handle("handle.example.com"))
-	assert.Equal(ErrHandleNotFound, err)
+	assert.ErrorIs(err, ErrHandleNotFound)
 	_, err = c.LookupDID(ctx, syntax.DID("did:plc:abc123"))
-	assert.Equal(ErrDIDNotFound, err)
+	assert.ErrorIs(err, ErrDIDNotFound)
 
 	c.Insert(id1)
 	c.Insert(id2)
@@ -49,7 +49,7 @@ func TestMockDirectory(t *testing.T) {
 	assert.True(out.Handle.IsInvalidHandle())
 
 	_, err = c.LookupHandle(ctx, syntax.HandleInvalid)
-	assert.Equal(ErrHandleNotFound, err)
+	assert.ErrorIs(err, ErrHandleNotFound)
 	out, err = c.LookupDID(ctx, syntax.DID("did:plc:abc999"))
-	assert.Equal(ErrDIDNotFound, err)
+	assert.ErrorIs(err, ErrDIDNotFound)
 }


### PR DESCRIPTION
Root motivation here was that a bunch of remote errors were trickling up as full errors when doing identity resolution (via DID), while in reality they should result in "invalid.handle".

I didn't want to just force everything in to ErrHandleNotFound, so I created some new error types (and renamed a couple existing types), and ensured that we were using errors.Is() for matching. This way downstream code can distinguish between "not found" and "error during resolution" when calling the lower-level methods, if they care (eg, a debugging tool or interface would care). Also wrapped the errors instead of just returning, so additional context couple be tacked on the message.

There are still some situations where the root cause might be a local error (like local wifi) as opposed to a remote error (server is broken), and we can't distinguish those, at least for now.

Note: I checked and recent versions of golang does explicitly allow multiple `%w` in a single `fmt.Errorf()`
