### PR TITLE
example ban evasion rule

### DIFF
--- a/automod/rules/all.go
+++ b/automod/rules/all.go
@@ -40,6 +40,7 @@ func DefaultRules() automod.RuleSet {
 			NewAccountRule,
 			BadWordHandleRule,
 			BadWordDIDRule,
+			BanEvasionHandleRule,
 		},
 		BlobRules: []automod.BlobRuleFunc{
 			//BlobVerifyRule,

--- a/automod/rules/banevasion.go
+++ b/automod/rules/banevasion.go
@@ -1,0 +1,43 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bluesky-social/indigo/automod"
+)
+
+// example rule showing how to detect a pattern in handles
+func BanEvasionHandleRule(c *automod.AccountContext) error {
+
+	// TODO: move these to config
+	patterns := []string{
+		"rapeskids",
+		"isapedo",
+		"thegroomer",
+		"isarapist",
+	}
+
+	handle := c.Account.Identity.Handle.Normalize().String()
+	email := ""
+	if c.Account.Private != nil {
+		email = strings.ToLower(c.Account.Private.Email)
+	}
+	for _, w := range patterns {
+		if strings.Contains(handle, w) {
+			c.AddAccountFlag("evasion-pattern-handle")
+			c.ReportAccount(automod.ReportReasonViolation, fmt.Sprintf("possible ban evasion pattern (username): %s", w))
+			c.Notify("slack")
+			break
+		}
+		if email != "" && strings.Contains(email, w) {
+			c.AddAccountFlag("evasion-pattern-email")
+			c.ReportAccount(automod.ReportReasonViolation, fmt.Sprintf("possible ban evasion pattern (email): %s", w))
+			c.Notify("slack")
+			break
+		}
+	}
+	return nil
+}
+
+var _ automod.IdentityRuleFunc = BanEvasionHandleRule


### PR DESCRIPTION
This isn't really going to work until we get identities on the event stream. And should get the strings in some config API, not hardcoded.