### PR TITLE
Update `blueskyweb.xyz` links in README.md to `bsky.social`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ The [HACKING](./HACKING.md) file has a list of commands and packages in this rep
 
 *not to be confused with the [AT command set](https://en.wikipedia.org/wiki/Hayes_command_set) or [Adenosine triphosphate](https://en.wikipedia.org/wiki/Adenosine_triphosphate)*
 
-The Authenticated Transfer Protocol ("ATP" or "atproto") is a decentralized social media protocol, developed by [Bluesky PBC](https://blueskyweb.xyz). Learn more at:
+The Authenticated Transfer Protocol ("ATP" or "atproto") is a decentralized social media protocol, developed by [Bluesky PBC](https://bsky.social). Learn more at:
 
 - [Overview and Guides](https://atproto.com/guides/overview) 👈 Best starting point
 - [Github Discussions](https://github.com/bluesky-social/atproto/discussions) 👈 Great place to ask questions
 - [Protocol Specifications](https://atproto.com/specs/atp)
-- [Blogpost on self-authenticating data structures](https://blueskyweb.xyz/blog/3-6-2022-a-self-authenticating-social-protocol)
+- [Blogpost on self-authenticating data structures](https://bsky.social/about/blog/3-6-2022-a-self-authenticating-social-protocol)
 
 The Bluesky Social application encompasses a set of schemas and APIs built in the overall AT Protocol framework. The namespace for these "Lexicons" is `app.bsky.*`.
 


### PR DESCRIPTION
This PR updates the two links in README.md that point to `blueskyweb.xyz` to the equivalent `bsky.social` URLs.

Also, I noticed that Line 13 still refers to 'Big Graph Service', should this be updated to 'Relay'?

https://github.com/bluesky-social/indigo/blob/c72ce2340db3cc99fc886c2284daf19e438c7b91/README.md?plain=1#L13