### PR TITLE
automod context plumbing

### DIFF
--- a/automod/action_dedupe_test.go
+++ b/automod/action_dedupe_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func alwaysReportAccountRule(evt *RecordEvent) error {
+func alwaysReportAccountRule(ctx context.Context, evt *RecordEvent) error {
 	evt.ReportAccount(ReportReasonOther, "test report")
 	return nil
 }

--- a/automod/circuit_breaker_test.go
+++ b/automod/circuit_breaker_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func alwaysTakedownRecordRule(evt *RecordEvent) error {
+func alwaysTakedownRecordRule(ctx context.Context, evt *RecordEvent) error {
 	evt.TakedownRecord()
 	return nil
 }
 
-func alwaysReportRecordRule(evt *RecordEvent) error {
+func alwaysReportRecordRule(ctx context.Context, evt *RecordEvent) error {
 	evt.ReportRecord(ReportReasonOther, "test report")
 	return nil
 }

--- a/automod/engine.go
+++ b/automod/engine.go
@@ -57,7 +57,7 @@ func (e *Engine) ProcessIdentityEvent(ctx context.Context, t string, did syntax.
 			Account: *am,
 		},
 	}
-	if err := e.Rules.CallIdentityRules(&evt); err != nil {
+	if err := e.Rules.CallIdentityRules(ctx, &evt); err != nil {
 		return err
 	}
 	if evt.Err != nil {
@@ -100,7 +100,7 @@ func (e *Engine) ProcessRecord(ctx context.Context, did syntax.DID, path, recCID
 	}
 	evt := e.NewRecordEvent(*am, path, recCID, rec)
 	e.Logger.Debug("processing record", "did", ident.DID, "path", path)
-	if err := e.Rules.CallRecordRules(&evt); err != nil {
+	if err := e.Rules.CallRecordRules(ctx, &evt); err != nil {
 		return err
 	}
 	if evt.Err != nil {
@@ -146,7 +146,7 @@ func (e *Engine) ProcessRecordDelete(ctx context.Context, did syntax.DID, path s
 	}
 	evt := e.NewRecordDeleteEvent(*am, path)
 	e.Logger.Debug("processing record deletion", "did", ident.DID, "path", path)
-	if err := e.Rules.CallRecordDeleteRules(&evt); err != nil {
+	if err := e.Rules.CallRecordDeleteRules(ctx, &evt); err != nil {
 		return err
 	}
 	if evt.Err != nil {

--- a/automod/event.go
+++ b/automod/event.go
@@ -592,8 +592,8 @@ type RecordDeleteEvent struct {
 	RecordKey  string
 }
 
-type IdentityRuleFunc = func(evt *IdentityEvent) error
-type RecordRuleFunc = func(evt *RecordEvent) error
-type PostRuleFunc = func(evt *RecordEvent, post *appbsky.FeedPost) error
-type ProfileRuleFunc = func(evt *RecordEvent, profile *appbsky.ActorProfile) error
-type RecordDeleteRuleFunc = func(evt *RecordDeleteEvent) error
+type IdentityRuleFunc = func(ctx context.Context, evt *IdentityEvent) error
+type RecordRuleFunc = func(ctx context.Context, evt *RecordEvent) error
+type PostRuleFunc = func(ctx context.Context, evt *RecordEvent, post *appbsky.FeedPost) error
+type ProfileRuleFunc = func(ctx context.Context, evt *RecordEvent, profile *appbsky.ActorProfile) error
+type RecordDeleteRuleFunc = func(ctx context.Context, evt *RecordDeleteEvent) error

--- a/automod/rules/all.go
+++ b/automod/rules/all.go
@@ -19,7 +19,7 @@ func DefaultRules() automod.RuleSet {
 			ReplySingleKeywordPostRule,
 			AggressivePromotionRule,
 			IdenticalReplyPostRule,
-			SpamMentionsRule,
+			DistinctMentionsRule,
 		},
 		ProfileRules: []automod.ProfileRuleFunc{
 			GtubeProfileRule,

--- a/automod/rules/all.go
+++ b/automod/rules/all.go
@@ -19,6 +19,7 @@ func DefaultRules() automod.RuleSet {
 			ReplySingleKeywordPostRule,
 			AggressivePromotionRule,
 			IdenticalReplyPostRule,
+			SpamMentionsRule,
 		},
 		ProfileRules: []automod.ProfileRuleFunc{
 			GtubeProfileRule,

--- a/automod/rules/gtube.go
+++ b/automod/rules/gtube.go
@@ -1,23 +1,29 @@
 package rules
 
 import (
+	"context"
 	"strings"
 
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/automod"
 )
 
+var (
+	_ automod.PostRuleFunc    = GtubePostRule
+	_ automod.ProfileRuleFunc = GtubeProfileRule
+)
+
 // https://en.wikipedia.org/wiki/GTUBE
 var gtubeString = "XJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X"
 
-func GtubePostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+func GtubePostRule(ctx context.Context, evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	if strings.Contains(post.Text, gtubeString) {
 		evt.AddRecordLabel("spam")
 	}
 	return nil
 }
 
-func GtubeProfileRule(evt *automod.RecordEvent, profile *appbsky.ActorProfile) error {
+func GtubeProfileRule(ctx context.Context, evt *automod.RecordEvent, profile *appbsky.ActorProfile) error {
 	if profile.Description != nil && strings.Contains(*profile.Description, gtubeString) {
 		evt.AddRecordLabel("spam")
 	}

--- a/automod/rules/hashtags.go
+++ b/automod/rules/hashtags.go
@@ -1,12 +1,19 @@
 package rules
 
 import (
+	"context"
+
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/automod"
 )
 
+var (
+	_ automod.PostRuleFunc = BadHashtagsPostRule
+	_ automod.PostRuleFunc = TooManyHashtagsPostRule
+)
+
 // looks for specific hashtags from known lists
-func BadHashtagsPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+func BadHashtagsPostRule(ctx context.Context, evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	for _, tag := range ExtractHashtags(post) {
 		tag = NormalizeHashtag(tag)
 		if evt.InSet("bad-hashtags", tag) {
@@ -18,7 +25,7 @@ func BadHashtagsPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error
 }
 
 // if a post is "almost all" hashtags, it might be a form of search spam
-func TooManyHashtagsPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+func TooManyHashtagsPostRule(ctx context.Context, evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	tags := ExtractHashtags(post)
 	tagChars := 0
 	for _, tag := range tags {

--- a/automod/rules/hashtags_test.go
+++ b/automod/rules/hashtags_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"testing"
 
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
@@ -12,6 +13,7 @@ import (
 )
 
 func TestBadHashtagPostRule(t *testing.T) {
+	ctx := context.Background()
 	assert := assert.New(t)
 
 	engine := automod.EngineTestFixture()
@@ -27,7 +29,7 @@ func TestBadHashtagPostRule(t *testing.T) {
 		Text: "some post blah",
 	}
 	evt1 := engine.NewRecordEvent(am1, path, cid1, &p1)
-	assert.NoError(BadHashtagsPostRule(&evt1, &p1))
+	assert.NoError(BadHashtagsPostRule(ctx, &evt1, &p1))
 	assert.Empty(evt1.RecordFlags)
 
 	p2 := appbsky.FeedPost{
@@ -35,6 +37,6 @@ func TestBadHashtagPostRule(t *testing.T) {
 		Tags: []string{"one", "slur"},
 	}
 	evt2 := engine.NewRecordEvent(am1, path, cid1, &p2)
-	assert.NoError(BadHashtagsPostRule(&evt2, &p2))
+	assert.NoError(BadHashtagsPostRule(ctx, &evt2, &p2))
 	assert.NotEmpty(evt2.RecordFlags)
 }

--- a/automod/rules/identity.go
+++ b/automod/rules/identity.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"net/url"
 	"strings"
 	"time"
@@ -9,8 +10,10 @@ import (
 	"github.com/bluesky-social/indigo/automod/countstore"
 )
 
+var _ automod.IdentityRuleFunc = NewAccountRule
+
 // triggers on first identity event for an account (DID)
-func NewAccountRule(evt *automod.IdentityEvent) error {
+func NewAccountRule(ctx context.Context, evt *automod.IdentityEvent) error {
 	// need access to IndexedAt for this rule
 	if evt.Account.Private == nil || evt.Account.Identity == nil {
 		return nil

--- a/automod/rules/interaction.go
+++ b/automod/rules/interaction.go
@@ -1,16 +1,22 @@
 package rules
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bluesky-social/indigo/automod"
 	"github.com/bluesky-social/indigo/automod/countstore"
 )
 
+var (
+	_ automod.RecordRuleFunc       = InteractionChurnRule
+	_ automod.RecordDeleteRuleFunc = DeleteInteractionRule
+)
+
 var interactionDailyThreshold = 800
 
 // looks for accounts which do frequent interaction churn, such as follow-unfollow.
-func InteractionChurnRule(evt *automod.RecordEvent) error {
+func InteractionChurnRule(ctx context.Context, evt *automod.RecordEvent) error {
 	did := evt.Account.Identity.DID.String()
 	switch evt.Collection {
 	case "app.bsky.feed.like":
@@ -37,7 +43,7 @@ func InteractionChurnRule(evt *automod.RecordEvent) error {
 	return nil
 }
 
-func DeleteInteractionRule(evt *automod.RecordDeleteEvent) error {
+func DeleteInteractionRule(ctx context.Context, evt *automod.RecordDeleteEvent) error {
 	did := evt.Account.Identity.DID.String()
 	switch evt.Collection {
 	case "app.bsky.feed.like":

--- a/automod/rules/keyword.go
+++ b/automod/rules/keyword.go
@@ -1,11 +1,19 @@
 package rules
 
 import (
+	"context"
+
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/automod"
 )
 
-func KeywordPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+var (
+	_ automod.PostRuleFunc    = KeywordPostRule
+	_ automod.ProfileRuleFunc = KeywordProfileRule
+	_ automod.PostRuleFunc    = ReplySingleKeywordPostRule
+)
+
+func KeywordPostRule(ctx context.Context, evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	for _, tok := range ExtractTextTokensPost(post) {
 		if evt.InSet("bad-words", tok) {
 			evt.AddRecordFlag("bad-word")
@@ -15,7 +23,7 @@ func KeywordPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	return nil
 }
 
-func KeywordProfileRule(evt *automod.RecordEvent, profile *appbsky.ActorProfile) error {
+func KeywordProfileRule(ctx context.Context, evt *automod.RecordEvent, profile *appbsky.ActorProfile) error {
 	for _, tok := range ExtractTextTokensProfile(profile) {
 		if evt.InSet("bad-words", tok) {
 			evt.AddRecordFlag("bad-word")
@@ -25,7 +33,7 @@ func KeywordProfileRule(evt *automod.RecordEvent, profile *appbsky.ActorProfile)
 	return nil
 }
 
-func ReplySingleKeywordPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+func ReplySingleKeywordPostRule(ctx context.Context, evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	if post.Reply != nil && !IsSelfThread(evt, post) {
 		tokens := ExtractTextTokensPost(post)
 		if len(tokens) == 1 && evt.InSet("bad-words", tokens[0]) {

--- a/automod/rules/mentions.go
+++ b/automod/rules/mentions.go
@@ -5,12 +5,12 @@ import (
 	"github.com/bluesky-social/indigo/automod"
 )
 
-var _ automod.PostRuleFunc = SpamMentionsRule
+var _ automod.PostRuleFunc = DistinctMentionsRule
 
 var mentionHourlyThreshold = 20
 
-// SpamMentionsRule looks for accounts which mention an unusually large number of distinct accounts per period.
-func SpamMentionsRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+// DistinctMentionsRule looks for accounts which mention an unusually large number of distinct accounts per period.
+func DistinctMentionsRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	did := evt.Account.Identity.DID.String()
 
 	// Increment counters for all new mentions in this post.

--- a/automod/rules/mentions.go
+++ b/automod/rules/mentions.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"context"
+
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/automod"
 )
@@ -10,7 +12,7 @@ var _ automod.PostRuleFunc = DistinctMentionsRule
 var mentionHourlyThreshold = 20
 
 // DistinctMentionsRule looks for accounts which mention an unusually large number of distinct accounts per period.
-func DistinctMentionsRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+func DistinctMentionsRule(ctx context.Context, evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	did := evt.Account.Identity.DID.String()
 
 	// Increment counters for all new mentions in this post.

--- a/automod/rules/misleading.go
+++ b/automod/rules/misleading.go
@@ -12,6 +12,11 @@ import (
 	"github.com/bluesky-social/indigo/automod"
 )
 
+var (
+	_ automod.PostRuleFunc = MisleadingURLPostRule
+	_ automod.PostRuleFunc = MisleadingMentionPostRule
+)
+
 func isMisleadingURLFacet(facet PostFacet, logger *slog.Logger) bool {
 	linkURL, err := url.Parse(*facet.URL)
 	if err != nil {
@@ -78,7 +83,7 @@ func isMisleadingURLFacet(facet PostFacet, logger *slog.Logger) bool {
 	return false
 }
 
-func MisleadingURLPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+func MisleadingURLPostRule(ctx context.Context, evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	// TODO: make this an InSet() config?
 	if evt.Account.Identity.Handle == "nowbreezing.ntw.app" {
 		return nil
@@ -100,9 +105,7 @@ func MisleadingURLPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) err
 	return nil
 }
 
-func MisleadingMentionPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
-	// TODO: do we really need to route context around? probably
-	ctx := context.TODO()
+func MisleadingMentionPostRule(ctx context.Context, evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	facets, err := ExtractFacets(post)
 	if err != nil {
 		evt.Logger.Warn("invalid facets", "err", err)

--- a/automod/rules/misleading_test.go
+++ b/automod/rules/misleading_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 )
 
 func TestMisleadingURLPostRule(t *testing.T) {
+	ctx := context.Background()
 	assert := assert.New(t)
 
 	engine := automod.EngineTestFixture()
@@ -43,11 +45,12 @@ func TestMisleadingURLPostRule(t *testing.T) {
 		},
 	}
 	evt1 := engine.NewRecordEvent(am1, path, cid1, &p1)
-	assert.NoError(MisleadingURLPostRule(&evt1, &p1))
+	assert.NoError(MisleadingURLPostRule(ctx, &evt1, &p1))
 	assert.NotEmpty(evt1.RecordFlags)
 }
 
 func TestMisleadingMentionPostRule(t *testing.T) {
+	ctx := context.Background()
 	assert := assert.New(t)
 
 	engine := automod.EngineTestFixture()
@@ -78,7 +81,7 @@ func TestMisleadingMentionPostRule(t *testing.T) {
 		},
 	}
 	evt1 := engine.NewRecordEvent(am1, path, cid1, &p1)
-	assert.NoError(MisleadingMentionPostRule(&evt1, &p1))
+	assert.NoError(MisleadingMentionPostRule(ctx, &evt1, &p1))
 	assert.NotEmpty(evt1.RecordFlags)
 }
 

--- a/automod/rules/private.go
+++ b/automod/rules/private.go
@@ -1,14 +1,17 @@
 package rules
 
 import (
+	"context"
 	"strings"
 
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/automod"
 )
 
+var _ automod.PostRuleFunc = AccountPrivateDemoPostRule
+
 // dummy rule. this leaks PII (account email) in logs and should never be used in real life
-func AccountPrivateDemoPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+func AccountPrivateDemoPostRule(ctx context.Context, evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	if evt.Account.Private != nil {
 		if strings.HasSuffix(evt.Account.Private.Email, "@blueskyweb.xyz") {
 			evt.Logger.Info("hello dev!", "email", evt.Account.Private.Email)

--- a/automod/rules/profile.go
+++ b/automod/rules/profile.go
@@ -1,12 +1,16 @@
 package rules
 
 import (
+	"context"
+
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/automod"
 )
 
+var _ automod.PostRuleFunc = AccountDemoPostRule
+
 // this is a dummy rule to demonstrate accessing account metadata (eg, profile) from within post handler
-func AccountDemoPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+func AccountDemoPostRule(ctx context.Context, evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	if evt.Account.Profile.Description != nil && len(post.Text) > 5 && *evt.Account.Profile.Description == post.Text {
 		evt.AddRecordFlag("own-profile-description")
 	}

--- a/automod/rules/promo.go
+++ b/automod/rules/promo.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"context"
 	"net/url"
 	"strings"
 	"time"
@@ -10,10 +11,12 @@ import (
 	"github.com/bluesky-social/indigo/automod/countstore"
 )
 
+var _ automod.PostRuleFunc = AggressivePromotionRule
+
 // looks for new accounts, with a commercial or donation link in profile, which directly reply to several accounts
 //
 // this rule depends on ReplyCountPostRule() to set counts
-func AggressivePromotionRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+func AggressivePromotionRule(ctx context.Context, evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	if evt.Account.Private == nil || evt.Account.Identity == nil {
 		return nil
 	}

--- a/automod/rules/replies.go
+++ b/automod/rules/replies.go
@@ -1,14 +1,21 @@
 package rules
 
 import (
+	"context"
+
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/bluesky-social/indigo/automod"
 	"github.com/bluesky-social/indigo/automod/countstore"
 )
 
+var (
+	_ automod.PostRuleFunc = ReplyCountPostRule
+	_ automod.PostRuleFunc = IdenticalReplyPostRule
+)
+
 // does not count "self-replies" (direct to self, or in own post thread)
-func ReplyCountPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+func ReplyCountPostRule(ctx context.Context, evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	if post.Reply == nil || IsSelfThread(evt, post) {
 		return nil
 	}
@@ -34,7 +41,7 @@ var identicalReplyLimit = 5
 // Looks for accounts posting the exact same text multiple times. Does not currently count the number of distinct accounts replied to, just counts replies at all.
 //
 // There can be legitimate situations that trigger this rule, so in most situations should be a "report" not "label" action.
-func IdenticalReplyPostRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+func IdenticalReplyPostRule(ctx context.Context, evt *automod.RecordEvent, post *appbsky.FeedPost) error {
 	if post.Reply == nil || IsSelfThread(evt, post) {
 		return nil
 	}

--- a/automod/rules/spammentions.go
+++ b/automod/rules/spammentions.go
@@ -1,0 +1,38 @@
+package rules
+
+import (
+	appbsky "github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/indigo/automod"
+)
+
+var _ automod.PostRuleFunc = SpamMentionsRule
+
+var mentionHourlyThreshold = 20
+
+// SpamMentionsRule looks for accounts which mention an unusually large number of distinct accounts per period.
+func SpamMentionsRule(evt *automod.RecordEvent, post *appbsky.FeedPost) error {
+	did := evt.Account.Identity.DID.String()
+
+	// Increment counters for all new mentions in this post.
+	var newMentions bool
+	for _, facet := range post.Facets {
+		for _, feature := range facet.Features {
+			mention := feature.RichtextFacet_Mention
+			if mention == nil {
+				continue
+			}
+			evt.IncrementDistinct("mentions", did, mention.Did)
+			newMentions = true
+		}
+	}
+
+	// If there were any new mentions, check if it's gotten spammy.
+	if !newMentions {
+		return nil
+	}
+	if mentionHourlyThreshold <= evt.GetCountDistinct("mentions", did, automod.PeriodHour) {
+		evt.AddAccountFlag("high-distinct-mentions")
+	}
+
+	return nil
+}

--- a/automod/ruleset.go
+++ b/automod/ruleset.go
@@ -1,6 +1,7 @@
 package automod
 
 import (
+	"context"
 	"fmt"
 
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
@@ -14,10 +15,10 @@ type RuleSet struct {
 	IdentityRules     []IdentityRuleFunc
 }
 
-func (r *RuleSet) CallRecordRules(evt *RecordEvent) error {
+func (r *RuleSet) CallRecordRules(ctx context.Context, evt *RecordEvent) error {
 	// first the generic rules
 	for _, f := range r.RecordRules {
-		err := f(evt)
+		err := f(ctx, evt)
 		if err != nil {
 			return err
 		}
@@ -33,7 +34,7 @@ func (r *RuleSet) CallRecordRules(evt *RecordEvent) error {
 			return fmt.Errorf("mismatch between collection (%s) and type", evt.Collection)
 		}
 		for _, f := range r.PostRules {
-			err := f(evt, post)
+			err := f(ctx, evt, post)
 			if err != nil {
 				return err
 			}
@@ -47,7 +48,7 @@ func (r *RuleSet) CallRecordRules(evt *RecordEvent) error {
 			return fmt.Errorf("mismatch between collection (%s) and type", evt.Collection)
 		}
 		for _, f := range r.ProfileRules {
-			err := f(evt, profile)
+			err := f(ctx, evt, profile)
 			if err != nil {
 				return err
 			}
@@ -59,9 +60,9 @@ func (r *RuleSet) CallRecordRules(evt *RecordEvent) error {
 	return nil
 }
 
-func (r *RuleSet) CallRecordDeleteRules(evt *RecordDeleteEvent) error {
+func (r *RuleSet) CallRecordDeleteRules(ctx context.Context, evt *RecordDeleteEvent) error {
 	for _, f := range r.RecordDeleteRules {
-		err := f(evt)
+		err := f(ctx, evt)
 		if err != nil {
 			return err
 		}
@@ -72,9 +73,9 @@ func (r *RuleSet) CallRecordDeleteRules(evt *RecordDeleteEvent) error {
 	return nil
 }
 
-func (r *RuleSet) CallIdentityRules(evt *IdentityEvent) error {
+func (r *RuleSet) CallIdentityRules(ctx context.Context, evt *IdentityEvent) error {
 	for _, f := range r.IdentityRules {
-		err := f(evt)
+		err := f(ctx, evt)
 		if err != nil {
 			return err
 		}

--- a/automod/testing.go
+++ b/automod/testing.go
@@ -13,7 +13,7 @@ import (
 	"github.com/bluesky-social/indigo/atproto/syntax"
 )
 
-func simpleRule(evt *RecordEvent, post *appbsky.FeedPost) error {
+func simpleRule(ctx context.Context, evt *RecordEvent, post *appbsky.FeedPost) error {
 	for _, tag := range post.Tags {
 		if evt.InSet("bad-hashtags", tag) {
 			evt.AddRecordLabel("bad-hashtag")
@@ -100,7 +100,7 @@ func ProcessCaptureRules(e *Engine, capture AccountCapture) error {
 			Account: capture.AccountMeta,
 		},
 	}
-	if err := e.Rules.CallIdentityRules(&idevt); err != nil {
+	if err := e.Rules.CallIdentityRules(ctx, &idevt); err != nil {
 		return err
 	}
 	if idevt.Err != nil {
@@ -123,7 +123,7 @@ func ProcessCaptureRules(e *Engine, capture AccountCapture) error {
 		path := aturi.Collection().String() + "/" + aturi.RecordKey().String()
 		evt := e.NewRecordEvent(capture.AccountMeta, path, pr.Cid, pr.Value.Val)
 		e.Logger.Debug("processing record", "did", aturi.Authority(), "path", path)
-		if err := e.Rules.CallRecordRules(&evt); err != nil {
+		if err := e.Rules.CallRecordRules(ctx, &evt); err != nil {
 			return err
 		}
 		if evt.Err != nil {


### PR DESCRIPTION
Plumb context through rules.

This is mostly not yet used, but prepares for future needs.  It does also remove one TODO -- there was one existing rule that uses a directory lookup, and was doing so without a fully connected context.

I took the liberty of adding type assertion "variables" to the header of each rule file, while at it.

(Currently also includes a few commits from another branch, but will rebase as soon as that's merged.)