### PR TITLE
automod visual auto-labeling, and abusive image scanning

### DIFF
--- a/automod/engine/blobs.go
+++ b/automod/engine/blobs.go
@@ -1,0 +1,115 @@
+package engine
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	appbsky "github.com/bluesky-social/indigo/api/bsky"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
+)
+
+// Parses out any blobs from the enclosed record.
+//
+// TODO: currently this function uses schema-specific logic, and won't work with generic lexicon records. A future version could use the indigo/atproto/data package and the raw record CBOR to extract blobs from arbitrary records
+//
+// NOTE: for consistency with other RecordContext methods, which don't usually return errors, maybe the error-returning version of this function should be a helper function, or definted on RecordOp, and the RecordContext version should return an empty array on error?
+func (c *RecordContext) Blobs() ([]lexutil.LexBlob, error) {
+
+	if c.RecordOp.Action != CreateOp {
+		// TODO: should this really error, or return empty array?
+		return nil, fmt.Errorf("expected record creation, got: %s", c.RecordOp.Action)
+	}
+
+	var blobs []lexutil.LexBlob
+
+	switch c.RecordOp.Collection.String() {
+	case "app.bsky.feed.post":
+		post, ok := c.RecordOp.Value.(*appbsky.FeedPost)
+		if !ok {
+			return nil, fmt.Errorf("mismatch between collection (%s) and type", c.RecordOp.Collection)
+		}
+		if post.Embed != nil && post.Embed.EmbedImages != nil {
+			for _, eii := range post.Embed.EmbedImages.Images {
+				if eii.Image != nil {
+					blobs = append(blobs, *eii.Image)
+				}
+			}
+		}
+		if post.Embed != nil && post.Embed.EmbedExternal != nil {
+			ext := post.Embed.EmbedExternal.External
+			if ext != nil && ext.Thumb != nil {
+				blobs = append(blobs, *ext.Thumb)
+			}
+		}
+		if post.Embed != nil && post.Embed.EmbedRecordWithMedia != nil {
+			media := post.Embed.EmbedRecordWithMedia.Media
+			if media != nil && media.EmbedImages != nil {
+				for _, eii := range media.EmbedImages.Images {
+					if eii.Image != nil {
+						blobs = append(blobs, *eii.Image)
+					}
+				}
+			}
+			if media != nil && media.EmbedExternal != nil {
+				ext := media.EmbedExternal.External
+				if ext != nil && ext.Thumb != nil {
+					blobs = append(blobs, *ext.Thumb)
+				}
+			}
+		}
+	case "app.bsky.actor.profile":
+		profile, ok := c.RecordOp.Value.(*appbsky.ActorProfile)
+		if !ok {
+			return nil, fmt.Errorf("mismatch between collection (%s) and type", c.RecordOp.Collection)
+		}
+		if profile.Avatar != nil {
+			blobs = append(blobs, *profile.Avatar)
+		}
+		if profile.Banner != nil {
+			blobs = append(blobs, *profile.Banner)
+		}
+	case "app.bsky.graph.list":
+		list, ok := c.RecordOp.Value.(*appbsky.GraphList)
+		if !ok {
+			return nil, fmt.Errorf("mismatch between collection (%s) and type", c.RecordOp.Collection)
+		}
+		if list.Avatar != nil {
+			blobs = append(blobs, *list.Avatar)
+		}
+	case "app.bsky.feed.generator":
+		generator, ok := c.RecordOp.Value.(*appbsky.FeedGenerator)
+		if !ok {
+			return nil, fmt.Errorf("mismatch between collection (%s) and type", c.RecordOp.Collection)
+		}
+		if generator.Avatar != nil {
+			blobs = append(blobs, *generator.Avatar)
+		}
+	}
+	return blobs, nil
+}
+
+func fetchBlob(c *RecordContext, blob lexutil.LexBlob) ([]byte, error) {
+
+	var blobBytes []byte
+
+	// TODO: more robust way to write this?
+	xrpcURL := fmt.Sprintf("%s/xrpc/com.atproto.sync.getBlob?did=%s&cid=%s", c.Account.Identity.PDSEndpoint(), c.Account.Identity.DID, blob.Ref)
+
+	resp, err := http.Get(xrpcURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to fetch blob from PDS. did=%s cid=%s statusCode=%d", c.Account.Identity.DID, blob.Ref, resp.StatusCode)
+	}
+
+	blobBytes, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return blobBytes, nil
+}

--- a/automod/engine/context.go
+++ b/automod/engine/context.go
@@ -182,3 +182,7 @@ func (c *RecordContext) ReportRecord(reason, comment string) {
 func (c *RecordContext) TakedownRecord() {
 	c.effects.TakedownRecord()
 }
+
+func (c *RecordContext) TakedownBlob(cid string) {
+	c.effects.TakedownBlob(cid)
+}

--- a/automod/engine/effects.go
+++ b/automod/engine/effects.go
@@ -49,6 +49,8 @@ type Effects struct {
 	RecordReports []ModReport
 	// Same as "AccountTakedown", but at record-level
 	RecordTakedown bool
+	// Set of Blob CIDs to takedown (eg, purge from CDN) when doing a record takedown
+	BlobTakedowns []string
 }
 
 // Enqueues the named counter to be incremented at the end of all rule processing. Will automatically increment for all time periods.
@@ -116,4 +118,9 @@ func (e *Effects) ReportRecord(reason, comment string) {
 // Enqueues the record to be taken down at the end of rule processing.
 func (e *Effects) TakedownRecord() {
 	e.RecordTakedown = true
+}
+
+// Enqueues the blob CID to be taken down (aka, CDN purge) as part of any record takedown
+func (e *Effects) TakedownBlob(cid string) {
+	e.BlobTakedowns = append(e.BlobTakedowns, cid)
 }

--- a/automod/engine/persist.go
+++ b/automod/engine/persist.go
@@ -61,7 +61,7 @@ func (eng *Engine) persistAccountModActions(c *AccountContext) error {
 	if anyModActions && eng.SlackWebhookURL != "" {
 		msg := slackBody("⚠️ Automod Account Action ⚠️\n", c.Account, newLabels, newFlags, newReports, newTakedown)
 		if err := eng.SendSlackMsg(ctx, msg); err != nil {
-			eng.Logger.Error("sending slack webhook", "err", err)
+			c.Logger.Error("sending slack webhook", "err", err)
 		}
 	}
 
@@ -78,7 +78,7 @@ func (eng *Engine) persistAccountModActions(c *AccountContext) error {
 	xrpcc := eng.AdminClient
 
 	if len(newLabels) > 0 {
-		eng.Logger.Info("labeling record", "newLabels", newLabels)
+		c.Logger.Info("labeling record", "newLabels", newLabels)
 		comment := "automod"
 		_, err := comatproto.AdminEmitModerationEvent(ctx, xrpcc, &comatproto.AdminEmitModerationEvent_Input{
 			CreatedBy: xrpcc.Auth.Did,
@@ -113,7 +113,7 @@ func (eng *Engine) persistAccountModActions(c *AccountContext) error {
 	}
 
 	if newTakedown {
-		eng.Logger.Warn("account-takedown")
+		c.Logger.Warn("account-takedown")
 		comment := "automod"
 		_, err := comatproto.AdminEmitModerationEvent(ctx, xrpcc, &comatproto.AdminEmitModerationEvent_Input{
 			CreatedBy: xrpcc.Auth.Did,
@@ -168,7 +168,7 @@ func (eng *Engine) persistRecordModActions(c *RecordContext) error {
 			msg := slackBody("⚠️ Automod Record Action ⚠️\n", c.Account, newLabels, newFlags, newReports, newTakedown)
 			msg += fmt.Sprintf("`%s`\n", atURI)
 			if err := eng.SendSlackMsg(ctx, msg); err != nil {
-				eng.Logger.Error("sending slack webhook", "err", err)
+				c.Logger.Error("sending slack webhook", "err", err)
 			}
 		}
 	}
@@ -188,7 +188,7 @@ func (eng *Engine) persistRecordModActions(c *RecordContext) error {
 	}
 
 	if c.RecordOp.CID == nil {
-		eng.Logger.Warn("skipping record actions because CID is nil, can't construct strong ref")
+		c.Logger.Warn("skipping record actions because CID is nil, can't construct strong ref")
 		return nil
 	}
 	cid := *c.RecordOp.CID
@@ -199,7 +199,7 @@ func (eng *Engine) persistRecordModActions(c *RecordContext) error {
 
 	xrpcc := eng.AdminClient
 	if len(newLabels) > 0 {
-		eng.Logger.Info("labeling record", "newLabels", newLabels)
+		c.Logger.Info("labeling record", "newLabels", newLabels)
 		comment := "automod"
 		_, err := comatproto.AdminEmitModerationEvent(ctx, xrpcc, &comatproto.AdminEmitModerationEvent_Input{
 			CreatedBy: xrpcc.Auth.Did,
@@ -220,7 +220,7 @@ func (eng *Engine) persistRecordModActions(c *RecordContext) error {
 	}
 
 	for _, mr := range newReports {
-		eng.Logger.Info("reporting record", "reasonType", mr.ReasonType, "comment", mr.Comment)
+		c.Logger.Info("reporting record", "reasonType", mr.ReasonType, "comment", mr.Comment)
 		_, err := comatproto.ModerationCreateReport(ctx, xrpcc, &comatproto.ModerationCreateReport_Input{
 			ReasonType: &mr.ReasonType,
 			Reason:     &mr.Comment,
@@ -233,7 +233,7 @@ func (eng *Engine) persistRecordModActions(c *RecordContext) error {
 		}
 	}
 	if newTakedown {
-		eng.Logger.Warn("record-takedown")
+		c.Logger.Warn("record-takedown")
 		comment := "automod"
 		_, err := comatproto.AdminEmitModerationEvent(ctx, xrpcc, &comatproto.AdminEmitModerationEvent_Input{
 			CreatedBy: xrpcc.Auth.Did,

--- a/automod/engine/persist.go
+++ b/automod/engine/persist.go
@@ -245,6 +245,7 @@ func (eng *Engine) persistRecordModActions(c *RecordContext) error {
 			Subject: &comatproto.AdminEmitModerationEvent_Input_Subject{
 				RepoStrongRef: &strongRef,
 			},
+			SubjectBlobCids: dedupeStrings(c.effects.BlobTakedowns),
 		})
 		if err != nil {
 			return err

--- a/automod/engine/ruleset.go
+++ b/automod/engine/ruleset.go
@@ -12,6 +12,7 @@ type RuleSet struct {
 	RecordRules       []RecordRuleFunc
 	RecordDeleteRules []RecordRuleFunc
 	IdentityRules     []IdentityRuleFunc
+	BlobRules         []BlobRuleFunc
 }
 
 func (r *RuleSet) CallRecordRules(c *RecordContext) error {
@@ -42,6 +43,31 @@ func (r *RuleSet) CallRecordRules(c *RecordContext) error {
 		}
 		for _, f := range r.ProfileRules {
 			err := f(c, profile)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	// then blob rules, if any
+	if len(r.BlobRules) == 0 || c.RecordOp.Action != CreateOp {
+		return nil
+	}
+	blobs, err := c.Blobs()
+	if err != nil {
+		// TODO: should this really return error, or just log?
+		return err
+	}
+	if len(blobs) == 0 {
+		return nil
+	}
+	// TODO: concurrency
+	for _, blob := range blobs {
+		data, err := fetchBlob(c, blob)
+		if err != nil {
+			return err
+		}
+		for _, f := range r.BlobRules {
+			err := f(c, blob, data)
 			if err != nil {
 				return err
 			}

--- a/automod/engine/ruletypes.go
+++ b/automod/engine/ruletypes.go
@@ -2,9 +2,11 @@ package engine
 
 import (
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 )
 
 type IdentityRuleFunc = func(c *AccountContext) error
 type RecordRuleFunc = func(c *RecordContext) error
 type PostRuleFunc = func(c *RecordContext, post *appbsky.FeedPost) error
 type ProfileRuleFunc = func(c *RecordContext, profile *appbsky.ActorProfile) error
+type BlobRuleFunc = func(c *RecordContext, blob lexutil.LexBlob, data []byte) error

--- a/automod/pkg.go
+++ b/automod/pkg.go
@@ -17,6 +17,7 @@ type IdentityRuleFunc = engine.IdentityRuleFunc
 type RecordRuleFunc = engine.RecordRuleFunc
 type PostRuleFunc = engine.PostRuleFunc
 type ProfileRuleFunc = engine.ProfileRuleFunc
+type BlobRuleFunc = engine.BlobRuleFunc
 
 var (
 	ReportReasonSpam       = engine.ReportReasonSpam

--- a/automod/rules/all.go
+++ b/automod/rules/all.go
@@ -35,6 +35,9 @@ func DefaultRules() automod.RuleSet {
 		IdentityRules: []automod.IdentityRuleFunc{
 			NewAccountRule,
 		},
+		BlobRules: []automod.BlobRuleFunc{
+			//BlobVerifyRule,
+		},
 	}
 	return rules
 }

--- a/automod/rules/blobs.go
+++ b/automod/rules/blobs.go
@@ -1,0 +1,24 @@
+package rules
+
+import (
+	"github.com/bluesky-social/indigo/automod"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
+)
+
+var _ automod.BlobRuleFunc = BlobVerifyRule
+
+func BlobVerifyRule(c *automod.RecordContext, blob lexutil.LexBlob, data []byte) error {
+
+	if len(data) == 0 {
+		c.AddRecordFlag("empty-blob")
+	}
+
+	// check size
+	if blob.Size >= 0 && int64(len(data)) != blob.Size {
+		c.AddRecordFlag("invalid-blob")
+	} else {
+		c.Logger.Info("blob checks out", "cid", blob.Ref, "size", blob.Size, "mimetype", blob.MimeType)
+	}
+
+	return nil
+}

--- a/automod/visual/abyss_api.go
+++ b/automod/visual/abyss_api.go
@@ -1,0 +1,42 @@
+package visual
+
+import (
+	lexutil "github.com/bluesky-social/indigo/lex/util"
+)
+
+type AbyssScanResp struct {
+	Blob     *lexutil.LexBlob     `json:"blob"`
+	Match    *AbyssMatchResult    `json:"match,omitempty"`
+	Classify *AbyssClassifyResult `json:"classify,omitempty"`
+	Review   *AbyssReviewState    `json:"review,omitempty"`
+}
+
+type AbyssMatchResult struct {
+	Status string          `json:"status"`
+	Hits   []AbyssMatchHit `json:"hits"`
+}
+
+type AbyssMatchHit struct {
+	HashType  string `json:"hashType,omitempty"`
+	HashValue string `json:"hashValue,omitempty"`
+	Label     string `json:"label,omitempty"`
+	// TODO: Corpus
+}
+
+type AbyssClassifyResult struct {
+	// TODO
+}
+
+type AbyssReviewState struct {
+	State    string `json:"state,omitempty"`
+	TicketID string `json:"ticketId,omitempty"`
+}
+
+func (amr *AbyssMatchResult) IsAbuseMatch() bool {
+	for _, hit := range amr.Hits {
+		if hit.Label == "csam" || hit.Label == "csem" {
+			return true
+		}
+	}
+	return false
+}

--- a/automod/visual/abyss_client.go
+++ b/automod/visual/abyss_client.go
@@ -47,7 +47,7 @@ func (ac *AbyssClient) ScanBlob(ctx context.Context, blob lexutil.LexBlob, blobB
 
 	req.SetBasicAuth("admin", ac.Password)
 	req.Header.Add("Content-Type", blob.MimeType)
-	req.Header.Add("Content-Length", string(blob.Size))
+	req.Header.Add("Content-Length", fmt.Sprintf("%d", blob.Size))
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "indigo-automod/"+versioninfo.Short())
 

--- a/automod/visual/abyss_client.go
+++ b/automod/visual/abyss_client.go
@@ -1,0 +1,75 @@
+package visual
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	lexutil "github.com/bluesky-social/indigo/lex/util"
+	"github.com/bluesky-social/indigo/util"
+
+	"github.com/carlmjohnson/versioninfo"
+)
+
+type AbyssClient struct {
+	Client   http.Client
+	Host     string
+	Password string
+}
+
+func NewAbyssClient(host, password string) AbyssClient {
+	return AbyssClient{
+		Client:   *util.RobustHTTPClient(),
+		Host:     host,
+		Password: password,
+	}
+}
+
+func (ac *AbyssClient) ScanBlob(ctx context.Context, blob lexutil.LexBlob, blobBytes []byte, params map[string]string) (*AbyssScanResp, error) {
+
+	slog.Info("sending blob to abyss", "cid", blob.Ref.String(), "mimetype", blob.MimeType, "size", len(blobBytes))
+
+	body := bytes.NewBuffer(blobBytes)
+	req, err := http.NewRequest("POST", ac.Host+"/xrpc/com.atproto.unspecced.scanBlob", body)
+	if err != nil {
+		return nil, err
+	}
+
+	q := req.URL.Query()
+	for k, v := range params {
+		q.Add(k, v)
+	}
+	req.URL.RawQuery = q.Encode()
+
+	req.SetBasicAuth("admin", ac.Password)
+	req.Header.Add("Content-Type", blob.MimeType)
+	req.Header.Add("Content-Length", string(blob.Size))
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "indigo-automod/"+versioninfo.Short())
+
+	req = req.WithContext(ctx)
+	res, err := ac.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("abyss request failed: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("abyss request failed statusCode=%d", res.StatusCode)
+	}
+
+	respBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read abyss resp body: %v", err)
+	}
+
+	var respObj AbyssScanResp
+	if err := json.Unmarshal(respBytes, &respObj); err != nil {
+		return nil, fmt.Errorf("failed to parse abyss resp JSON: %v", err)
+	}
+	slog.Info("abyss-scan-response", "cid", blob.Ref.String(), "obj", respObj)
+	return &respObj, nil
+}

--- a/automod/visual/abyss_rule.go
+++ b/automod/visual/abyss_rule.go
@@ -1,0 +1,46 @@
+package visual
+
+import (
+	"strings"
+
+	"github.com/bluesky-social/indigo/automod"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
+)
+
+func (ac *AbyssClient) AbyssScanBlobRule(c *automod.RecordContext, blob lexutil.LexBlob, data []byte) error {
+
+	if !strings.HasPrefix(blob.MimeType, "image/") {
+		return nil
+	}
+
+	params := make(map[string]string)
+	params["did"] = c.Account.Identity.DID.String()
+	if !c.Account.Identity.Handle.IsInvalidHandle() {
+		params["handle"] = c.Account.Identity.Handle.String()
+	}
+	if c.Account.Private != nil && c.Account.Private.Email != "" {
+		params["accountEmail"] = c.Account.Private.Email
+	}
+	params["uri"] = c.RecordOp.ATURI().String()
+
+	resp, err := ac.ScanBlob(c.Ctx, blob, data, params)
+	if err != nil {
+		return err
+	}
+
+	if resp.Match == nil || resp.Match.Status != "success" {
+		// TODO: should this return an error, or just log?
+		c.Logger.Error("abyss blob scan failed", "cid", blob.Ref.String())
+		return nil
+	}
+
+	if resp.Match.IsAbuseMatch() {
+		c.Logger.Warn("abyss blob match", "cid", blob.Ref.String())
+		c.AddRecordFlag("abyss-match")
+		c.TakedownRecord()
+		// purge blob as part of record takedown
+		c.TakedownBlob(blob.Ref.String())
+	}
+
+	return nil
+}

--- a/automod/visual/doc.go
+++ b/automod/visual/doc.go
@@ -1,3 +1,2 @@
 // automod helpers for visual content (image blobs)
 package visual
-

--- a/automod/visual/doc.go
+++ b/automod/visual/doc.go
@@ -1,0 +1,3 @@
+// automod helpers for visual content (image blobs)
+package visual
+

--- a/automod/visual/hive_rule.go
+++ b/automod/visual/hive_rule.go
@@ -1,0 +1,26 @@
+package visual
+
+import (
+	"strings"
+
+	"github.com/bluesky-social/indigo/automod"
+	lexutil "github.com/bluesky-social/indigo/lex/util"
+)
+
+func (hal *HiveAILabeler) HiveLabelBlobRule(c *automod.RecordContext, blob lexutil.LexBlob, data []byte) error {
+
+	if !strings.HasPrefix(blob.MimeType, "image/") {
+		return nil
+	}
+
+	labels, err := hal.LabelBlob(c.Ctx, blob, data)
+	if err != nil {
+		return err
+	}
+
+	for _, l := range labels {
+		c.AddRecordLabel(l)
+	}
+
+	return nil
+}

--- a/automod/visual/hiveai.go
+++ b/automod/visual/hiveai.go
@@ -1,0 +1,147 @@
+package visual
+
+import (
+	"log/slog"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+
+	lexutil "github.com/bluesky-social/indigo/lex/util"
+	"github.com/bluesky-social/indigo/util"
+
+	"github.com/carlmjohnson/versioninfo"
+)
+
+type HiveAILabeler struct {
+	Client   http.Client
+	ApiToken string
+}
+
+// schema: https://docs.thehive.ai/reference/classification
+type HiveAIResp struct {
+	Status []HiveAIResp_Status `json:"status"`
+}
+
+type HiveAIResp_Status struct {
+	Response HiveAIResp_Response `json:"response"`
+}
+
+type HiveAIResp_Response struct {
+	Output []HiveAIResp_Out `json:"output"`
+}
+
+type HiveAIResp_Out struct {
+	Time    float64            `json:"time"`
+	Classes []HiveAIResp_Class `json:"classes"`
+}
+
+type HiveAIResp_Class struct {
+	Class string  `json:"class"`
+	Score float64 `json:"score"`
+}
+
+func NewHiveAILabeler(token string) HiveAILabeler {
+	return HiveAILabeler{
+		Client:   *util.RobustHTTPClient(),
+		ApiToken: token,
+	}
+}
+
+func (resp *HiveAIResp) SummarizeLabels() []string {
+	var labels []string
+
+	for _, status := range resp.Status {
+		for _, out := range status.Response.Output {
+			for _, cls := range out.Classes {
+				// TODO(bnewbold): lots more upstream tags could be included here.
+				// for example, "sexy" for not nude but still explicit/suggestive,
+				// or lolicon (animated, not nude, "sugggestive"
+
+				// sexual: https://docs.thehive.ai/docs/sexual-content
+				// note: won't apply "nude" if "porn" already applied
+				if cls.Class == "yes_sexual_activity" && cls.Score >= 0.90 {
+					// NOTE: will include "hentai"
+					labels = append(labels, "porn")
+				} else if cls.Class == "animal_genitalia_and_human" && cls.Score >= 0.90 {
+					labels = append(labels, "porn")
+				} else if cls.Class == "yes_male_nudity" && cls.Score >= 0.90 {
+					labels = append(labels, "nude")
+				} else if cls.Class == "yes_female_nudity" && cls.Score >= 0.90 {
+					labels = append(labels, "nude")
+				}
+
+				// gore and violence: https://docs.thehive.ai/docs/class-descriptions-violence-gore
+				if cls.Class == "very_bloody" && cls.Score >= 0.90 {
+					labels = append(labels, "gore")
+				}
+				if cls.Class == "human_corpse" && cls.Score >= 0.90 {
+					labels = append(labels, "corpse")
+				}
+				if cls.Class == "yes_self_harm" && cls.Score >= 0.90 {
+					labels = append(labels, "self-harm")
+				}
+			}
+		}
+	}
+
+	return labels
+}
+
+func (hal *HiveAILabeler) LabelBlob(ctx context.Context, blob lexutil.LexBlob, blobBytes []byte) ([]string, error) {
+
+	slog.Info("sending blob to thehive.ai", "cid", blob.Ref, "mimetype", blob.MimeType, "size", len(blobBytes))
+
+	// generic HTTP form file upload, then parse the response JSON
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("media", blob.Ref.String())
+	if err != nil {
+		return nil, err
+	}
+	_, err = part.Write(blobBytes)
+	if err != nil {
+		return nil, err
+	}
+	err = writer.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", "https://api.thehive.ai/api/v2/task/sync", body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Token %s", hal.ApiToken))
+	req.Header.Add("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "labelmaker/"+versioninfo.Short())
+
+	res, err := hal.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HiveAI request failed: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("HiveAI request failed  statusCode=%d", res.StatusCode)
+	}
+
+	respBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read HiveAI resp body: %v", err)
+	}
+
+	slog.Debug("HiveAI raw result", "cid", blob.Ref, "body", string(respBytes))
+
+	var respObj HiveAIResp
+	if err := json.Unmarshal(respBytes, &respObj); err != nil {
+		return nil, fmt.Errorf("failed to parse HiveAI resp JSON: %v", err)
+	}
+	respJson, _ := json.Marshal(respObj.Status[0].Response.Output[0])
+	slog.Info("HiveAI result", "cid", blob.Ref, "json", string(respJson))
+	return respObj.SummarizeLabels(), nil
+}

--- a/automod/visual/hiveai.go
+++ b/automod/visual/hiveai.go
@@ -1,12 +1,12 @@
 package visual
 
 import (
-	"log/slog"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"mime/multipart"
 	"net/http"
 
@@ -51,39 +51,105 @@ func NewHiveAILabeler(token string) HiveAILabeler {
 	}
 }
 
+// Simple direct mappings from individual classes to to labels
+//
+// hive gore and violence: https://docs.thehive.ai/docs/class-descriptions-violence-gore
+func summarizeSimpleLabels(cl []HiveAIResp_Class) []string {
+	var labels []string
+
+	for _, cls := range cl {
+		if cls.Class == "very_bloody" && cls.Score >= 0.90 {
+			labels = append(labels, "gore")
+		}
+		if cls.Class == "human_corpse" && cls.Score >= 0.90 {
+			labels = append(labels, "corpse")
+		}
+		if cls.Class == "hanging" && cls.Score >= 0.90 {
+			labels = append(labels, "corpse")
+		}
+		if cls.Class == "yes_self_harm" && cls.Score >= 0.96 {
+			labels = append(labels, "self-harm")
+		}
+	}
+	return labels
+}
+
+// Matches only one (or none) of: porn, sexual, nudity
+//
+// porn: sexual and nudity. including both explicit activity or full-frontal and suggestive/intent
+// sexual: sexually suggestive, not explicit; may include some forms of nudity
+// nudity: non-sexual nudity (eg, artistic, possibly some photographic)
+//
+// hive docs/definitions: https://docs.thehive.ai/docs/sexual-content
+func summarizeSexualLabels(cl []HiveAIResp_Class) string {
+
+	scores := make(map[string]float64)
+	for _, cls := range cl {
+		scores[cls.Class] = cls.Score
+	}
+
+	// first check if porn...
+	for _, pornClass := range []string{"yes_sexual_activity", "animal_genitalia_and_human", "yes_realistic_nsfw"} {
+		if scores[pornClass] >= 0.9 {
+			return "porn"
+		}
+	}
+	if scores["general_nsfw"] >= 0.9 {
+		// special case for some anime examples
+		if scores["animated_animal_genitalia"] >= 0.5 {
+			return "porn"
+		}
+
+		// special case for some pornographic/explicit classic drawings
+		if scores["yes_undressed"] >= 0.9 && scores["yes_sexual_activity"] >= 0.9 {
+			return "porn"
+		}
+	}
+
+	// then check for sexual suggestive (which may include nudity)...
+	for _, sexualClass := range []string{"yes_sexual_intent", "yes_sex_toy"} {
+		if scores[sexualClass] >= 0.9 {
+			return "sexual"
+		}
+	}
+	if scores["yes_undressed"] >= 0.9 {
+		// special case for bondage examples
+		if scores["yes_sex_toy"] > 0.75 {
+			return "sexual"
+		}
+	}
+
+	// then non-sexual nudity...
+	for _, nudityClass := range []string{"yes_male_nudity", "yes_female_nudity", "yes_undressed"} {
+		if scores[nudityClass] >= 0.9 {
+			return "nudity"
+		}
+	}
+
+	// then finally flag remaining "underwear" images in to sexually suggestive
+	// (after non-sexual content already labeled above)
+	for _, underwearClass := range []string{"yes_male_underwear", "yes_female_underwear"} {
+		if scores[underwearClass] >= 0.9 {
+			return "sexual"
+		}
+	}
+
+	return ""
+}
+
 func (resp *HiveAIResp) SummarizeLabels() []string {
 	var labels []string
 
 	for _, status := range resp.Status {
 		for _, out := range status.Response.Output {
-			for _, cls := range out.Classes {
-				// TODO(bnewbold): lots more upstream tags could be included here.
-				// for example, "sexy" for not nude but still explicit/suggestive,
-				// or lolicon (animated, not nude, "sugggestive"
+			simple := summarizeSimpleLabels(out.Classes)
+			if len(simple) > 0 {
+				labels = append(labels, simple...)
+			}
 
-				// sexual: https://docs.thehive.ai/docs/sexual-content
-				// note: won't apply "nude" if "porn" already applied
-				if cls.Class == "yes_sexual_activity" && cls.Score >= 0.90 {
-					// NOTE: will include "hentai"
-					labels = append(labels, "porn")
-				} else if cls.Class == "animal_genitalia_and_human" && cls.Score >= 0.90 {
-					labels = append(labels, "porn")
-				} else if cls.Class == "yes_male_nudity" && cls.Score >= 0.90 {
-					labels = append(labels, "nude")
-				} else if cls.Class == "yes_female_nudity" && cls.Score >= 0.90 {
-					labels = append(labels, "nude")
-				}
-
-				// gore and violence: https://docs.thehive.ai/docs/class-descriptions-violence-gore
-				if cls.Class == "very_bloody" && cls.Score >= 0.90 {
-					labels = append(labels, "gore")
-				}
-				if cls.Class == "human_corpse" && cls.Score >= 0.90 {
-					labels = append(labels, "corpse")
-				}
-				if cls.Class == "yes_self_harm" && cls.Score >= 0.90 {
-					labels = append(labels, "self-harm")
-				}
+			sexual := summarizeSexualLabels(out.Classes)
+			if sexual != "" {
+				labels = append(labels, sexual)
 			}
 		}
 	}

--- a/automod/visual/hiveai_client.go
+++ b/automod/visual/hiveai_client.go
@@ -16,7 +16,7 @@ import (
 	"github.com/carlmjohnson/versioninfo"
 )
 
-type HiveAILabeler struct {
+type HiveAIClient struct {
 	Client   http.Client
 	ApiToken string
 }
@@ -44,8 +44,8 @@ type HiveAIResp_Class struct {
 	Score float64 `json:"score"`
 }
 
-func NewHiveAILabeler(token string) HiveAILabeler {
-	return HiveAILabeler{
+func NewHiveAIClient(token string) HiveAIClient {
+	return HiveAIClient{
 		Client:   *util.RobustHTTPClient(),
 		ApiToken: token,
 	}
@@ -157,7 +157,7 @@ func (resp *HiveAIResp) SummarizeLabels() []string {
 	return labels
 }
 
-func (hal *HiveAILabeler) LabelBlob(ctx context.Context, blob lexutil.LexBlob, blobBytes []byte) ([]string, error) {
+func (hal *HiveAIClient) LabelBlob(ctx context.Context, blob lexutil.LexBlob, blobBytes []byte) ([]string, error) {
 
 	slog.Info("sending blob to Hive AI", "cid", blob.Ref.String(), "mimetype", blob.MimeType, "size", len(blobBytes))
 

--- a/automod/visual/hiveai_rule.go
+++ b/automod/visual/hiveai_rule.go
@@ -7,7 +7,7 @@ import (
 	lexutil "github.com/bluesky-social/indigo/lex/util"
 )
 
-func (hal *HiveAILabeler) HiveLabelBlobRule(c *automod.RecordContext, blob lexutil.LexBlob, data []byte) error {
+func (hal *HiveAIClient) HiveLabelBlobRule(c *automod.RecordContext, blob lexutil.LexBlob, data []byte) error {
 
 	if !strings.HasPrefix(blob.MimeType, "image/") {
 		return nil

--- a/automod/visual/hiveai_test.go
+++ b/automod/visual/hiveai_test.go
@@ -1,0 +1,42 @@
+package visual
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestHiveParse(t *testing.T) {
+	file, err := os.Open("testdata/hiveai_resp_example.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	respBytes, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var respObj HiveAIResp
+	if err := json.Unmarshal(respBytes, &respObj); err != nil {
+		t.Fatal(err)
+	}
+
+	classes := respObj.Status[0].Response.Output[0].Classes
+	if len(classes) <= 10 {
+		t.Fatal("didn't get expected class count")
+	}
+	for _, c := range classes {
+		if c.Class == "" || c.Score == 0.0 {
+			t.Fatal("got null/empty class in resp")
+		}
+	}
+
+	labels := respObj.SummarizeLabels()
+	expected := []string{"porn"}
+	if !reflect.DeepEqual(labels, expected) {
+		t.Fatal("didn't summarize to expected labels")
+	}
+}

--- a/automod/visual/testdata/hiveai_resp_example.json
+++ b/automod/visual/testdata/hiveai_resp_example.json
@@ -1,0 +1,401 @@
+{
+  "id": "02122580-c37f-11ed-81d2-000000000000",
+  "code": 200,
+  "project_id": 12345,
+  "user_id": 12345,
+  "created_on": "2023-03-15T22:16:18.408Z",
+  "status": [
+    {
+      "status": {
+        "code": "0",
+        "message": "SUCCESS"
+      },
+      "response": {
+        "input": {
+          "id": "02122580-c37f-11ed-81d2-000000000000",
+          "charge": 0.003,
+          "model": "mod55_dense",
+          "model_version": 1,
+          "model_type": "CATEGORIZATION",
+          "created_on": "2023-03-15T22:16:18.136Z",
+          "media": {
+            "url": null,
+            "filename": "bafkreiam7k6mvkyuoybq4ynhljvj5xa75sdbhjbolzjf5j2udx7vj5gnsy",
+            "type": "PHOTO",
+            "mime_type": "jpeg",
+            "mimetype": "image/jpeg",
+            "width": 800,
+            "height": 800,
+            "num_frames": 1,
+            "duration": 0
+          },
+          "user_id": 12345,
+          "project_id": 12345,
+          "config_version": 1,
+          "config_tag": "default"
+        },
+        "output": [
+          {
+            "time": 0,
+            "classes": [
+              {
+                "class": "general_not_nsfw_not_suggestive",
+                "score": 0.9998097218132356
+              },
+              {
+                "class": "general_nsfw",
+                "score": 8.857344804177162e-05
+              },
+              {
+                "class": "general_suggestive",
+                "score": 0.00010170473872266839
+              },
+              {
+                "class": "no_female_underwear",
+                "score": 0.9999923079040384
+              },
+              {
+                "class": "yes_female_underwear",
+                "score": 7.692095961599136e-06
+              },
+              {
+                "class": "no_male_underwear",
+                "score": 0.9999984904867634
+              },
+              {
+                "class": "yes_male_underwear",
+                "score": 1.5095132367094679e-06
+              },
+              {
+                "class": "no_sex_toy",
+                "score": 0.9999970970762551
+              },
+              {
+                "class": "yes_sex_toy",
+                "score": 2.9029237450490604e-06
+              },
+              {
+                "class": "no_female_nudity",
+                "score": 0.9999739028909301
+              },
+              {
+                "class": "yes_female_nudity",
+                "score": 2.60971090699536e-05
+              },
+              {
+                "class": "no_male_nudity",
+                "score": 0.9999711373083747
+              },
+              {
+                "class": "yes_male_nudity",
+                "score": 2.8862691625255323e-05
+              },
+              {
+                "class": "no_female_swimwear",
+                "score": 0.9999917609899659
+              },
+              {
+                "class": "yes_female_swimwear",
+                "score": 8.239010034025379e-06
+              },
+              {
+                "class": "no_male_shirtless",
+                "score": 0.9999583350744331
+              },
+              {
+                "class": "yes_male_shirtless",
+                "score": 4.166492556688088e-05
+              },
+              {
+                "class": "no_text",
+                "score": 0.9958378716447616
+              },
+              {
+                "class": "text",
+                "score": 0.0041621283552384265
+              },
+              {
+                "class": "animated",
+                "score": 0.46755478950048235
+              },
+              {
+                "class": "hybrid",
+                "score": 0.0011440363434524984
+              },
+              {
+                "class": "natural",
+                "score": 0.5313011741560651
+              },
+              {
+                "class": "animated_gun",
+                "score": 2.0713000782979496e-05
+              },
+              {
+                "class": "gun_in_hand",
+                "score": 1.5844730446534659e-06
+              },
+              {
+                "class": "gun_not_in_hand",
+                "score": 1.0338973818006654e-06
+              },
+              {
+                "class": "no_gun",
+                "score": 0.9999766686287906
+              },
+              {
+                "class": "culinary_knife_in_hand",
+                "score": 3.8063500083369785e-06
+              },
+              {
+                "class": "culinary_knife_not_in_hand",
+                "score": 7.94057948996249e-07
+              },
+              {
+                "class": "knife_in_hand",
+                "score": 4.5578955723278505e-07
+              },
+              {
+                "class": "knife_not_in_hand",
+                "score": 3.842124714748908e-07
+              },
+              {
+                "class": "no_knife",
+                "score": 0.999994559590014
+              },
+              {
+                "class": "a_little_bloody",
+                "score": 2.1317745626539786e-07
+              },
+              {
+                "class": "no_blood",
+                "score": 0.9999793341236429
+              },
+              {
+                "class": "other_blood",
+                "score": 2.0322054269591763e-05
+              },
+              {
+                "class": "very_bloody",
+                "score": 1.306446309561673e-07
+              },
+              {
+                "class": "no_pills",
+                "score": 0.9999989592376954
+              },
+              {
+                "class": "yes_pills",
+                "score": 1.0407623044588633e-06
+              },
+              {
+                "class": "no_smoking",
+                "score": 0.9999939101969173
+              },
+              {
+                "class": "yes_smoking",
+                "score": 6.089803082758281e-06
+              },
+              {
+                "class": "illicit_injectables",
+                "score": 6.925695592003094e-07
+              },
+              {
+                "class": "medical_injectables",
+                "score": 8.587808234452378e-07
+              },
+              {
+                "class": "no_injectables",
+                "score": 0.9999984486496174
+              },
+              {
+                "class": "no_nazi",
+                "score": 0.9999987449628097
+              },
+              {
+                "class": "yes_nazi",
+                "score": 1.2550371902234279e-06
+              },
+              {
+                "class": "no_kkk",
+                "score": 0.999999762417549
+              },
+              {
+                "class": "yes_kkk",
+                "score": 2.3758245111050425e-07
+              },
+              {
+                "class": "no_middle_finger",
+                "score": 0.9999881515231847
+              },
+              {
+                "class": "yes_middle_finger",
+                "score": 1.184847681536747e-05
+              },
+              {
+                "class": "no_terrorist",
+                "score": 0.9999998870793229
+              },
+              {
+                "class": "yes_terrorist",
+                "score": 1.1292067715380635e-07
+              },
+              {
+                "class": "no_overlay_text",
+                "score": 0.9996453363440359
+              },
+              {
+                "class": "yes_overlay_text",
+                "score": 0.0003546636559640924
+              },
+              {
+                "class": "no_sexual_activity",
+                "score": 0.9999563580374798
+              },
+              {
+                "class": "yes_sexual_activity",
+                "score": 0.99,
+                "realScore": 4.364196252012032e-05
+              },
+              {
+                "class": "hanging",
+                "score": 3.6435135762510905e-07
+              },
+              {
+                "class": "no_hanging_no_noose",
+                "score": 0.9999980779196416
+              },
+              {
+                "class": "noose",
+                "score": 1.5577290007796094e-06
+              },
+              {
+                "class": "no_realistic_nsfw",
+                "score": 0.9999944341007805
+              },
+              {
+                "class": "yes_realistic_nsfw",
+                "score": 5.565899219571182e-06
+              },
+              {
+                "class": "animated_corpse",
+                "score": 5.276802046755426e-07
+              },
+              {
+                "class": "human_corpse",
+                "score": 2.5449360984211012e-08
+              },
+              {
+                "class": "no_corpse",
+                "score": 0.9999994468704343
+              },
+              {
+                "class": "no_self_harm",
+                "score": 0.9999994515625507
+              },
+              {
+                "class": "yes_self_harm",
+                "score": 5.484374493605692e-07
+              },
+              {
+                "class": "no_drawing",
+                "score": 0.9978276028816608
+              },
+              {
+                "class": "yes_drawing",
+                "score": 0.0021723971183392485
+              },
+              {
+                "class": "no_emaciated_body",
+                "score": 0.9999998146500432
+              },
+              {
+                "class": "yes_emaciated_body",
+                "score": 1.853499568724518e-07
+              },
+              {
+                "class": "no_child_present",
+                "score": 0.9999970498515446
+              },
+              {
+                "class": "yes_child_present",
+                "score": 2.950148455380443e-06
+              },
+              {
+                "class": "no_sexual_intent",
+                "score": 0.9999963861546292
+              },
+              {
+                "class": "yes_sexual_intent",
+                "score": 3.613845370766111e-06
+              },
+              {
+                "class": "animal_genitalia_and_human",
+                "score": 2.255472023465222e-08
+              },
+              {
+                "class": "animal_genitalia_only",
+                "score": 4.6783185199931176e-07
+              },
+              {
+                "class": "animated_animal_genitalia",
+                "score": 6.707857419436447e-07
+              },
+              {
+                "class": "no_animal_genitalia",
+                "score": 0.9999988388276858
+              },
+              {
+                "class": "no_gambling",
+                "score": 0.9999960939687145
+              },
+              {
+                "class": "yes_gambling",
+                "score": 3.906031285604864e-06
+              },
+              {
+                "class": "no_undressed",
+                "score": 0.99999923356218
+              },
+              {
+                "class": "yes_undressed",
+                "score": 7.664378199789045e-07
+              },
+              {
+                "class": "no_confederate",
+                "score": 0.9999925456900376
+              },
+              {
+                "class": "yes_confederate",
+                "score": 7.454309962453175e-06
+              },
+              {
+                "class": "animated_alcohol",
+                "score": 1.8109949948066074e-06
+              },
+              {
+                "class": "no_alcohol",
+                "score": 0.9999916620957963
+              },
+              {
+                "class": "yes_alcohol",
+                "score": 5.88781463445443e-06
+              },
+              {
+                "class": "yes_drinking_alcohol",
+                "score": 6.390945746578106e-07
+              },
+              {
+                "class": "no_religious_icon",
+                "score": 0.9999862158580689
+              },
+              {
+                "class": "yes_religious_icon",
+                "score": 1.3784141931119298e-05
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "from_cache": false
+}

--- a/automod/visual/testdata/hiveai_resp_example.json
+++ b/automod/visual/testdata/hiveai_resp_example.json
@@ -44,7 +44,7 @@
               },
               {
                 "class": "general_nsfw",
-                "score": 8.857344804177162e-05
+                "score": 8.857344804177162e-5
               },
               {
                 "class": "general_suggestive",
@@ -56,7 +56,7 @@
               },
               {
                 "class": "yes_female_underwear",
-                "score": 7.692095961599136e-06
+                "score": 7.692095961599136e-6
               },
               {
                 "class": "no_male_underwear",
@@ -64,7 +64,7 @@
               },
               {
                 "class": "yes_male_underwear",
-                "score": 1.5095132367094679e-06
+                "score": 1.5095132367094679e-6
               },
               {
                 "class": "no_sex_toy",
@@ -72,7 +72,7 @@
               },
               {
                 "class": "yes_sex_toy",
-                "score": 2.9029237450490604e-06
+                "score": 2.9029237450490604e-6
               },
               {
                 "class": "no_female_nudity",
@@ -80,7 +80,7 @@
               },
               {
                 "class": "yes_female_nudity",
-                "score": 2.60971090699536e-05
+                "score": 2.60971090699536e-5
               },
               {
                 "class": "no_male_nudity",
@@ -88,7 +88,7 @@
               },
               {
                 "class": "yes_male_nudity",
-                "score": 2.8862691625255323e-05
+                "score": 2.8862691625255323e-5
               },
               {
                 "class": "no_female_swimwear",
@@ -96,7 +96,7 @@
               },
               {
                 "class": "yes_female_swimwear",
-                "score": 8.239010034025379e-06
+                "score": 8.239010034025379e-6
               },
               {
                 "class": "no_male_shirtless",
@@ -104,7 +104,7 @@
               },
               {
                 "class": "yes_male_shirtless",
-                "score": 4.166492556688088e-05
+                "score": 4.166492556688088e-5
               },
               {
                 "class": "no_text",
@@ -128,15 +128,15 @@
               },
               {
                 "class": "animated_gun",
-                "score": 2.0713000782979496e-05
+                "score": 2.0713000782979496e-5
               },
               {
                 "class": "gun_in_hand",
-                "score": 1.5844730446534659e-06
+                "score": 1.5844730446534659e-6
               },
               {
                 "class": "gun_not_in_hand",
-                "score": 1.0338973818006654e-06
+                "score": 1.0338973818006654e-6
               },
               {
                 "class": "no_gun",
@@ -144,19 +144,19 @@
               },
               {
                 "class": "culinary_knife_in_hand",
-                "score": 3.8063500083369785e-06
+                "score": 3.8063500083369785e-6
               },
               {
                 "class": "culinary_knife_not_in_hand",
-                "score": 7.94057948996249e-07
+                "score": 7.94057948996249e-7
               },
               {
                 "class": "knife_in_hand",
-                "score": 4.5578955723278505e-07
+                "score": 4.5578955723278505e-7
               },
               {
                 "class": "knife_not_in_hand",
-                "score": 3.842124714748908e-07
+                "score": 3.842124714748908e-7
               },
               {
                 "class": "no_knife",
@@ -164,7 +164,7 @@
               },
               {
                 "class": "a_little_bloody",
-                "score": 2.1317745626539786e-07
+                "score": 2.1317745626539786e-7
               },
               {
                 "class": "no_blood",
@@ -172,11 +172,11 @@
               },
               {
                 "class": "other_blood",
-                "score": 2.0322054269591763e-05
+                "score": 2.0322054269591763e-5
               },
               {
                 "class": "very_bloody",
-                "score": 1.306446309561673e-07
+                "score": 1.306446309561673e-7
               },
               {
                 "class": "no_pills",
@@ -184,7 +184,7 @@
               },
               {
                 "class": "yes_pills",
-                "score": 1.0407623044588633e-06
+                "score": 1.0407623044588633e-6
               },
               {
                 "class": "no_smoking",
@@ -192,15 +192,15 @@
               },
               {
                 "class": "yes_smoking",
-                "score": 6.089803082758281e-06
+                "score": 6.089803082758281e-6
               },
               {
                 "class": "illicit_injectables",
-                "score": 6.925695592003094e-07
+                "score": 6.925695592003094e-7
               },
               {
                 "class": "medical_injectables",
-                "score": 8.587808234452378e-07
+                "score": 8.587808234452378e-7
               },
               {
                 "class": "no_injectables",
@@ -212,7 +212,7 @@
               },
               {
                 "class": "yes_nazi",
-                "score": 1.2550371902234279e-06
+                "score": 1.2550371902234279e-6
               },
               {
                 "class": "no_kkk",
@@ -220,7 +220,7 @@
               },
               {
                 "class": "yes_kkk",
-                "score": 2.3758245111050425e-07
+                "score": 2.3758245111050425e-7
               },
               {
                 "class": "no_middle_finger",
@@ -228,7 +228,7 @@
               },
               {
                 "class": "yes_middle_finger",
-                "score": 1.184847681536747e-05
+                "score": 1.184847681536747e-5
               },
               {
                 "class": "no_terrorist",
@@ -236,7 +236,7 @@
               },
               {
                 "class": "yes_terrorist",
-                "score": 1.1292067715380635e-07
+                "score": 1.1292067715380635e-7
               },
               {
                 "class": "no_overlay_text",
@@ -253,11 +253,11 @@
               {
                 "class": "yes_sexual_activity",
                 "score": 0.99,
-                "realScore": 4.364196252012032e-05
+                "realScore": 4.364196252012032e-5
               },
               {
                 "class": "hanging",
-                "score": 3.6435135762510905e-07
+                "score": 3.6435135762510905e-7
               },
               {
                 "class": "no_hanging_no_noose",
@@ -265,7 +265,7 @@
               },
               {
                 "class": "noose",
-                "score": 1.5577290007796094e-06
+                "score": 1.5577290007796094e-6
               },
               {
                 "class": "no_realistic_nsfw",
@@ -273,15 +273,15 @@
               },
               {
                 "class": "yes_realistic_nsfw",
-                "score": 5.565899219571182e-06
+                "score": 5.565899219571182e-6
               },
               {
                 "class": "animated_corpse",
-                "score": 5.276802046755426e-07
+                "score": 5.276802046755426e-7
               },
               {
                 "class": "human_corpse",
-                "score": 2.5449360984211012e-08
+                "score": 2.5449360984211012e-8
               },
               {
                 "class": "no_corpse",
@@ -293,7 +293,7 @@
               },
               {
                 "class": "yes_self_harm",
-                "score": 5.484374493605692e-07
+                "score": 5.484374493605692e-7
               },
               {
                 "class": "no_drawing",
@@ -309,7 +309,7 @@
               },
               {
                 "class": "yes_emaciated_body",
-                "score": 1.853499568724518e-07
+                "score": 1.853499568724518e-7
               },
               {
                 "class": "no_child_present",
@@ -317,7 +317,7 @@
               },
               {
                 "class": "yes_child_present",
-                "score": 2.950148455380443e-06
+                "score": 2.950148455380443e-6
               },
               {
                 "class": "no_sexual_intent",
@@ -325,19 +325,19 @@
               },
               {
                 "class": "yes_sexual_intent",
-                "score": 3.613845370766111e-06
+                "score": 3.613845370766111e-6
               },
               {
                 "class": "animal_genitalia_and_human",
-                "score": 2.255472023465222e-08
+                "score": 2.255472023465222e-8
               },
               {
                 "class": "animal_genitalia_only",
-                "score": 4.6783185199931176e-07
+                "score": 4.6783185199931176e-7
               },
               {
                 "class": "animated_animal_genitalia",
-                "score": 6.707857419436447e-07
+                "score": 6.707857419436447e-7
               },
               {
                 "class": "no_animal_genitalia",
@@ -349,7 +349,7 @@
               },
               {
                 "class": "yes_gambling",
-                "score": 3.906031285604864e-06
+                "score": 3.906031285604864e-6
               },
               {
                 "class": "no_undressed",
@@ -357,7 +357,7 @@
               },
               {
                 "class": "yes_undressed",
-                "score": 7.664378199789045e-07
+                "score": 7.664378199789045e-7
               },
               {
                 "class": "no_confederate",
@@ -365,11 +365,11 @@
               },
               {
                 "class": "yes_confederate",
-                "score": 7.454309962453175e-06
+                "score": 7.454309962453175e-6
               },
               {
                 "class": "animated_alcohol",
-                "score": 1.8109949948066074e-06
+                "score": 1.8109949948066074e-6
               },
               {
                 "class": "no_alcohol",
@@ -377,11 +377,11 @@
               },
               {
                 "class": "yes_alcohol",
-                "score": 5.88781463445443e-06
+                "score": 5.88781463445443e-6
               },
               {
                 "class": "yes_drinking_alcohol",
-                "score": 6.390945746578106e-07
+                "score": 6.390945746578106e-7
               },
               {
                 "class": "no_religious_icon",
@@ -389,7 +389,7 @@
               },
               {
                 "class": "yes_religious_icon",
-                "score": 1.3784141931119298e-05
+                "score": 1.3784141931119298e-5
               }
             ]
           }

--- a/cmd/hepa/main.go
+++ b/cmd/hepa/main.go
@@ -98,6 +98,16 @@ func run(args []string) error {
 			Usage:   "API token for Hive AI image auto-labeling",
 			EnvVars: []string{"HIVEAI_API_TOKEN"},
 		},
+		&cli.StringFlag{
+			Name:    "abyss-host",
+			Usage:   "host for abusive image scanning API (scheme, host, port)",
+			EnvVars: []string{"ABYSS_HOST"},
+		},
+		&cli.StringFlag{
+			Name:    "abyss-password",
+			Usage:   "admin auth password for abyss API",
+			EnvVars: []string{"ABYSS_PASSWORD"},
+		},
 	}
 
 	app.Commands = []*cli.Command{
@@ -179,6 +189,8 @@ var runCmd = &cli.Command{
 				RedisURL:        cctx.String("redis-url"),
 				SlackWebhookURL: cctx.String("slack-webhook-url"),
 				HiveAPIToken:    cctx.String("hiveai-api-token"),
+				AbyssHost:       cctx.String("abyss-host"),
+				AbyssPassword:   cctx.String("abyss-password"),
 			},
 		)
 		if err != nil {
@@ -241,6 +253,8 @@ func configEphemeralServer(cctx *cli.Context) (*Server, error) {
 			SetsFileJSON:  cctx.String("sets-json-path"),
 			RedisURL:      cctx.String("redis-url"),
 			HiveAPIToken:  cctx.String("hiveai-api-token"),
+			AbyssHost:     cctx.String("abyss-host"),
+			AbyssPassword: cctx.String("abyss-password"),
 		},
 	)
 }

--- a/cmd/hepa/main.go
+++ b/cmd/hepa/main.go
@@ -93,6 +93,11 @@ func run(args []string) error {
 			Usage:   "file path of JSON file containing static sets",
 			EnvVars: []string{"HEPA_SETS_JSON_PATH"},
 		},
+		&cli.StringFlag{
+			Name:    "hiveai-api-token",
+			Usage:   "API token for Hive AI image auto-labeling",
+			EnvVars: []string{"HIVEAI_API_TOKEN"},
+		},
 	}
 
 	app.Commands = []*cli.Command{
@@ -173,6 +178,7 @@ var runCmd = &cli.Command{
 				SetsFileJSON:    cctx.String("sets-json-path"),
 				RedisURL:        cctx.String("redis-url"),
 				SlackWebhookURL: cctx.String("slack-webhook-url"),
+				HiveAPIToken:    cctx.String("hiveai-api-token"),
 			},
 		)
 		if err != nil {
@@ -234,6 +240,7 @@ func configEphemeralServer(cctx *cli.Context) (*Server, error) {
 			ModPassword:   cctx.String("mod-password"),
 			SetsFileJSON:  cctx.String("sets-json-path"),
 			RedisURL:      cctx.String("redis-url"),
+			HiveAPIToken:  cctx.String("hiveai-api-token"),
 		},
 	)
 }

--- a/cmd/hepa/main.go
+++ b/cmd/hepa/main.go
@@ -108,6 +108,11 @@ func run(args []string) error {
 			Usage:   "admin auth password for abyss API",
 			EnvVars: []string{"ABYSS_PASSWORD"},
 		},
+		&cli.StringFlag{
+			Name:    "ruleset",
+			Usage:   "which ruleset config to use: default, no-blobs, only-blobs",
+			EnvVars: []string{"HEPA_RULESET"},
+		},
 	}
 
 	app.Commands = []*cli.Command{
@@ -191,6 +196,7 @@ var runCmd = &cli.Command{
 				HiveAPIToken:    cctx.String("hiveai-api-token"),
 				AbyssHost:       cctx.String("abyss-host"),
 				AbyssPassword:   cctx.String("abyss-password"),
+				RulesetName:     cctx.String("ruleset"),
 			},
 		)
 		if err != nil {
@@ -255,6 +261,7 @@ func configEphemeralServer(cctx *cli.Context) (*Server, error) {
 			HiveAPIToken:  cctx.String("hiveai-api-token"),
 			AbyssHost:     cctx.String("abyss-host"),
 			AbyssPassword: cctx.String("abyss-password"),
+			RulesetName:   cctx.String("ruleset"),
 		},
 	)
 }

--- a/cmd/hepa/server.go
+++ b/cmd/hepa/server.go
@@ -44,6 +44,8 @@ type Config struct {
 	RedisURL        string
 	SlackWebhookURL string
 	HiveAPIToken    string
+	AbyssHost       string
+	AbyssPassword   string
 	Logger          *slog.Logger
 }
 
@@ -138,6 +140,12 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 		logger.Info("configuring Hive AI image labeler")
 		hc := visual.NewHiveAILabeler(config.HiveAPIToken)
 		ruleset.BlobRules = append(ruleset.BlobRules, hc.HiveLabelBlobRule)
+	}
+
+	if config.AbyssHost != "" && config.AbyssPassword != "" {
+		logger.Info("configuring abyss abusive image scanning")
+		ac := visual.NewAbyssClient(config.AbyssHost, config.AbyssPassword)
+		ruleset.BlobRules = append(ruleset.BlobRules, ac.AbyssScanBlobRule)
 	}
 
 	engine := automod.Engine{

--- a/cmd/hepa/server.go
+++ b/cmd/hepa/server.go
@@ -158,6 +158,8 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 		ruleset.BlobRules = []automod.BlobRuleFunc{}
 	case "only-blobs":
 		ruleset.BlobRules = extraBlobRules
+	default:
+		return nil, fmt.Errorf("unknown ruleset config: %s", config.RulesetName)
 	}
 
 	engine := automod.Engine{

--- a/cmd/hepa/server.go
+++ b/cmd/hepa/server.go
@@ -138,7 +138,7 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 
 	if config.HiveAPIToken != "" {
 		logger.Info("configuring Hive AI image labeler")
-		hc := visual.NewHiveAILabeler(config.HiveAPIToken)
+		hc := visual.NewHiveAIClient(config.HiveAPIToken)
 		ruleset.BlobRules = append(ruleset.BlobRules, hc.HiveLabelBlobRule)
 	}
 


### PR DESCRIPTION
This is just porting over existing auto-labeling stuff from appview in to the automod framework.

New engine-level supporting features:

- new "blob" rule function type
- ruleset fetches blobs from upstream PDS, if necessary
- `Effects` can track blob-level takedowns (CDN purges) as part of record takedowns