### PR TITLE
identity: use shared http.Client for lookups, and close resp bodies

### DIFF
--- a/atproto/identity/handle.go
+++ b/atproto/identity/handle.go
@@ -143,6 +143,7 @@ func (d *BaseDirectory) ResolveHandleWellKnown(ctx context.Context, handle synta
 		}
 		return "", fmt.Errorf("%w: HTTP well-known request error: %w", ErrHandleResolutionFailed, err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
 		return "", fmt.Errorf("%w: HTTP 404 for %s", ErrHandleNotFound, handle)
 	}


### PR DESCRIPTION
I think these were embarrassing oversights?

For PLC in particular, want to keep HTTP/2 connections open for reuse. Less of a thing for the well-known lookups, though for the common case of `*.bsky.social` lookups, there are lots of hostnames, but all the same backing server, so hopefully still works.

`did:web` we might actually want a separate connection every time.