### PR TITLE
lint: use default 'go vet' settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ coverage-html: ## Generate test coverage report and open in browser
 
 .PHONY: lint
 lint: ## Verify code style and run static checks
-	go vet -asmdecl -assign -atomic -bools -buildtag -cgocall -copylocks -httpresponse -loopclosure -lostcancel -nilfunc -printf -shift -stdmethods -structtag -tests -unmarshal -unreachable -unsafeptr -unusedresult ./...
+	go vet ./...
 	test -z $(gofmt -l ./...)
 
 .PHONY: fmt

--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -199,7 +199,7 @@ func (uv *userView) Get(ctx context.Context, k cid.Cid) (blockformat.Block, erro
 		return nil, err
 	}
 	if info.Path == "" {
-		return nil, ipld.ErrNotFound{k}
+		return nil, ipld.ErrNotFound{Cid: k}
 	}
 
 	if uv.prefetch {
@@ -581,7 +581,7 @@ func (ds *DeltaSession) DeleteBlock(ctx context.Context, c cid.Cid) error {
 	}
 
 	if _, ok := ds.blks[c]; !ok {
-		return ipld.ErrNotFound{c}
+		return ipld.ErrNotFound{Cid: c}
 	}
 
 	delete(ds.blks, c)

--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -158,7 +158,7 @@ func (uv *userView) Has(ctx context.Context, k cid.Cid) (bool, error) {
 		Model(blockRef{}).
 		Select("path, block_refs.offset").
 		Joins("left join car_shards on block_refs.shard = car_shards.id").
-		Where("usr = ? AND cid = ?", uv.user, models.DbCID{k}).
+		Where("usr = ? AND cid = ?", uv.user, models.DbCID{CID: k}).
 		Count(&count).Error; err != nil {
 		return false, err
 	}
@@ -194,7 +194,7 @@ func (uv *userView) Get(ctx context.Context, k cid.Cid) (blockformat.Block, erro
 		Model(blockRef{}).
 		Select("path, block_refs.offset").
 		Joins("left join car_shards on block_refs.shard = car_shards.id").
-		Where("usr = ? AND cid = ?", uv.user, models.DbCID{k}).
+		Where("usr = ? AND cid = ?", uv.user, models.DbCID{CID: k}).
 		Find(&info).Error; err != nil {
 		return nil, err
 	}
@@ -712,7 +712,7 @@ func (cs *CarStore) writeNewShard(ctx context.Context, root cid.Cid, rev string,
 		// adding things to the db by map is the only way to get gorm to not
 		// add the 'returning' clause, which costs a lot of time
 		brefs = append(brefs, map[string]interface{}{
-			"cid":    models.DbCID{k},
+			"cid":    models.DbCID{CID: k},
 			"offset": offset,
 		})
 
@@ -725,7 +725,7 @@ func (cs *CarStore) writeNewShard(ctx context.Context, root cid.Cid, rev string,
 	}
 
 	shard := CarShard{
-		Root:      models.DbCID{root},
+		Root:      models.DbCID{CID: root},
 		DataStart: hnw,
 		Seq:       seq,
 		Path:      path,
@@ -1582,7 +1582,7 @@ func (cs *CarStore) compactBucket(ctx context.Context, user models.Uid, b *compB
 				}
 
 				nbrefs = append(nbrefs, map[string]interface{}{
-					"cid":    models.DbCID{blk.Cid()},
+					"cid":    models.DbCID{CID: blk.Cid()},
 					"offset": offset,
 				})
 
@@ -1596,7 +1596,7 @@ func (cs *CarStore) compactBucket(ctx context.Context, user models.Uid, b *compB
 	}
 
 	shard := CarShard{
-		Root:      models.DbCID{root},
+		Root:      models.DbCID{CID: root},
 		DataStart: hnw,
 		Seq:       lastsh.Seq,
 		Path:      path,

--- a/cmd/bigsky/main.go
+++ b/cmd/bigsky/main.go
@@ -313,7 +313,7 @@ func Bigsky(cctx *cli.Context) error {
 
 	var blobstore blobs.BlobStore
 	if bsdir := cctx.String("disk-blob-store"); bsdir != "" {
-		blobstore = &blobs.DiskBlobStore{bsdir}
+		blobstore = &blobs.DiskBlobStore{Dir: bsdir}
 	}
 
 	prodHR, err := api.NewProdHandleResolver(100_000)

--- a/cmd/gosky/bsky.go
+++ b/cmd/gosky/bsky.go
@@ -53,7 +53,7 @@ var bskyFollowCmd = &cli.Command{
 		resp, err := comatproto.RepoCreateRecord(context.TODO(), xrpcc, &comatproto.RepoCreateRecord_Input{
 			Collection: "app.bsky.graph.follow",
 			Repo:       xrpcc.Auth.Did,
-			Record:     &lexutil.LexiconTypeDecoder{&follow},
+			Record:     &lexutil.LexiconTypeDecoder{Val: &follow},
 		})
 		if err != nil {
 			return err
@@ -111,7 +111,7 @@ var bskyPostCmd = &cli.Command{
 		resp, err := comatproto.RepoCreateRecord(context.TODO(), xrpcc, &comatproto.RepoCreateRecord_Input{
 			Collection: "app.bsky.feed.post",
 			Repo:       auth.Did,
-			Record: &lexutil.LexiconTypeDecoder{&appbsky.FeedPost{
+			Record: &lexutil.LexiconTypeDecoder{Val: &appbsky.FeedPost{
 				Text:      text,
 				CreatedAt: time.Now().Format(util.ISO8601),
 			}},

--- a/cmd/gosky/main.go
+++ b/cmd/gosky/main.go
@@ -120,7 +120,7 @@ func cborToJson(data []byte) ([]byte, error) {
 	enc := rejson.NewEncoder(buf, rejson.EncodeOptions{})
 
 	dec := cbor.NewDecoder(cbor.DecodeOptions{}, bytes.NewReader(data))
-	err := shared.TokenPump{dec, enc}.Run()
+	err := shared.TokenPump{TokenSource: dec, TokenSink: enc}.Run()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gosky/main.go
+++ b/cmd/gosky/main.go
@@ -544,7 +544,7 @@ var createFeedGeneratorCmd = &cli.Command{
 
 		ctx := context.TODO()
 
-		rec := &lexutil.LexiconTypeDecoder{&bsky.FeedGenerator{
+		rec := &lexutil.LexiconTypeDecoder{Val: &bsky.FeedGenerator{
 			CreatedAt:   time.Now().Format(util.ISO8601),
 			Description: desc,
 			Did:         did,

--- a/cmd/stress/main.go
+++ b/cmd/stress/main.go
@@ -135,7 +135,7 @@ var postingCmd = &cli.Command{
 					res, err := comatproto.RepoCreateRecord(context.TODO(), xrpcc, &comatproto.RepoCreateRecord_Input{
 						Collection: "app.bsky.feed.post",
 						Repo:       xrpcc.Auth.Did,
-						Record: &lexutil.LexiconTypeDecoder{&appbsky.FeedPost{
+						Record: &lexutil.LexiconTypeDecoder{Val: &appbsky.FeedPost{
 							Text:      hex.EncodeToString(buf),
 							CreatedAt: time.Now().Format(time.RFC3339),
 						}},

--- a/events/dbpersist.go
+++ b/events/dbpersist.go
@@ -278,7 +278,7 @@ func (p *DbPersistence) RecordFromRepoCommit(ctx context.Context, evt *comatprot
 
 	var prev *models.DbCID
 	if evt.Prev != nil && evt.Prev.Defined() {
-		prev = &models.DbCID{cid.Cid(*evt.Prev)}
+		prev = &models.DbCID{CID: cid.Cid(*evt.Prev)}
 	}
 
 	var blobs []byte
@@ -296,7 +296,7 @@ func (p *DbPersistence) RecordFromRepoCommit(ctx context.Context, evt *comatprot
 	}
 
 	rer := RepoEventRecord{
-		Commit: &models.DbCID{cid.Cid(evt.Commit)},
+		Commit: &models.DbCID{CID: cid.Cid(evt.Commit)},
 		Prev:   prev,
 		Repo:   uid,
 		Type:   "repo_append", // TODO: refactor to "#commit"? can "rebase" come through this path?

--- a/fakedata/generators.go
+++ b/fakedata/generators.go
@@ -115,7 +115,7 @@ func GenProfile(xrpcc *xrpc.Client, acc *AccountContext, genAvatar, genBanner bo
 		Repo:       acc.Auth.Did,
 		Collection: "app.bsky.actor.profile",
 		Rkey:       "self",
-		Record: &lexutil.LexiconTypeDecoder{&appbsky.ActorProfile{
+		Record: &lexutil.LexiconTypeDecoder{Val: &appbsky.ActorProfile{
 			Description: &desc,
 			DisplayName: &name,
 			Avatar:      avatar,
@@ -201,7 +201,7 @@ func GenPosts(xrpcc *xrpc.Client, catalog *AccountCatalog, acc *AccountContext, 
 		if _, err := comatproto.RepoCreateRecord(ctx, xrpcc, &comatproto.RepoCreateRecord_Input{
 			Collection: "app.bsky.feed.post",
 			Repo:       acc.Auth.Did,
-			Record:     &lexutil.LexiconTypeDecoder{&post},
+			Record:     &lexutil.LexiconTypeDecoder{Val: &post},
 		}); err != nil {
 			return err
 		}
@@ -218,7 +218,7 @@ func CreateFollow(xrpcc *xrpc.Client, tgt *AccountContext) error {
 	_, err := comatproto.RepoCreateRecord(context.TODO(), xrpcc, &comatproto.RepoCreateRecord_Input{
 		Collection: "app.bsky.graph.follow",
 		Repo:       xrpcc.Auth.Did,
-		Record:     &lexutil.LexiconTypeDecoder{follow},
+		Record:     &lexutil.LexiconTypeDecoder{Val: follow},
 	})
 	return err
 }
@@ -236,7 +236,7 @@ func CreateLike(xrpcc *xrpc.Client, viewPost *appbsky.FeedDefs_FeedViewPost) err
 	_, err := comatproto.RepoCreateRecord(ctx, xrpcc, &comatproto.RepoCreateRecord_Input{
 		Collection: "app.bsky.feed.like",
 		Repo:       xrpcc.Auth.Did,
-		Record:     &lexutil.LexiconTypeDecoder{&like},
+		Record:     &lexutil.LexiconTypeDecoder{Val: &like},
 	})
 	return err
 }
@@ -252,7 +252,7 @@ func CreateRepost(xrpcc *xrpc.Client, viewPost *appbsky.FeedDefs_FeedViewPost) e
 	_, err := comatproto.RepoCreateRecord(context.TODO(), xrpcc, &comatproto.RepoCreateRecord_Input{
 		Collection: "app.bsky.feed.repost",
 		Repo:       xrpcc.Auth.Did,
-		Record:     &lexutil.LexiconTypeDecoder{repost},
+		Record:     &lexutil.LexiconTypeDecoder{Val: repost},
 	})
 	return err
 }
@@ -284,7 +284,7 @@ func CreateReply(xrpcc *xrpc.Client, viewPost *appbsky.FeedDefs_FeedViewPost) er
 	_, err := comatproto.RepoCreateRecord(context.TODO(), xrpcc, &comatproto.RepoCreateRecord_Input{
 		Collection: "app.bsky.feed.post",
 		Repo:       xrpcc.Auth.Did,
-		Record:     &lexutil.LexiconTypeDecoder{replyPost},
+		Record:     &lexutil.LexiconTypeDecoder{Val: replyPost},
 	})
 	return err
 }

--- a/labeler/admin.go
+++ b/labeler/admin.go
@@ -34,7 +34,7 @@ func (s *Server) hydrateRecordView(ctx context.Context, did string, uri, cid *st
 		Moderation: nil,
 		Repo:       repoView,
 		// TODO: replace with actual record (from proxied backend)
-		Value: &lexutil.LexiconTypeDecoder{&appbsky.FeedPost{}},
+		Value: &lexutil.LexiconTypeDecoder{Val: &appbsky.FeedPost{}},
 	}
 	if uri != nil {
 		recordView.Uri = *uri

--- a/lex/util/lex_interop_old_test.go
+++ b/lex/util/lex_interop_old_test.go
@@ -91,7 +91,7 @@ func TestInteropBasicOldSchema(t *testing.T) {
 	assert.NoError(goObj.MarshalCBOR(goCborBytes))
 	assert.Equal(cborBytes, goCborBytes.Bytes())
 	// 0x71 = dag-cbor, 0x12 = sha2-256, 0 = default length
-	cidBuilder := cid.V1Builder{0x71, 0x12, 0}
+	cidBuilder := cid.V1Builder{Codec: 0x71, MhType: 0x12, MhLength: 0}
 	goCborCid, err := cidBuilder.Sum(goCborBytes.Bytes())
 	assert.NoError(err)
 	assert.Equal(cidStr, goCborCid.String())
@@ -156,7 +156,7 @@ func TestInteropIpldOldSchema(t *testing.T) {
 	assert.NoError(goObj.MarshalCBOR(goCborBytes))
 	assert.Equal(cborBytes, goCborBytes.Bytes())
 	// 0x71 = dag-cbor, 0x12 = sha2-256, 0 = default length
-	cidBuilder := cid.V1Builder{0x71, 0x12, 0}
+	cidBuilder := cid.V1Builder{Codec: 0x71, MhType: 0x12, MhLength: 0}
 	goCborCid, err := cidBuilder.Sum(goCborBytes.Bytes())
 	assert.NoError(err)
 	assert.Equal(cidStr, goCborCid.String())

--- a/lex/util/lex_interop_test.go
+++ b/lex/util/lex_interop_test.go
@@ -122,7 +122,7 @@ func TestInteropBasicSchema(t *testing.T) {
 	assert.NoError(goObj.MarshalCBOR(goCborBytes))
 	assert.Equal(cborBytes, goCborBytes.Bytes())
 	// 0x71 = dag-cbor, 0x12 = sha2-256, 0 = default length
-	cidBuilder := cid.V1Builder{0x71, 0x12, 0}
+	cidBuilder := cid.V1Builder{Codec: 0x71, MhType: 0x12, MhLength: 0}
 	goCborCid, err := cidBuilder.Sum(goCborBytes.Bytes())
 	assert.NoError(err)
 	assert.Equal(cidStr, goCborCid.String())
@@ -208,7 +208,7 @@ func TestInteropIpldSchema(t *testing.T) {
 	assert.NoError(goObj.MarshalCBOR(goCborBytes))
 	assert.Equal(cborBytes, goCborBytes.Bytes())
 	// 0x71 = dag-cbor, 0x12 = sha2-256, 0 = default length
-	cidBuilder := cid.V1Builder{0x71, 0x12, 0}
+	cidBuilder := cid.V1Builder{Codec: 0x71, MhType: 0x12, MhLength: 0}
 	goCborCid, err := cidBuilder.Sum(goCborBytes.Bytes())
 	assert.NoError(err)
 	assert.Equal(cidStr, goCborCid.String())
@@ -314,7 +314,7 @@ func TestInteropIpldNestedSchema(t *testing.T) {
 		assert.NoError(goObj.MarshalCBOR(goCborBytes))
 		assert.Equal(cborBytes, goCborBytes.Bytes())
 		// 0x71 = dag-cbor, 0x12 = sha2-256, 0 = default length
-		cidBuilder := cid.V1Builder{ 0x71, 0x12, 0 }
+		cidBuilder := cid.V1Builder{Codec: 0x71, MhType: 0x12, MhLength: 0}
 		goCborCid, err := cidBuilder.Sum(goCborBytes.Bytes())
 		assert.NoError(err)
 		assert.Equal(cidStr, goCborCid.String())

--- a/notifs/notifs.go
+++ b/notifs/notifs.go
@@ -214,7 +214,7 @@ func (nm *DBNotifMan) hydrateNotificationRepost(ctx context.Context, nrec *Notif
 	rsub := "at://" + postAuthor.Did + "/app.bsky.feed.post/" + reposted.Rkey
 
 	return &appbskytypes.NotificationListNotifications_Notification{
-		Record:        &lexutil.LexiconTypeDecoder{rec},
+		Record:        &lexutil.LexiconTypeDecoder{Val: rec},
 		IsRead:        nrec.CreatedAt.Before(lastSeen),
 		IndexedAt:     nrec.CreatedAt.Format(time.RFC3339),
 		Uri:           "at://" + reposter.Did + "/app.bsky.feed.repost/" + repost.Rkey,
@@ -254,7 +254,7 @@ func (nm *DBNotifMan) hydrateNotificationReply(ctx context.Context, nrec *NotifR
 	rsub := "at://" + opAuthor.Did + "/app.bsky.feed.post/" + replyTo.Rkey
 
 	return &appbskytypes.NotificationListNotifications_Notification{
-		Record:        &lexutil.LexiconTypeDecoder{rec},
+		Record:        &lexutil.LexiconTypeDecoder{Val: rec},
 		IsRead:        nrec.CreatedAt.Before(lastSeen),
 		IndexedAt:     nrec.CreatedAt.Format(time.RFC3339),
 		Uri:           "at://" + author.Did + "/app.bsky.feed.post/" + fp.Rkey,
@@ -282,7 +282,7 @@ func (nm *DBNotifMan) hydrateNotificationFollow(ctx context.Context, nrec *Notif
 	}
 
 	return &appbskytypes.NotificationListNotifications_Notification{
-		Record:    &lexutil.LexiconTypeDecoder{rec},
+		Record:    &lexutil.LexiconTypeDecoder{Val: rec},
 		IsRead:    nrec.CreatedAt.Before(lastSeen),
 		IndexedAt: nrec.CreatedAt.Format(time.RFC3339),
 		Uri:       "at://" + follower.Did + "/app.bsky.graph.follow/" + frec.Rkey,

--- a/pds/feedgen.go
+++ b/pds/feedgen.go
@@ -148,7 +148,7 @@ func (fg *FeedGenerator) hydrateItem(ctx context.Context, item *models.FeedPost)
 		return nil, err
 	}
 
-	out.Post.Record = &lexutil.LexiconTypeDecoder{rec}
+	out.Post.Record = &lexutil.LexiconTypeDecoder{Val: rec}
 
 	return out, nil
 }

--- a/pds/handlers.go
+++ b/pds/handlers.go
@@ -467,7 +467,7 @@ func (s *Server) handleComAtprotoRepoGetRecord(ctx context.Context, c string, co
 	return &comatprototypes.RepoGetRecord_Output{
 		Cid:   &ccstr,
 		Uri:   "at://" + targetUser.Did + "/" + collection + "/" + rkey,
-		Value: &lexutil.LexiconTypeDecoder{rec},
+		Value: &lexutil.LexiconTypeDecoder{Val: rec},
 	}, nil
 }
 

--- a/testing/car_did_repro_test.go
+++ b/testing/car_did_repro_test.go
@@ -106,7 +106,7 @@ func mustReadDidDoc(t *testing.T, docPath string) did.Document {
 func reproduceRecord(t *testing.T, path string, c cid.Cid, rec cbg.CBORMarshaler) {
 	assert := assert.New(t)
 	// 0x71 = dag-cbor, 0x12 = sha2-256, 0 = default length
-	cidBuilder := cid.V1Builder{0x71, 0x12, 0}
+	cidBuilder := cid.V1Builder{Codec: 0x71, MhType: 0x12, MhLength: 0}
 	recordCBOR := new(bytes.Buffer)
 	nsid := strings.SplitN(path, "/", 2)[0]
 

--- a/testing/feedpost_test.go
+++ b/testing/feedpost_test.go
@@ -150,7 +150,7 @@ func TestPostToJson(t *testing.T) {
 // checks a corner-case with $type: "app.bsky.richtext.facet#link"
 func TestFeedPostRichtextLink(t *testing.T) {
 	assert := assert.New(t)
-	cidBuilder := cid.V1Builder{0x71, 0x12, 0}
+	cidBuilder := cid.V1Builder{Codec: 0x71, MhType: 0x12, MhLength: 0}
 
 	// this is a app.bsky.feed.post with richtext link
 	inFile, err := os.Open("testdata/post_richtext_link.cbor")

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -231,7 +231,7 @@ func (u *TestUser) Reply(t *testing.T, replyto, root *atproto.RepoStrongRef, bod
 	resp, err := atproto.RepoCreateRecord(ctx, u.client, &atproto.RepoCreateRecord_Input{
 		Collection: "app.bsky.feed.post",
 		Repo:       u.did,
-		Record: &lexutil.LexiconTypeDecoder{&bsky.FeedPost{
+		Record: &lexutil.LexiconTypeDecoder{Val: &bsky.FeedPost{
 			CreatedAt: time.Now().Format(time.RFC3339),
 			Text:      body,
 			Reply: &bsky.FeedPost_ReplyRef{
@@ -258,7 +258,7 @@ func (u *TestUser) Post(t *testing.T, body string) *atproto.RepoStrongRef {
 	resp, err := atproto.RepoCreateRecord(ctx, u.client, &atproto.RepoCreateRecord_Input{
 		Collection: "app.bsky.feed.post",
 		Repo:       u.did,
-		Record: &lexutil.LexiconTypeDecoder{&bsky.FeedPost{
+		Record: &lexutil.LexiconTypeDecoder{Val: &bsky.FeedPost{
 			CreatedAt: time.Now().Format(time.RFC3339),
 			Text:      body,
 		}},
@@ -281,7 +281,7 @@ func (u *TestUser) Like(t *testing.T, post *atproto.RepoStrongRef) {
 	_, err := atproto.RepoCreateRecord(ctx, u.client, &atproto.RepoCreateRecord_Input{
 		Collection: "app.bsky.feed.vote",
 		Repo:       u.did,
-		Record: &lexutil.LexiconTypeDecoder{&bsky.FeedLike{
+		Record: &lexutil.LexiconTypeDecoder{Val: &bsky.FeedLike{
 			LexiconTypeID: "app.bsky.feed.vote",
 			CreatedAt:     time.Now().Format(time.RFC3339),
 			Subject:       post,
@@ -300,7 +300,7 @@ func (u *TestUser) Follow(t *testing.T, did string) string {
 	resp, err := atproto.RepoCreateRecord(ctx, u.client, &atproto.RepoCreateRecord_Input{
 		Collection: "app.bsky.graph.follow",
 		Repo:       u.did,
-		Record: &lexutil.LexiconTypeDecoder{&bsky.GraphFollow{
+		Record: &lexutil.LexiconTypeDecoder{Val: &bsky.GraphFollow{
 			CreatedAt: time.Now().Format(time.RFC3339),
 			Subject:   did,
 		}},


### PR DESCRIPTION
Pretty straight-forward, we do this in other repos. Run *all* `go vet` rules, not just a fixed list (the default is all rules).