### PR TITLE
engine: remove wrapper counter and set methods

### DIFF
--- a/automod/capture/capture_test.go
+++ b/automod/capture/capture_test.go
@@ -1,6 +1,7 @@
 package capture
 
 import (
+	"context"
 	"testing"
 
 	"github.com/bluesky-social/indigo/automod/countstore"
@@ -9,15 +10,16 @@ import (
 )
 
 func TestNoOpCaptureReplyRule(t *testing.T) {
+	ctx := context.Background()
 	assert := assert.New(t)
 
 	eng := engine.EngineTestFixture()
 	capture := MustLoadCapture("testdata/capture_atprotocom.json")
 	assert.NoError(ProcessCaptureRules(&eng, capture))
-	c, err := eng.GetCount("automod-quota", "report", countstore.PeriodDay)
+	c, err := eng.Counters.GetCount(ctx, "automod-quota", "report", countstore.PeriodDay)
 	assert.NoError(err)
 	assert.Equal(0, c)
-	c, err = eng.GetCount("automod-quota", "takedown", countstore.PeriodDay)
+	c, err = eng.Counters.GetCount(ctx, "automod-quota", "takedown", countstore.PeriodDay)
 	assert.NoError(err)
 	assert.Equal(0, c)
 }

--- a/automod/engine/action_dedupe_test.go
+++ b/automod/engine/action_dedupe_test.go
@@ -48,7 +48,7 @@ func TestAccountReportDedupe(t *testing.T) {
 		assert.NoError(eng.ProcessRecordOp(ctx, op))
 	}
 
-	reports, err := eng.GetCount("automod-quota", "report", countstore.PeriodDay)
+	reports, err := eng.Counters.GetCount(ctx, "automod-quota", "report", countstore.PeriodDay)
 	assert.NoError(err)
 	assert.Equal(1, reports)
 }

--- a/automod/engine/circuit_breaker_test.go
+++ b/automod/engine/circuit_breaker_test.go
@@ -57,11 +57,11 @@ func TestTakedownCircuitBreaker(t *testing.T) {
 		assert.NoError(eng.ProcessRecordOp(ctx, op))
 	}
 
-	takedowns, err := eng.GetCount("automod-quota", "takedown", countstore.PeriodDay)
+	takedowns, err := eng.Counters.GetCount(ctx, "automod-quota", "takedown", countstore.PeriodDay)
 	assert.NoError(err)
 	assert.Equal(QuotaModTakedownDay, takedowns)
 
-	reports, err := eng.GetCount("automod-quota", "report", countstore.PeriodDay)
+	reports, err := eng.Counters.GetCount(ctx, "automod-quota", "report", countstore.PeriodDay)
 	assert.NoError(err)
 	assert.Equal(0, reports)
 }
@@ -99,11 +99,11 @@ func TestReportCircuitBreaker(t *testing.T) {
 		assert.NoError(eng.ProcessRecordOp(ctx, op))
 	}
 
-	takedowns, err := eng.GetCount("automod-quota", "takedown", countstore.PeriodDay)
+	takedowns, err := eng.Counters.GetCount(ctx, "automod-quota", "takedown", countstore.PeriodDay)
 	assert.NoError(err)
 	assert.Equal(0, takedowns)
 
-	reports, err := eng.GetCount("automod-quota", "report", countstore.PeriodDay)
+	reports, err := eng.Counters.GetCount(ctx, "automod-quota", "report", countstore.PeriodDay)
 	assert.NoError(err)
 	assert.Equal(QuotaModReportDay, reports)
 }

--- a/automod/engine/persisthelpers.go
+++ b/automod/engine/persisthelpers.go
@@ -56,7 +56,7 @@ func (eng *Engine) dedupeReportActions(ctx context.Context, did syntax.DID, repo
 	newReports := []ModReport{}
 	for _, r := range reports {
 		counterName := "automod-account-report-" + ReasonShortName(r.ReasonType)
-		existing, err := eng.GetCount(counterName, did.String(), countstore.PeriodDay)
+		existing, err := eng.Counters.GetCount(ctx, counterName, did.String(), countstore.PeriodDay)
 		if err != nil {
 			return nil, fmt.Errorf("checking report de-dupe counts: %w", err)
 		}
@@ -77,7 +77,7 @@ func (eng *Engine) circuitBreakReports(ctx context.Context, reports []ModReport)
 	if len(reports) == 0 {
 		return []ModReport{}, nil
 	}
-	c, err := eng.GetCount("automod-quota", "report", countstore.PeriodDay)
+	c, err := eng.Counters.GetCount(ctx, "automod-quota", "report", countstore.PeriodDay)
 	if err != nil {
 		return nil, fmt.Errorf("checking report action quota: %w", err)
 	}
@@ -96,7 +96,7 @@ func (eng *Engine) circuitBreakTakedown(ctx context.Context, takedown bool) (boo
 	if !takedown {
 		return false, nil
 	}
-	c, err := eng.GetCount("automod-quota", "takedown", countstore.PeriodDay)
+	c, err := eng.Counters.GetCount(ctx, "automod-quota", "takedown", countstore.PeriodDay)
 	if err != nil {
 		return false, fmt.Errorf("checking takedown action quota: %w", err)
 	}


### PR DESCRIPTION
These were from earlier API design, and are just confusing now.