### PR TITLE
palomar: handle bogus future createdAt better

### DIFF
--- a/search/query.go
+++ b/search/query.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log/slog"
-	"time"
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
@@ -76,11 +75,11 @@ func DoSearchPosts(ctx context.Context, dir identity.Directory, escli *es.Client
 		},
 	}
 	// filter out future posts (TODO: temporary hack)
-	today := syntax.DatetimeNow().Time().Format(time.DateOnly)
+	now := syntax.DatetimeNow()
 	filters = append(filters, map[string]interface{}{
 		"range": map[string]interface{}{
 			"created_at": map[string]interface{}{
-				"lte": today,
+				"lte": now,
 			},
 		},
 	})

--- a/search/query.go
+++ b/search/query.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log/slog"
+	"time"
 
 	"github.com/bluesky-social/indigo/atproto/identity"
-	"go.opentelemetry.io/otel/attribute"
+	"github.com/bluesky-social/indigo/atproto/syntax"
 
 	es "github.com/opensearch-project/opensearch-go/v2"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type EsSearchHit struct {
@@ -73,7 +75,15 @@ func DoSearchPosts(ctx context.Context, dir identity.Directory, escli *es.Client
 			"analyze_wildcard": false,
 		},
 	}
-
+	// filter out future posts (TODO: temporary hack)
+	today := syntax.DatetimeNow().Time().Format(time.DateOnly)
+	filters = append(filters, map[string]interface{}{
+		"range": map[string]interface{}{
+			"created_at": map[string]interface{}{
+				"lte": today,
+			},
+		},
+	})
 	query := map[string]interface{}{
 		"query": map[string]interface{}{
 			"bool": map[string]interface{}{

--- a/search/transform.go
+++ b/search/transform.go
@@ -188,6 +188,8 @@ func TransformPost(post *appbsky.FeedPost, ident *identity.Identity, rkey, cid s
 				doc.CreatedAt = &s
 			} else {
 				slog.Warn("rejecting future post CreatedAt", "datetime", dt.String(), "did", ident.DID.String(), "rkey", rkey)
+				s := syntax.DatetimeNow().String()
+				doc.CreatedAt = &s
 			}
 		}
 	}


### PR DESCRIPTION
This tries to mitigate issues with bogus createdAt timestamps in post records. In particular this might (?) be causing a bunch of network traffic in-app when you search posts for "hello".

We have a batch of these in the current index which mess up ranking, so there is a query-time filter. A better mitigation would be to run a cleanup "update by query" which might look like this (untested):

```
POST palomar_post/_update_by_query
{
  "script": {
    "source": "ctx._source.created_at = null",
    "lang": "painless"
  },
  "query": {
    "range": {
      "created_at": {
        "gte": "2024-01-01"
      }
    }
  }
}
```

Our PDS currently enforces a reasonable createdAt, but it might stop this Lexicon-specific behavior some day (speculative), or third-party PDS implementations might not take this step. So this PR adds checks at index-time.

There is no test coverage here, and haven't checked against an actual index, but wanted to share partial work if helpful.