### PR TITLE
dont include did doc in create session for now

### DIFF
--- a/api/atproto/servercreateSession.go
+++ b/api/atproto/servercreateSession.go
@@ -7,7 +7,6 @@ package atproto
 import (
 	"context"
 
-	"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -20,13 +19,13 @@ type ServerCreateSession_Input struct {
 
 // ServerCreateSession_Output is the output of a com.atproto.server.createSession call.
 type ServerCreateSession_Output struct {
-	AccessJwt      string                   `json:"accessJwt" cborgen:"accessJwt"`
-	Did            string                   `json:"did" cborgen:"did"`
-	DidDoc         *util.LexiconTypeDecoder `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
-	Email          *string                  `json:"email,omitempty" cborgen:"email,omitempty"`
-	EmailConfirmed *bool                    `json:"emailConfirmed,omitempty" cborgen:"emailConfirmed,omitempty"`
-	Handle         string                   `json:"handle" cborgen:"handle"`
-	RefreshJwt     string                   `json:"refreshJwt" cborgen:"refreshJwt"`
+	AccessJwt string `json:"accessJwt" cborgen:"accessJwt"`
+	Did       string `json:"did" cborgen:"did"`
+	//DidDoc         *util.LexiconTypeDecoder `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
+	Email          *string `json:"email,omitempty" cborgen:"email,omitempty"`
+	EmailConfirmed *bool   `json:"emailConfirmed,omitempty" cborgen:"emailConfirmed,omitempty"`
+	Handle         string  `json:"handle" cborgen:"handle"`
+	RefreshJwt     string  `json:"refreshJwt" cborgen:"refreshJwt"`
 }
 
 // ServerCreateSession calls the XRPC method "com.atproto.server.createSession".


### PR DESCRIPTION
The did doc is defined as an `any` type in the lexicon right now, which in all other cases implies a record (with a $type field). For now, lets just ignore this in the go code (its not necessary for anything) until we figure out a better way forward.