### PR TITLE
palomar: prod errors burndown

### DIFF
--- a/search/indexing.go
+++ b/search/indexing.go
@@ -66,12 +66,6 @@ func (s *Server) indexPost(ctx context.Context, ident *identity.Identity, rec *a
 
 	log = log.With("rkey", rkey)
 
-	_, err := syntax.ParseDatetimeLenient(rec.CreatedAt)
-	if err != nil {
-		log.Warn("post had invalid timestamp", "createdAt", rec.CreatedAt, "parseErr", err)
-		rec.CreatedAt = ""
-	}
-
 	doc := TransformPost(rec, ident, rkey, rcid.String())
 	b, err := json.Marshal(doc)
 	if err != nil {

--- a/search/server.go
+++ b/search/server.go
@@ -168,6 +168,7 @@ func (s *Server) EnsureIndices(ctx context.Context) error {
 }
 
 type HealthStatus struct {
+	Service string `json:"service,const=palomar"`
 	Status  string `json:"status"`
 	Version string `json:"version"`
 	Message string `json:"msg,omitempty"`
@@ -202,6 +203,7 @@ func (s *Server) RunAPI(listen string) error {
 	}
 
 	e.Use(middleware.CORS())
+	e.GET("/", s.handleHealthCheck)
 	e.GET("/_health", s.handleHealthCheck)
 	e.GET("/metrics", echo.WrapHandler(promhttp.Handler()))
 	e.GET("/xrpc/app.bsky.unspecced.searchPostsSkeleton", s.handleSearchPostsSkeleton)

--- a/search/transform.go
+++ b/search/transform.go
@@ -2,11 +2,11 @@ package search
 
 import (
 	"strings"
-	"time"
 
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/atproto/identity"
-	"github.com/bluesky-social/indigo/util"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+
 	"github.com/rivo/uniseg"
 )
 
@@ -80,7 +80,7 @@ func TransformProfile(profile *appbsky.ActorProfile, ident *identity.Identity, c
 		handle = ident.Handle.String()
 	}
 	return ProfileDoc{
-		DocIndexTs:  time.Now().UTC().Format(util.ISO8601),
+		DocIndexTs:  syntax.DatetimeNow().String(),
 		DID:         ident.DID.String(),
 		RecordCID:   cid,
 		Handle:      handle,
@@ -157,7 +157,7 @@ func TransformPost(post *appbsky.FeedPost, ident *identity.Identity, rkey, cid s
 	}
 
 	doc := PostDoc{
-		DocIndexTs:      time.Now().UTC().Format(util.ISO8601),
+		DocIndexTs:      syntax.DatetimeNow().String(),
 		DID:             ident.DID.String(),
 		RecordRkey:      rkey,
 		RecordCID:       cid,
@@ -177,7 +177,12 @@ func TransformPost(post *appbsky.FeedPost, ident *identity.Identity, rkey, cid s
 	}
 
 	if post.CreatedAt != "" {
-		doc.CreatedAt = &post.CreatedAt
+		// there are some old bad timestamps out there!
+		dt, err := syntax.ParseDatetimeLenient(post.CreatedAt)
+		if nil == err { // *not* an error
+			s := dt.String()
+			doc.CreatedAt = &s
+		}
 	}
 
 	return doc


### PR DESCRIPTION
I took a peek at prod error logs and found some issues:

- deleting search documents is failing, because the "document ID" (docID) was formatted wrong, because the `rkey` parameter is actually a full path, not just the record key part
- many actually-valid datetimes were not getting parsed correctly, resulting in posts not having correct createdAt, likely resulting in them not appearing with expected ranking in search results
- many HTTP 404 errors on fetches of base path; not really a big deal but might as well return healthcheck

I haven't tested these much yet, we should probably deploy to staging (which consumes the prod firehose, IIRC) and observe that for a bit.