### PR TITLE
Fixed backfill GormJob.FlushBufferedOps not skipping final stale event

### DIFF
--- a/backfill/gormstore.go
+++ b/backfill/gormstore.go
@@ -321,7 +321,7 @@ func (j *Gormjob) FlushBufferedOps(ctx context.Context, fn func(kind, rev, path 
 	defer j.lk.Unlock()
 
 	for _, opset := range j.bufferedOps {
-		if opset.rev < j.rev {
+		if opset.rev <= j.rev {
 			// stale events, skip
 			continue
 		}


### PR DESCRIPTION
The backfiller fails to flush operations when it doesn't identify an event as stale if its `rev` is equal to the last seen `rev`. This gets caught as a discontinuity, and it returns an error:
```
2024/02/05 18:25:18 ERROR failed to flush buffered ops source=backfiller_buffer_flush repo=[repo] error="event since did not match current rev (3kkpf3r7lx22m != 3kkpf53gjgs24): buffered event revs did not line up"
```
which blocks the rest of the buffered events from being processed, and the job is eternally marked as enqueued.