### PR TITLE
hepa: periodically refresh auth session

### DIFF
--- a/cmd/hepa/main.go
+++ b/cmd/hepa/main.go
@@ -192,6 +192,14 @@ var runCmd = &cli.Command{
 			}
 		}()
 
+		if srv.engine.AdminClient != nil {
+			go func() {
+				if err := srv.RunRefreshAdminClient(ctx); err != nil {
+					slog.Error("session refresh failed", "err", err)
+				}
+			}()
+		}
+
 		// the main service loop
 		if err := srv.RunConsumer(ctx); err != nil {
 			return fmt.Errorf("failure consuming and processing firehose: %w", err)


### PR DESCRIPTION
This works around a current issue in prod where actions are failing to persist because the session expires.

The real fix for the underlying issue (IMHO) is to re-implement `xrpc.Client` to handle this in a more elegant and robust way. That is sort-of tracked in https://github.com/bluesky-social/indigo/issues/378

I was initially confused why this was only coming up when taking actions, because the client is used for a number of reads (GET) as well. Those GETs mostly use *admin* auth (a token in the HTTP Authorization header), not login/session auth (which requires refresh), which explains why it mostly works, then fails for actions.