### PR TITLE
quick tweaks to rules at scale

### DIFF
--- a/automod/rules/keyword.go
+++ b/automod/rules/keyword.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"fmt"
+
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/automod"
 )
@@ -9,6 +11,7 @@ func KeywordPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	for _, tok := range ExtractTextTokensPost(post) {
 		if evt.InSet("bad-words", tok) {
 			evt.AddRecordFlag("bad-word")
+			evt.ReportRecord(automod.ReportReasonRude, fmt.Sprintf("bad-word: %s", tok))
 			break
 		}
 	}
@@ -19,6 +22,7 @@ func KeywordProfileRule(evt *automod.RecordEvent, profile *appbsky.ActorProfile)
 	for _, tok := range ExtractTextTokensProfile(profile) {
 		if evt.InSet("bad-words", tok) {
 			evt.AddRecordFlag("bad-word")
+			evt.ReportRecord(automod.ReportReasonRude, fmt.Sprintf("bad-word: %s", tok))
 			break
 		}
 	}

--- a/automod/rules/replies.go
+++ b/automod/rules/replies.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"unicode/utf8"
+
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/bluesky-social/indigo/automod"
@@ -40,7 +42,7 @@ func IdenticalReplyPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) er
 	}
 
 	// short reply? ignore it
-	if len(post.Text) <= 8 {
+	if utf8.RuneCountInString(post.Text) <= 10 {
 		return nil
 	}
 

--- a/automod/rules/replies.go
+++ b/automod/rules/replies.go
@@ -39,6 +39,11 @@ func IdenticalReplyPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) er
 		return nil
 	}
 
+	// short reply? ignore it
+	if len(post.Text) <= 8 {
+		return nil
+	}
+
 	// use a specific period (IncrementPeriod()) to reduce the number of counters (one per unique post text)
 	period := automod.PeriodDay
 	bucket := evt.Account.Identity.DID.String() + "/" + HashOfString(post.Text)


### PR DESCRIPTION
- skip short post text for identical replies
- start reporting bad word records for review

The "short post text" instead of skipping just empty also handles a common case of "handful of emoji".