### PR TITLE
automod: mentions spike rule

### DIFF
--- a/automod/rules/all.go
+++ b/automod/rules/all.go
@@ -19,7 +19,7 @@ func DefaultRules() automod.RuleSet {
 			ReplySingleKeywordPostRule,
 			AggressivePromotionRule,
 			IdenticalReplyPostRule,
-			SpamMentionsRule,
+			DistinctMentionsRule,
 		},
 		ProfileRules: []automod.ProfileRuleFunc{
 			GtubeProfileRule,

--- a/automod/rules/all.go
+++ b/automod/rules/all.go
@@ -19,6 +19,7 @@ func DefaultRules() automod.RuleSet {
 			ReplySingleKeywordPostRule,
 			AggressivePromotionRule,
 			IdenticalReplyPostRule,
+			SpamMentionsRule,
 		},
 		ProfileRules: []automod.ProfileRuleFunc{
 			GtubeProfileRule,

--- a/automod/rules/mentions.go
+++ b/automod/rules/mentions.go
@@ -5,12 +5,12 @@ import (
 	"github.com/bluesky-social/indigo/automod"
 )
 
-var _ automod.PostRuleFunc = SpamMentionsRule
+var _ automod.PostRuleFunc = DistinctMentionsRule
 
 var mentionHourlyThreshold = 20
 
-// SpamMentionsRule looks for accounts which mention an unusually large number of distinct accounts per period.
-func SpamMentionsRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+// DistinctMentionsRule looks for accounts which mention an unusually large number of distinct accounts per period.
+func DistinctMentionsRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	did := evt.Account.Identity.DID.String()
 
 	// Increment counters for all new mentions in this post.

--- a/automod/rules/spammentions.go
+++ b/automod/rules/spammentions.go
@@ -1,0 +1,38 @@
+package rules
+
+import (
+	appbsky "github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/indigo/automod"
+)
+
+var _ automod.PostRuleFunc = SpamMentionsRule
+
+var mentionHourlyThreshold = 20
+
+// SpamMentionsRule looks for accounts which mention an unusually large number of distinct accounts per period.
+func SpamMentionsRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+	did := evt.Account.Identity.DID.String()
+
+	// Increment counters for all new mentions in this post.
+	var newMentions bool
+	for _, facet := range post.Facets {
+		for _, feature := range facet.Features {
+			mention := feature.RichtextFacet_Mention
+			if mention == nil {
+				continue
+			}
+			evt.IncrementDistinct("mentions", did, mention.Did)
+			newMentions = true
+		}
+	}
+
+	// If there were any new mentions, check if it's gotten spammy.
+	if !newMentions {
+		return nil
+	}
+	if mentionHourlyThreshold <= evt.GetCountDistinct("mentions", did, automod.PeriodHour) {
+		evt.AddAccountFlag("high-distinct-mentions")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Introduce a simple new rule for detecting and flagging spikes of mentions within a period.