### PR TITLE
automod: notification rules/processing

### DIFF
--- a/automod/engine/context.go
+++ b/automod/engine/context.go
@@ -35,6 +35,13 @@ type RecordContext struct {
 	// TODO: could consider adding commit-level metadata here. probably nullable if so, commit-level metadata isn't always available. might be best to do a separate event/context type for that
 }
 
+type NotificationContext struct {
+	AccountContext
+
+	Recipient AccountMeta
+	// TODO: more context about the notification? "Reason", "Subject"
+}
+
 var (
 	CreateOp = "create"
 	UpdateOp = "update"
@@ -138,6 +145,14 @@ func NewRecordContext(ctx context.Context, eng *Engine, meta AccountMeta, op Rec
 	}
 }
 
+func NewNotificationContext(ctx context.Context, eng *Engine, sender, recipient AccountMeta) NotificationContext {
+	ac := NewAccountContext(ctx, eng, sender)
+	return NotificationContext{
+		AccountContext: ac,
+		Recipient:      recipient,
+	}
+}
+
 // update effects (indirect)
 func (c *BaseContext) Increment(name, val string) {
 	c.effects.Increment(name, val)
@@ -185,4 +200,8 @@ func (c *RecordContext) TakedownRecord() {
 
 func (c *RecordContext) TakedownBlob(cid string) {
 	c.effects.TakedownBlob(cid)
+}
+
+func (c *NotificationContext) Reject() {
+	c.effects.Reject()
 }

--- a/automod/engine/context.go
+++ b/automod/engine/context.go
@@ -62,7 +62,6 @@ type NotificationContext struct {
 
 	Recipient    AccountMeta
 	Notification NotificationMeta
-	// TODO: more context about the notification? "Reason", "Subject"
 }
 
 type NotificationMeta struct {
@@ -156,6 +155,7 @@ func NewRecordContext(ctx context.Context, eng *Engine, meta AccountMeta, op Rec
 
 func NewNotificationContext(ctx context.Context, eng *Engine, sender, recipient AccountMeta, reason string, subject syntax.ATURI) NotificationContext {
 	ac := NewAccountContext(ctx, eng, sender)
+	ac.BaseContext.Logger = ac.BaseContext.Logger.With("recipient", recipient.Identity.DID, "reason", reason, "subject", subject.String())
 	return NotificationContext{
 		AccountContext: ac,
 		Recipient:      recipient,

--- a/automod/engine/context.go
+++ b/automod/engine/context.go
@@ -64,8 +64,11 @@ type NotificationContext struct {
 	Notification NotificationMeta
 }
 
+// Additional notification metadata, with fields aligning with the `app.bsky.notification.listNotifications` Lexicon schemas
 type NotificationMeta struct {
-	Reason  string
+	// Expected values are 'like', 'repost', 'follow', 'mention', 'reply', and 'quote'; arbitrary values may be added in the future.
+	Reason string
+	// The content (atproto record) which was the cause of this notification. Could be a post with a mention, or a like, follow, or repost record.
 	Subject syntax.ATURI
 }
 

--- a/automod/engine/effects.go
+++ b/automod/engine/effects.go
@@ -51,6 +51,8 @@ type Effects struct {
 	RecordTakedown bool
 	// Set of Blob CIDs to takedown (eg, purge from CDN) when doing a record takedown
 	BlobTakedowns []string
+	// If "true", indicates that a rule indicates that the action causing the event should be blocked or prevented
+	RejectEvent bool
 }
 
 // Enqueues the named counter to be incremented at the end of all rule processing. Will automatically increment for all time periods.
@@ -123,4 +125,8 @@ func (e *Effects) TakedownRecord() {
 // Enqueues the blob CID to be taken down (aka, CDN purge) as part of any record takedown
 func (e *Effects) TakedownBlob(cid string) {
 	e.BlobTakedowns = append(e.BlobTakedowns, cid)
+}
+
+func (e *Effects) Reject() {
+	e.RejectEvent = true
 }

--- a/automod/engine/engine.go
+++ b/automod/engine/engine.go
@@ -176,8 +176,7 @@ func (eng *Engine) ProcessNotificationEvent(ctx context.Context, senderDID, reci
 	if err := eng.Rules.CallNotificationRules(&nc); err != nil {
 		return false, err
 	}
-	// TODO:
-	eng.CanonicalLogLineAccount(&nc.AccountContext)
+	eng.CanonicalLogLineNotification(&nc)
 	return nc.effects.RejectEvent, nil
 }
 
@@ -206,6 +205,16 @@ func (e *Engine) CanonicalLogLineRecord(c *RecordContext) {
 		"recordFlags", c.effects.RecordFlags,
 		"recordTakedown", c.effects.RecordTakedown,
 		"recordReports", len(c.effects.RecordReports),
+	)
+}
+
+func (e *Engine) CanonicalLogLineNotification(c *NotificationContext) {
+	c.Logger.Info("canonical-event-line",
+		"accountLabels", c.effects.AccountLabels,
+		"accountFlags", c.effects.AccountFlags,
+		"accountTakedown", c.effects.AccountTakedown,
+		"accountReports", len(c.effects.AccountReports),
+		"reject", c.effects.RejectEvent,
 	)
 }
 

--- a/automod/engine/engine.go
+++ b/automod/engine/engine.go
@@ -137,7 +137,7 @@ func (eng *Engine) ProcessRecordOp(ctx context.Context, op RecordOp) error {
 }
 
 // returns a boolean indicating "block the event"
-func (eng *Engine) ProcessNotificationEvent(ctx context.Context, senderDID, recipientDID syntax.DID) (bool, error) {
+func (eng *Engine) ProcessNotificationEvent(ctx context.Context, senderDID, recipientDID syntax.DID, reason string, subject syntax.ATURI) (bool, error) {
 	// similar to an HTTP server, we want to recover any panics from rule execution
 	defer func() {
 		if r := recover(); r != nil {
@@ -172,7 +172,7 @@ func (eng *Engine) ProcessNotificationEvent(ctx context.Context, senderDID, reci
 		return false, err
 	}
 
-	nc := NewNotificationContext(ctx, eng, *senderMeta, *recipientMeta)
+	nc := NewNotificationContext(ctx, eng, *senderMeta, *recipientMeta, reason, subject)
 	if err := eng.Rules.CallNotificationRules(&nc); err != nil {
 		return false, err
 	}

--- a/automod/engine/ruleset.go
+++ b/automod/engine/ruleset.go
@@ -16,6 +16,7 @@ type RuleSet struct {
 	RecordDeleteRules []RecordRuleFunc
 	IdentityRules     []IdentityRuleFunc
 	BlobRules         []BlobRuleFunc
+	NotificationRules []NotificationRuleFunc
 }
 
 // Executes all the various record-related rules. Only dispatches execution, does no other de-dupe or pre/post processing.
@@ -78,6 +79,16 @@ func (r *RuleSet) CallRecordDeleteRules(c *RecordContext) error {
 // Executes rules for identity update events.
 func (r *RuleSet) CallIdentityRules(c *AccountContext) error {
 	for _, f := range r.IdentityRules {
+		err := f(c)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *RuleSet) CallNotificationRules(c *NotificationContext) error {
+	for _, f := range r.NotificationRules {
 		err := f(c)
 		if err != nil {
 			return err

--- a/automod/engine/ruletypes.go
+++ b/automod/engine/ruletypes.go
@@ -10,3 +10,4 @@ type RecordRuleFunc = func(c *RecordContext) error
 type PostRuleFunc = func(c *RecordContext, post *appbsky.FeedPost) error
 type ProfileRuleFunc = func(c *RecordContext, profile *appbsky.ActorProfile) error
 type BlobRuleFunc = func(c *RecordContext, blob lexutil.LexBlob, data []byte) error
+type NotificationRuleFunc = func(c *NotificationContext) error

--- a/automod/pkg.go
+++ b/automod/pkg.go
@@ -18,6 +18,7 @@ type RecordRuleFunc = engine.RecordRuleFunc
 type PostRuleFunc = engine.PostRuleFunc
 type ProfileRuleFunc = engine.ProfileRuleFunc
 type BlobRuleFunc = engine.BlobRuleFunc
+type NotificationRuleFunc = engine.NotificationRuleFunc
 
 var (
 	ReportReasonSpam       = engine.ReportReasonSpam

--- a/automod/rules/all.go
+++ b/automod/rules/all.go
@@ -38,6 +38,9 @@ func DefaultRules() automod.RuleSet {
 		BlobRules: []automod.BlobRuleFunc{
 			//BlobVerifyRule,
 		},
+		NotificationRules: []automod.NotificationRuleFunc{
+			// none
+		},
 	}
 	return rules
 }


### PR DESCRIPTION
This is prep work to get automod inserted in to our push notification service as a library.

Relatively small PR, which is great.

Open questions:
- what should response to the notification service look like? here I proposed just a boolean (false for no change, true to reject the message)
- what other context and info is available? working with the original notification types might be good, though they only really exist in "view" form (with extra hydrated metadata), not as a record or something like that. probably at least the "Reason" and an AT-URI reference?