### PR TITLE
hepa: add pprof endpoint, and enable block profiling.

### DIFF
--- a/cmd/hepa/main.go
+++ b/cmd/hepa/main.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -235,6 +237,8 @@ var runCmd = &cli.Command{
 
 		// prometheus HTTP endpoint: /metrics
 		go func() {
+			runtime.SetBlockProfileRate(10)
+			runtime.SetMutexProfileFraction(10)
 			if err := srv.RunMetrics(cctx.String("metrics-listen")); err != nil {
 				slog.Error("failed to start metrics endpoint", "error", err)
 				panic(fmt.Errorf("failed to start metrics endpoint: %w", err))


### PR DESCRIPTION
Hepa already has an http service for prometh metrics, and it's the http package's default one, so this continues to just dogpile on that.

With the defaults, http://localhost:3989/debug/pprof/ is now informative.

Also added nudges to the runtime to enable block profiling and mutex profiling.  Without these nudges, those reports are empty.

I picked the rate numbers here somewhat capriciously; they may need tuning to keep impact down in prod, or we may end up needing knobs for toggling this at runtime.  We'll see.

(The goroutine profiles alone, requested periodically, provide a decent sampling of data that can be used to infer some things about blocking anyway, even if that pprof feature isn't enabled explicitly!  But more data is almost always better, so I propose turning it on for now.)