### PR TITLE
automod orga

### DIFF
--- a/automod/account_meta.go
+++ b/automod/account_meta.go
@@ -10,6 +10,7 @@ import (
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/bluesky-social/indigo/automod/util"
 )
 
 type ProfileSummary struct {
@@ -95,8 +96,8 @@ func (e *Engine) GetAccountMeta(ctx context.Context, ident *identity.Identity) (
 			Description: pv.Description,
 			DisplayName: pv.DisplayName,
 		},
-		AccountLabels:        dedupeStrings(labels),
-		AccountNegatedLabels: dedupeStrings(negLabels),
+		AccountLabels:        util.DedupeStrings(labels),
+		AccountNegatedLabels: util.DedupeStrings(negLabels),
 		AccountFlags:         flags,
 	}
 	if pv.PostsCount != nil {

--- a/automod/cachestore/cachestore.go
+++ b/automod/cachestore/cachestore.go
@@ -1,0 +1,11 @@
+package cachestore
+
+import (
+	"context"
+)
+
+type CacheStore interface {
+	Get(ctx context.Context, name, key string) (string, error)
+	Set(ctx context.Context, name, key string, val string) error
+	Purge(ctx context.Context, name, key string) error
+}

--- a/automod/cachestore/cachestore_mem.go
+++ b/automod/cachestore/cachestore_mem.go
@@ -1,4 +1,4 @@
-package automod
+package cachestore
 
 import (
 	"context"
@@ -6,12 +6,6 @@ import (
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
 )
-
-type CacheStore interface {
-	Get(ctx context.Context, name, key string) (string, error)
-	Set(ctx context.Context, name, key string, val string) error
-	Purge(ctx context.Context, name, key string) error
-}
 
 type MemCacheStore struct {
 	Data *expirable.LRU[string, string]

--- a/automod/cachestore/cachestore_redis.go
+++ b/automod/cachestore/cachestore_redis.go
@@ -1,4 +1,4 @@
-package automod
+package cachestore
 
 import (
 	"context"

--- a/automod/directory/redis_directory.go
+++ b/automod/directory/redis_directory.go
@@ -1,4 +1,4 @@
-package automod
+package directory
 
 import (
 	"context"

--- a/automod/engine.go
+++ b/automod/engine.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/bluesky-social/indigo/automod/countstore"
+	"github.com/bluesky-social/indigo/automod/flagstore"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -22,7 +23,7 @@ type Engine struct {
 	Counters    countstore.CountStore
 	Sets        SetStore
 	Cache       CacheStore
-	Flags       FlagStore
+	Flags       flagstore.FlagStore
 	RelayClient *xrpc.Client
 	BskyClient  *xrpc.Client
 	// used to persist moderation actions in mod service (optional)

--- a/automod/engine.go
+++ b/automod/engine.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/bluesky-social/indigo/automod/cachestore"
 	"github.com/bluesky-social/indigo/automod/countstore"
 	"github.com/bluesky-social/indigo/automod/flagstore"
 	"github.com/bluesky-social/indigo/xrpc"
@@ -22,7 +23,7 @@ type Engine struct {
 	Rules       RuleSet
 	Counters    countstore.CountStore
 	Sets        SetStore
-	Cache       CacheStore
+	Cache       cachestore.CacheStore
 	Flags       flagstore.FlagStore
 	RelayClient *xrpc.Client
 	BskyClient  *xrpc.Client

--- a/automod/engine.go
+++ b/automod/engine.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bluesky-social/indigo/automod/cachestore"
 	"github.com/bluesky-social/indigo/automod/countstore"
 	"github.com/bluesky-social/indigo/automod/flagstore"
+	"github.com/bluesky-social/indigo/automod/setstore"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -22,7 +23,7 @@ type Engine struct {
 	Directory   identity.Directory
 	Rules       RuleSet
 	Counters    countstore.CountStore
-	Sets        SetStore
+	Sets        setstore.SetStore
 	Cache       cachestore.CacheStore
 	Flags       flagstore.FlagStore
 	RelayClient *xrpc.Client

--- a/automod/event.go
+++ b/automod/event.go
@@ -11,6 +11,7 @@ import (
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/bluesky-social/indigo/automod/countstore"
+	"github.com/bluesky-social/indigo/automod/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -164,7 +165,7 @@ func slackBody(header string, acct AccountMeta, newLabels, newFlags []string, ne
 
 func dedupeLabelActions(labels, existing, existingNegated []string) []string {
 	newLabels := []string{}
-	for _, val := range dedupeStrings(labels) {
+	for _, val := range util.DedupeStrings(labels) {
 		exists := false
 		for _, e := range existingNegated {
 			if val == e {
@@ -187,7 +188,7 @@ func dedupeLabelActions(labels, existing, existingNegated []string) []string {
 
 func dedupeFlagActions(flags, existing []string) []string {
 	newFlags := []string{}
-	for _, val := range dedupeStrings(flags) {
+	for _, val := range util.DedupeStrings(flags) {
 		exists := false
 		for _, e := range existing {
 			if val == e {
@@ -483,8 +484,8 @@ func (e *RecordEvent) ReportRecord(reason, comment string) {
 func (e *RecordEvent) PersistRecordActions(ctx context.Context) error {
 
 	// NOTE: record-level actions are *not* currently de-duplicated (aka, the same record could be labeled multiple times, or re-reported, etc)
-	newLabels := dedupeStrings(e.RecordLabels)
-	newFlags := dedupeStrings(e.RecordFlags)
+	newLabels := util.DedupeStrings(e.RecordLabels)
+	newFlags := util.DedupeStrings(e.RecordFlags)
 	newReports := circuitBreakReports(&e.RepoEvent, e.RecordReports)
 	newTakedown := circuitBreakTakedown(&e.RepoEvent, e.RecordTakedown)
 	atURI := fmt.Sprintf("at://%s/%s/%s", e.Account.Identity.DID, e.Collection, e.RecordKey)

--- a/automod/flagstore/flagstore.go
+++ b/automod/flagstore/flagstore.go
@@ -1,0 +1,11 @@
+package flagstore
+
+import (
+	"context"
+)
+
+type FlagStore interface {
+	Get(ctx context.Context, key string) ([]string, error)
+	Add(ctx context.Context, key string, flags []string) error
+	Remove(ctx context.Context, key string, flags []string) error
+}

--- a/automod/flagstore/flagstore_mem.go
+++ b/automod/flagstore/flagstore_mem.go
@@ -1,14 +1,10 @@
-package automod
+package flagstore
 
 import (
 	"context"
-)
 
-type FlagStore interface {
-	Get(ctx context.Context, key string) ([]string, error)
-	Add(ctx context.Context, key string, flags []string) error
-	Remove(ctx context.Context, key string, flags []string) error
-}
+	"github.com/bluesky-social/indigo/automod/util"
+)
 
 type MemFlagStore struct {
 	Data map[string][]string
@@ -36,7 +32,7 @@ func (s MemFlagStore) Add(ctx context.Context, key string, flags []string) error
 	for _, f := range flags {
 		v = append(v, f)
 	}
-	v = dedupeStrings(v)
+	v = util.DedupeStrings(v)
 	s.Data[key] = v
 	return nil
 }

--- a/automod/flagstore/flagstore_redis.go
+++ b/automod/flagstore/flagstore_redis.go
@@ -1,4 +1,4 @@
-package automod
+package flagstore
 
 import (
 	"context"

--- a/automod/flagstore/flagstore_redis_test.go
+++ b/automod/flagstore/flagstore_redis_test.go
@@ -1,4 +1,4 @@
-package automod
+package flagstore
 
 import (
 	"context"
@@ -7,11 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFlagStoreBasics(t *testing.T) {
+func TestRedisFlagStoreBasics(t *testing.T) {
+	t.Skip("live test, need redis running locally")
 	assert := assert.New(t)
 	ctx := context.Background()
 
-	fs := NewMemFlagStore()
+	fs, err := NewRedisFlagStore("redis://localhost:6379/0")
+	if err != nil {
+		t.Fail()
+	}
 
 	l, err := fs.Get(ctx, "test1")
 	assert.NoError(err)
@@ -23,8 +27,9 @@ func TestFlagStoreBasics(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(3, len(l))
 
-	assert.NoError(fs.Remove(ctx, "test1", []string{"red", "blue"}))
+	assert.NoError(fs.Remove(ctx, "test1", []string{"red", "blue", "orange"}))
 	l, err = fs.Get(ctx, "test1")
 	assert.NoError(err)
 	assert.Equal([]string{"green"}, l)
+	assert.NoError(fs.Remove(ctx, "test1", []string{"green"}))
 }

--- a/automod/flagstore/flagstore_test.go
+++ b/automod/flagstore/flagstore_test.go
@@ -1,4 +1,4 @@
-package automod
+package flagstore
 
 import (
 	"context"
@@ -7,15 +7,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRedisFlagStoreBasics(t *testing.T) {
-	t.Skip("live test, need redis running locally")
+func TestFlagStoreBasics(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 
-	fs, err := NewRedisFlagStore("redis://localhost:6379/0")
-	if err != nil {
-		t.Fail()
-	}
+	fs := NewMemFlagStore()
 
 	l, err := fs.Get(ctx, "test1")
 	assert.NoError(err)
@@ -27,9 +23,8 @@ func TestRedisFlagStoreBasics(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(3, len(l))
 
-	assert.NoError(fs.Remove(ctx, "test1", []string{"red", "blue", "orange"}))
+	assert.NoError(fs.Remove(ctx, "test1", []string{"red", "blue"}))
 	l, err = fs.Get(ctx, "test1")
 	assert.NoError(err)
 	assert.Equal([]string{"green"}, l)
-	assert.NoError(fs.Remove(ctx, "test1", []string{"green"}))
 }

--- a/automod/setstore/setstore.go
+++ b/automod/setstore/setstore.go
@@ -1,4 +1,4 @@
-package automod
+package setstore
 
 import (
 	"context"

--- a/automod/testing.go
+++ b/automod/testing.go
@@ -11,6 +11,7 @@ import (
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/bluesky-social/indigo/automod/cachestore"
 	"github.com/bluesky-social/indigo/automod/countstore"
 	"github.com/bluesky-social/indigo/automod/flagstore"
 )
@@ -42,7 +43,7 @@ func EngineTestFixture() Engine {
 			simpleRule,
 		},
 	}
-	cache := NewMemCacheStore(10, time.Hour)
+	cache := cachestore.NewMemCacheStore(10, time.Hour)
 	flags := flagstore.NewMemFlagStore()
 	sets := NewMemSetStore()
 	sets.Sets["bad-hashtags"] = make(map[string]bool)

--- a/automod/testing.go
+++ b/automod/testing.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bluesky-social/indigo/automod/cachestore"
 	"github.com/bluesky-social/indigo/automod/countstore"
 	"github.com/bluesky-social/indigo/automod/flagstore"
+	"github.com/bluesky-social/indigo/automod/setstore"
 )
 
 func simpleRule(evt *RecordEvent, post *appbsky.FeedPost) error {
@@ -45,7 +46,7 @@ func EngineTestFixture() Engine {
 	}
 	cache := cachestore.NewMemCacheStore(10, time.Hour)
 	flags := flagstore.NewMemFlagStore()
-	sets := NewMemSetStore()
+	sets := setstore.NewMemSetStore()
 	sets.Sets["bad-hashtags"] = make(map[string]bool)
 	sets.Sets["bad-hashtags"]["slur"] = true
 	dir := identity.NewMockDirectory()

--- a/automod/testing.go
+++ b/automod/testing.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/bluesky-social/indigo/automod/countstore"
+	"github.com/bluesky-social/indigo/automod/flagstore"
 )
 
 func simpleRule(evt *RecordEvent, post *appbsky.FeedPost) error {
@@ -42,7 +43,7 @@ func EngineTestFixture() Engine {
 		},
 	}
 	cache := NewMemCacheStore(10, time.Hour)
-	flags := NewMemFlagStore()
+	flags := flagstore.NewMemFlagStore()
 	sets := NewMemSetStore()
 	sets.Sets["bad-hashtags"] = make(map[string]bool)
 	sets.Sets["bad-hashtags"]["slur"] = true

--- a/automod/util/strings.go
+++ b/automod/util/strings.go
@@ -1,6 +1,6 @@
-package automod
+package util
 
-func dedupeStrings(in []string) []string {
+func DedupeStrings(in []string) []string {
 	var out []string
 	seen := make(map[string]bool)
 	for _, v := range in {

--- a/cmd/hepa/main.go
+++ b/cmd/hepa/main.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
-	"github.com/bluesky-social/indigo/automod"
+	"github.com/bluesky-social/indigo/automod/directory"
 
 	"github.com/carlmjohnson/versioninfo"
 	_ "github.com/joho/godotenv/autoload"
@@ -116,7 +116,7 @@ func configDirectory(cctx *cli.Context) (identity.Directory, error) {
 	}
 	var dir identity.Directory
 	if cctx.String("redis-url") != "" {
-		rdir, err := automod.NewRedisDirectory(&baseDir, cctx.String("redis-url"), time.Hour*24, time.Minute*2)
+		rdir, err := directory.NewRedisDirectory(&baseDir, cctx.String("redis-url"), time.Hour*24, time.Minute*2)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/hepa/server.go
+++ b/cmd/hepa/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/automod"
 	"github.com/bluesky-social/indigo/automod/countstore"
+	"github.com/bluesky-social/indigo/automod/flagstore"
 	"github.com/bluesky-social/indigo/automod/rules"
 	"github.com/bluesky-social/indigo/util"
 	"github.com/bluesky-social/indigo/xrpc"
@@ -89,7 +90,7 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 
 	var counters countstore.CountStore
 	var cache automod.CacheStore
-	var flags automod.FlagStore
+	var flags flagstore.FlagStore
 	var rdb *redis.Client
 	if config.RedisURL != "" {
 		// generic client, for cursor state
@@ -116,7 +117,7 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 		}
 		cache = csh
 
-		flg, err := automod.NewRedisFlagStore(config.RedisURL)
+		flg, err := flagstore.NewRedisFlagStore(config.RedisURL)
 		if err != nil {
 			return nil, fmt.Errorf("initializing redis flagstore: %v", err)
 		}
@@ -124,7 +125,7 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 	} else {
 		counters = countstore.NewMemCountStore()
 		cache = automod.NewMemCacheStore(5_000, 30*time.Minute)
-		flags = automod.NewMemFlagStore()
+		flags = flagstore.NewMemFlagStore()
 	}
 
 	engine := automod.Engine{

--- a/cmd/hepa/server.go
+++ b/cmd/hepa/server.go
@@ -12,6 +12,7 @@ import (
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/automod"
+	"github.com/bluesky-social/indigo/automod/cachestore"
 	"github.com/bluesky-social/indigo/automod/countstore"
 	"github.com/bluesky-social/indigo/automod/flagstore"
 	"github.com/bluesky-social/indigo/automod/rules"
@@ -89,7 +90,7 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 	}
 
 	var counters countstore.CountStore
-	var cache automod.CacheStore
+	var cache cachestore.CacheStore
 	var flags flagstore.FlagStore
 	var rdb *redis.Client
 	if config.RedisURL != "" {
@@ -111,7 +112,7 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 		}
 		counters = cnt
 
-		csh, err := automod.NewRedisCacheStore(config.RedisURL, 30*time.Minute)
+		csh, err := cachestore.NewRedisCacheStore(config.RedisURL, 30*time.Minute)
 		if err != nil {
 			return nil, fmt.Errorf("initializing redis cachestore: %v", err)
 		}
@@ -124,7 +125,7 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 		flags = flg
 	} else {
 		counters = countstore.NewMemCountStore()
-		cache = automod.NewMemCacheStore(5_000, 30*time.Minute)
+		cache = cachestore.NewMemCacheStore(5_000, 30*time.Minute)
 		flags = flagstore.NewMemFlagStore()
 	}
 

--- a/cmd/hepa/server.go
+++ b/cmd/hepa/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bluesky-social/indigo/automod/countstore"
 	"github.com/bluesky-social/indigo/automod/flagstore"
 	"github.com/bluesky-social/indigo/automod/rules"
+	"github.com/bluesky-social/indigo/automod/setstore"
 	"github.com/bluesky-social/indigo/util"
 	"github.com/bluesky-social/indigo/xrpc"
 
@@ -80,7 +81,7 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 		xrpcc.Auth.Handle = auth.Handle
 	}
 
-	sets := automod.NewMemSetStore()
+	sets := setstore.NewMemSetStore()
 	if config.SetsFileJSON != "" {
 		if err := sets.LoadFromFileJSON(config.SetsFileJSON); err != nil {
 			return nil, fmt.Errorf("initializing in-process setstore: %v", err)


### PR DESCRIPTION
Several more package extractions.

These are all the easy ones -- flagstore, cachestore, setstore, directory -- all get yanked out in the same way as countstore already was.

These didn't cause any major changes to package graph overall, it just makes the main automod package smaller (yay).  Near future targets are to try to tug engines and events a bit further apart, and that might be more complicated, so I thought I'd put up the easy-to-review diffs first.