### PR TITLE
automod: ability to surpress canonical-log-line verbosity when developing

### DIFF
--- a/automod/engine.go
+++ b/automod/engine.go
@@ -28,6 +28,7 @@ type Engine struct {
 	// used to persist moderation actions in mod service (optional)
 	AdminClient     *xrpc.Client
 	SlackWebhookURL string
+	LogQuieter      bool
 }
 
 func (e *Engine) ProcessIdentityEvent(ctx context.Context, t string, did syntax.DID) error {

--- a/automod/event.go
+++ b/automod/event.go
@@ -414,8 +414,22 @@ func (e *RepoEvent) PersistCounters(ctx context.Context) error {
 	return nil
 }
 
+func (e *RepoEvent) AnyActions() bool {
+	if len(e.AccountLabels) > 0 || len(e.AccountFlags) > 0 || e.AccountTakedown || len(e.AccountReports) > 0 {
+		return true
+	}
+	return false
+}
+
 func (e *RepoEvent) CanonicalLogLine() {
-	e.Logger.Info("canonical-event-line",
+	level := slog.LevelInfo
+	if e.Engine.LogQuieter && !e.AnyActions() {
+		level = slog.LevelDebug
+	}
+	e.Logger.Log(
+		context.Background(),
+		level,
+		"canonical-event-line",
 		"accountLabels", e.AccountLabels,
 		"accountFlags", e.AccountFlags,
 		"accountTakedown", e.AccountTakedown,
@@ -574,8 +588,25 @@ func (e *RecordEvent) PersistActions(ctx context.Context) error {
 	return e.PersistRecordActions(ctx)
 }
 
+func (e *RecordEvent) AnyActions() bool {
+	if e.RepoEvent.AnyActions() {
+		return true
+	}
+	if len(e.RecordLabels) > 0 || len(e.RecordFlags) > 0 || e.RecordTakedown || len(e.RecordReports) > 0 {
+		return true
+	}
+	return false
+}
+
 func (e *RecordEvent) CanonicalLogLine() {
-	e.Logger.Info("canonical-event-line",
+	level := slog.LevelInfo
+	if e.Engine.LogQuieter && !e.AnyActions() {
+		level = slog.LevelDebug
+	}
+	e.Logger.Log(
+		context.Background(),
+		level,
+		"canonical-event-line",
 		"accountLabels", e.AccountLabels,
 		"accountFlags", e.AccountFlags,
 		"accountTakedown", e.AccountTakedown,

--- a/cmd/hepa/main.go
+++ b/cmd/hepa/main.go
@@ -144,6 +144,11 @@ var runCmd = &cli.Command{
 			Usage:   "full URL of slack webhook",
 			EnvVars: []string{"SLACK_WEBHOOK_URL"},
 		},
+		&cli.StringFlag{
+			Name:    "quieter",
+			Usage:   "log events to lower-level unless there is an action",
+			EnvVars: []string{"HEPA_QUIETER"},
+		},
 	},
 	Action: func(cctx *cli.Context) error {
 		ctx := context.Background()
@@ -172,6 +177,7 @@ var runCmd = &cli.Command{
 				SetsFileJSON:    cctx.String("sets-json-path"),
 				RedisURL:        cctx.String("redis-url"),
 				SlackWebhookURL: cctx.String("slack-webhook-url"),
+				LogQuieter:      cctx.Bool("quieter"),
 			},
 		)
 		if err != nil {

--- a/cmd/hepa/server.go
+++ b/cmd/hepa/server.go
@@ -40,6 +40,7 @@ type Config struct {
 	RedisURL        string
 	SlackWebhookURL string
 	Logger          *slog.Logger
+	LogQuieter      bool
 }
 
 func NewServer(dir identity.Directory, config Config) (*Server, error) {
@@ -141,6 +142,7 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 			Host:   config.BskyHost,
 		},
 		SlackWebhookURL: config.SlackWebhookURL,
+		LogQuieter:      config.LogQuieter,
 	}
 
 	s := &Server{


### PR DESCRIPTION
The behavior with this CLI flag set is that most log lines end up being "DEBUG" not "INFO", and won't print by default. This is more useful for development when actually inspecting logs visually.

----

I'm not actually sure this is the right way forward. Maybe instead the canonical log line should have a fixed verbosity and we do something closer to the slack webhook for at a higher log level?