### PR TITLE
make shard threshold parameter usable through admin api

### DIFF
--- a/bgs/admin.go
+++ b/bgs/admin.go
@@ -463,7 +463,17 @@ func (bgs *BGS) handleAdminCompactAllRepos(e echo.Context) error {
 		lim = v
 	}
 
-	err := bgs.compactor.EnqueueAllRepos(ctx, bgs, lim, 0, fast)
+	shardThresh := 20
+	if threshstr := e.QueryParam("threshold"); threshstr != "" {
+		v, err := strconv.Atoi(threshstr)
+		if err != nil {
+			return err
+		}
+
+		shardThresh = v
+	}
+
+	err := bgs.compactor.EnqueueAllRepos(ctx, bgs, lim, shardThresh, fast)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to enqueue all repos: %w", err))
 	}

--- a/cmd/gosky/bgs.go
+++ b/cmd/gosky/bgs.go
@@ -377,6 +377,9 @@ var bgsCompactAll = &cli.Command{
 		&cli.IntFlag{
 			Name: "limit",
 		},
+		&cli.IntFlag{
+			Name: "threshold",
+		},
 		&cli.BoolFlag{
 			Name: "fast",
 		},
@@ -399,6 +402,11 @@ var bgsCompactAll = &cli.Command{
 		if cctx.IsSet("limit") {
 			q.Add("limit", fmt.Sprint(cctx.Int("limit")))
 		}
+
+		if cctx.IsSet("threshold") {
+			q.Add("threshold", fmt.Sprint(cctx.Int("threshold")))
+		}
+
 		uu.RawQuery = q.Encode()
 
 		req, err := http.NewRequest("POST", uu.String(), nil)


### PR DESCRIPTION
currently this will always default to 20 when called (despite the comment saying 50), which is better for our purposes than the 50 that defaults in the background routine, but still should be something we can set