### PR TITLE
lexgen update

### DIFF
--- a/api/atproto/admindefs.go
+++ b/api/atproto/admindefs.go
@@ -105,6 +105,8 @@ type AdminDefs_ModEventComment struct {
 // RECORDTYPE: AdminDefs_ModEventEmail
 type AdminDefs_ModEventEmail struct {
 	LexiconTypeID string `json:"$type,const=com.atproto.admin.defs#modEventEmail" cborgen:"$type,const=com.atproto.admin.defs#modEventEmail"`
+	// comment: Additional comment about the outgoing comm.
+	Comment *string `json:"comment,omitempty" cborgen:"comment,omitempty"`
 	// subjectLine: The subject line of the email sent to the user.
 	SubjectLine string `json:"subjectLine" cborgen:"subjectLine"`
 }

--- a/api/atproto/adminsendEmail.go
+++ b/api/atproto/adminsendEmail.go
@@ -12,6 +12,8 @@ import (
 
 // AdminSendEmail_Input is the input argument to a com.atproto.admin.sendEmail call.
 type AdminSendEmail_Input struct {
+	// comment: Additional comment by the sender that won't be used in the email itself but helpful to provide more context for moderators/reviewers
+	Comment      *string `json:"comment,omitempty" cborgen:"comment,omitempty"`
 	Content      string  `json:"content" cborgen:"content"`
 	RecipientDid string  `json:"recipientDid" cborgen:"recipientDid"`
 	SenderDid    string  `json:"senderDid" cborgen:"senderDid"`

--- a/api/atproto/repodescribeRepo.go
+++ b/api/atproto/repodescribeRepo.go
@@ -7,17 +7,16 @@ package atproto
 import (
 	"context"
 
-	//"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // RepoDescribeRepo_Output is the output of a com.atproto.repo.describeRepo call.
 type RepoDescribeRepo_Output struct {
-	Collections []string `json:"collections" cborgen:"collections"`
-	Did         string   `json:"did" cborgen:"did"`
-	//DidDoc          *util.LexiconTypeDecoder `json:"didDoc" cborgen:"didDoc"`
-	Handle          string `json:"handle" cborgen:"handle"`
-	HandleIsCorrect bool   `json:"handleIsCorrect" cborgen:"handleIsCorrect"`
+	Collections     []string    `json:"collections" cborgen:"collections"`
+	Did             string      `json:"did" cborgen:"did"`
+	DidDoc          interface{} `json:"didDoc" cborgen:"didDoc"`
+	Handle          string      `json:"handle" cborgen:"handle"`
+	HandleIsCorrect bool        `json:"handleIsCorrect" cborgen:"handleIsCorrect"`
 }
 
 // RepoDescribeRepo calls the XRPC method "com.atproto.repo.describeRepo".

--- a/api/atproto/servercreateAccount.go
+++ b/api/atproto/servercreateAccount.go
@@ -7,28 +7,27 @@ package atproto
 import (
 	"context"
 
-	//"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // ServerCreateAccount_Input is the input argument to a com.atproto.server.createAccount call.
 type ServerCreateAccount_Input struct {
-	Did        *string `json:"did,omitempty" cborgen:"did,omitempty"`
-	Email      *string `json:"email,omitempty" cborgen:"email,omitempty"`
-	Handle     string  `json:"handle" cborgen:"handle"`
-	InviteCode *string `json:"inviteCode,omitempty" cborgen:"inviteCode,omitempty"`
-	Password   *string `json:"password,omitempty" cborgen:"password,omitempty"`
-	//PlcOp       *util.LexiconTypeDecoder `json:"plcOp,omitempty" cborgen:"plcOp,omitempty"`
-	RecoveryKey *string `json:"recoveryKey,omitempty" cborgen:"recoveryKey,omitempty"`
+	Did         *string      `json:"did,omitempty" cborgen:"did,omitempty"`
+	Email       *string      `json:"email,omitempty" cborgen:"email,omitempty"`
+	Handle      string       `json:"handle" cborgen:"handle"`
+	InviteCode  *string      `json:"inviteCode,omitempty" cborgen:"inviteCode,omitempty"`
+	Password    *string      `json:"password,omitempty" cborgen:"password,omitempty"`
+	PlcOp       *interface{} `json:"plcOp,omitempty" cborgen:"plcOp,omitempty"`
+	RecoveryKey *string      `json:"recoveryKey,omitempty" cborgen:"recoveryKey,omitempty"`
 }
 
 // ServerCreateAccount_Output is the output of a com.atproto.server.createAccount call.
 type ServerCreateAccount_Output struct {
-	AccessJwt string `json:"accessJwt" cborgen:"accessJwt"`
-	Did       string `json:"did" cborgen:"did"`
-	//DidDoc     *util.LexiconTypeDecoder `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
-	Handle     string `json:"handle" cborgen:"handle"`
-	RefreshJwt string `json:"refreshJwt" cborgen:"refreshJwt"`
+	AccessJwt  string       `json:"accessJwt" cborgen:"accessJwt"`
+	Did        string       `json:"did" cborgen:"did"`
+	DidDoc     *interface{} `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
+	Handle     string       `json:"handle" cborgen:"handle"`
+	RefreshJwt string       `json:"refreshJwt" cborgen:"refreshJwt"`
 }
 
 // ServerCreateAccount calls the XRPC method "com.atproto.server.createAccount".

--- a/api/atproto/servercreateSession.go
+++ b/api/atproto/servercreateSession.go
@@ -19,13 +19,13 @@ type ServerCreateSession_Input struct {
 
 // ServerCreateSession_Output is the output of a com.atproto.server.createSession call.
 type ServerCreateSession_Output struct {
-	AccessJwt string `json:"accessJwt" cborgen:"accessJwt"`
-	Did       string `json:"did" cborgen:"did"`
-	//DidDoc         *util.LexiconTypeDecoder `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
-	Email          *string `json:"email,omitempty" cborgen:"email,omitempty"`
-	EmailConfirmed *bool   `json:"emailConfirmed,omitempty" cborgen:"emailConfirmed,omitempty"`
-	Handle         string  `json:"handle" cborgen:"handle"`
-	RefreshJwt     string  `json:"refreshJwt" cborgen:"refreshJwt"`
+	AccessJwt      string       `json:"accessJwt" cborgen:"accessJwt"`
+	Did            string       `json:"did" cborgen:"did"`
+	DidDoc         *interface{} `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
+	Email          *string      `json:"email,omitempty" cborgen:"email,omitempty"`
+	EmailConfirmed *bool        `json:"emailConfirmed,omitempty" cborgen:"emailConfirmed,omitempty"`
+	Handle         string       `json:"handle" cborgen:"handle"`
+	RefreshJwt     string       `json:"refreshJwt" cborgen:"refreshJwt"`
 }
 
 // ServerCreateSession calls the XRPC method "com.atproto.server.createSession".

--- a/api/atproto/servergetSession.go
+++ b/api/atproto/servergetSession.go
@@ -7,17 +7,16 @@ package atproto
 import (
 	"context"
 
-	//"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // ServerGetSession_Output is the output of a com.atproto.server.getSession call.
 type ServerGetSession_Output struct {
-	Did string `json:"did" cborgen:"did"`
-	//DidDoc         *util.LexiconTypeDecoder `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
-	Email          *string `json:"email,omitempty" cborgen:"email,omitempty"`
-	EmailConfirmed *bool   `json:"emailConfirmed,omitempty" cborgen:"emailConfirmed,omitempty"`
-	Handle         string  `json:"handle" cborgen:"handle"`
+	Did            string       `json:"did" cborgen:"did"`
+	DidDoc         *interface{} `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
+	Email          *string      `json:"email,omitempty" cborgen:"email,omitempty"`
+	EmailConfirmed *bool        `json:"emailConfirmed,omitempty" cborgen:"emailConfirmed,omitempty"`
+	Handle         string       `json:"handle" cborgen:"handle"`
 }
 
 // ServerGetSession calls the XRPC method "com.atproto.server.getSession".

--- a/api/atproto/serverrefreshSession.go
+++ b/api/atproto/serverrefreshSession.go
@@ -7,17 +7,16 @@ package atproto
 import (
 	"context"
 
-	//"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // ServerRefreshSession_Output is the output of a com.atproto.server.refreshSession call.
 type ServerRefreshSession_Output struct {
-	AccessJwt string `json:"accessJwt" cborgen:"accessJwt"`
-	Did       string `json:"did" cborgen:"did"`
-	//DidDoc     *util.LexiconTypeDecoder `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
-	Handle     string `json:"handle" cborgen:"handle"`
-	RefreshJwt string `json:"refreshJwt" cborgen:"refreshJwt"`
+	AccessJwt  string       `json:"accessJwt" cborgen:"accessJwt"`
+	Did        string       `json:"did" cborgen:"did"`
+	DidDoc     *interface{} `json:"didDoc,omitempty" cborgen:"didDoc,omitempty"`
+	Handle     string       `json:"handle" cborgen:"handle"`
+	RefreshJwt string       `json:"refreshJwt" cborgen:"refreshJwt"`
 }
 
 // ServerRefreshSession calls the XRPC method "com.atproto.server.refreshSession".

--- a/api/atproto/temptransferAccount.go
+++ b/api/atproto/temptransferAccount.go
@@ -7,15 +7,14 @@ package atproto
 import (
 	"context"
 
-	//"github.com/bluesky-social/indigo/lex/util"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // TempTransferAccount_Input is the input argument to a com.atproto.temp.transferAccount call.
 type TempTransferAccount_Input struct {
-	Did    string `json:"did" cborgen:"did"`
-	Handle string `json:"handle" cborgen:"handle"`
-	//PlcOp  *util.LexiconTypeDecoder `json:"plcOp" cborgen:"plcOp"`
+	Did    string      `json:"did" cborgen:"did"`
+	Handle string      `json:"handle" cborgen:"handle"`
+	PlcOp  interface{} `json:"plcOp" cborgen:"plcOp"`
 }
 
 // TempTransferAccount_Output is the output of a com.atproto.temp.transferAccount call.

--- a/api/bsky/notificationlistNotifications.go
+++ b/api/bsky/notificationlistNotifications.go
@@ -30,6 +30,7 @@ type NotificationListNotifications_Notification struct {
 type NotificationListNotifications_Output struct {
 	Cursor        *string                                       `json:"cursor,omitempty" cborgen:"cursor,omitempty"`
 	Notifications []*NotificationListNotifications_Notification `json:"notifications" cborgen:"notifications"`
+	SeenAt        *string                                       `json:"seenAt,omitempty" cborgen:"seenAt,omitempty"`
 }
 
 // NotificationListNotifications calls the XRPC method "app.bsky.notification.listNotifications".

--- a/cmd/lexgen/main.go
+++ b/cmd/lexgen/main.go
@@ -96,6 +96,10 @@ func main() {
 
 		var schemas []*lex.Schema
 		for _, arg := range paths {
+			if strings.HasSuffix(arg, "com/atproto/temp/importRepo.json") {
+				fmt.Printf("skipping schema: %s\n", arg)
+				continue
+			}
 			s, err := lex.ReadSchema(arg)
 			if err != nil {
 				return fmt.Errorf("failed to read file %q: %w", arg, err)


### PR DESCRIPTION
As a temporary hack, just skip the `com.atproto.temp.importRepo` endpoint which uses Lexicon features that lexgen does not support.

There are a small number of actual lexicon updates, but the main motivation here is to handle *all* of the `didDoc` and `plcOp` fields. That is also a hack for now, but this resolves a number of regressions, eg with refreshSession.