### PR TITLE
automod: defer parsing

### DIFF
--- a/automod/capture/fetch.go
+++ b/automod/capture/fetch.go
@@ -47,7 +47,7 @@ func FetchAndProcessRecord(ctx context.Context, eng *automod.Engine, aturi synta
 		Collection: aturi.Collection(),
 		RecordKey:  aturi.RecordKey(),
 		CID:        &recCID,
-		RecordCBOR: &recBytes,
+		RecordCBOR: recBytes,
 	}
 	return eng.ProcessRecordOp(ctx, op)
 }
@@ -96,7 +96,7 @@ func FetchAndProcessRecent(ctx context.Context, eng *automod.Engine, atid syntax
 			Collection: aturi.Collection(),
 			RecordKey:  aturi.RecordKey(),
 			CID:        &recCID,
-			RecordCBOR: &recBytes,
+			RecordCBOR: recBytes,
 		}
 		err = eng.ProcessRecordOp(ctx, op)
 		if err != nil {

--- a/automod/capture/fetch.go
+++ b/automod/capture/fetch.go
@@ -1,6 +1,7 @@
 package capture
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -35,13 +36,18 @@ func FetchAndProcessRecord(ctx context.Context, eng *automod.Engine, aturi synta
 		return fmt.Errorf("expected a CID in getRecord response")
 	}
 	recCID := syntax.CID(*out.Cid)
+	recBuf := new(bytes.Buffer)
+	if err := out.Value.Val.MarshalCBOR(recBuf); err != nil {
+		return err
+	}
+	recBytes := recBuf.Bytes()
 	op := automod.RecordOp{
 		Action:     automod.CreateOp,
 		DID:        ident.DID,
 		Collection: aturi.Collection(),
 		RecordKey:  aturi.RecordKey(),
 		CID:        &recCID,
-		Value:      out.Value.Val,
+		RecordCBOR: &recBytes,
 	}
 	return eng.ProcessRecordOp(ctx, op)
 }
@@ -79,13 +85,18 @@ func FetchAndProcessRecent(ctx context.Context, eng *automod.Engine, atid syntax
 			return fmt.Errorf("parsing PDS record response: %v", err)
 		}
 		recCID := syntax.CID(rec.Cid)
+		recBuf := new(bytes.Buffer)
+		if err := rec.Value.Val.MarshalCBOR(recBuf); err != nil {
+			return err
+		}
+		recBytes := recBuf.Bytes()
 		op := automod.RecordOp{
 			Action:     automod.CreateOp,
 			DID:        ident.DID,
 			Collection: aturi.Collection(),
 			RecordKey:  aturi.RecordKey(),
 			CID:        &recCID,
-			Value:      rec.Value.Val,
+			RecordCBOR: &recBytes,
 		}
 		err = eng.ProcessRecordOp(ctx, op)
 		if err != nil {

--- a/automod/capture/testing.go
+++ b/automod/capture/testing.go
@@ -68,7 +68,7 @@ func ProcessCaptureRules(eng *automod.Engine, capture AccountCapture) error {
 			Collection: aturi.Collection(),
 			RecordKey:  aturi.RecordKey(),
 			CID:        &recCID,
-			RecordCBOR: &recBytes,
+			RecordCBOR: recBytes,
 		}
 		eng.ProcessRecordOp(ctx, op)
 	}

--- a/automod/capture/testing.go
+++ b/automod/capture/testing.go
@@ -1,6 +1,7 @@
 package capture
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -55,6 +56,11 @@ func ProcessCaptureRules(eng *automod.Engine, capture AccountCapture) error {
 			return err
 		}
 		recCID := syntax.CID(pr.Cid)
+		recBuf := new(bytes.Buffer)
+		if err := pr.Value.Val.MarshalCBOR(recBuf); err != nil {
+			return err
+		}
+		recBytes := recBuf.Bytes()
 		eng.Logger.Debug("processing record", "did", did)
 		op := automod.RecordOp{
 			Action:     automod.CreateOp,
@@ -62,7 +68,7 @@ func ProcessCaptureRules(eng *automod.Engine, capture AccountCapture) error {
 			Collection: aturi.Collection(),
 			RecordKey:  aturi.RecordKey(),
 			CID:        &recCID,
-			Value:      pr.Value.Val,
+			RecordCBOR: &recBytes,
 		}
 		eng.ProcessRecordOp(ctx, op)
 	}

--- a/automod/engine/action_dedupe_test.go
+++ b/automod/engine/action_dedupe_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -30,6 +31,9 @@ func TestAccountReportDedupe(t *testing.T) {
 	//path := "app.bsky.feed.post/abc123"
 	cid1 := syntax.CID("cid123")
 	p1 := appbsky.FeedPost{Text: "some post blah"}
+	p1buf := new(bytes.Buffer)
+	assert.NoError(p1.MarshalCBOR(p1buf))
+	p1cbor := p1buf.Bytes()
 	id1 := identity.Identity{
 		DID:    syntax.DID("did:plc:abc111"),
 		Handle: syntax.Handle("handle.example.com"),
@@ -42,7 +46,7 @@ func TestAccountReportDedupe(t *testing.T) {
 		Collection: "app.bsky.feed.post",
 		RecordKey:  "abc123",
 		CID:        &cid1,
-		Value:      &p1,
+		RecordCBOR: &p1cbor,
 	}
 	for i := 0; i < 5; i++ {
 		assert.NoError(eng.ProcessRecordOp(ctx, op))

--- a/automod/engine/action_dedupe_test.go
+++ b/automod/engine/action_dedupe_test.go
@@ -46,7 +46,7 @@ func TestAccountReportDedupe(t *testing.T) {
 		Collection: "app.bsky.feed.post",
 		RecordKey:  "abc123",
 		CID:        &cid1,
-		RecordCBOR: &p1cbor,
+		RecordCBOR: p1cbor,
 	}
 	for i := 0; i < 5; i++ {
 		assert.NoError(eng.ProcessRecordOp(ctx, op))

--- a/automod/engine/blobs.go
+++ b/automod/engine/blobs.go
@@ -22,7 +22,7 @@ func (c *RecordContext) Blobs() ([]lexutil.LexBlob, error) {
 		return []lexutil.LexBlob{}, nil
 	}
 
-	rec, err := data.UnmarshalCBOR(*c.RecordOp.RecordCBOR)
+	rec, err := data.UnmarshalCBOR(c.RecordOp.RecordCBOR)
 	if err != nil {
 		return nil, fmt.Errorf("parsing generic record CBOR: %v", err)
 	}

--- a/automod/engine/circuit_breaker_test.go
+++ b/automod/engine/circuit_breaker_test.go
@@ -56,7 +56,7 @@ func TestTakedownCircuitBreaker(t *testing.T) {
 			Collection: syntax.NSID("app.bsky.feed.post"),
 			RecordKey:  syntax.RecordKey("abc123"),
 			CID:        &cid1,
-			RecordCBOR: &p1cbor,
+			RecordCBOR: p1cbor,
 		}
 		assert.NoError(eng.ProcessRecordOp(ctx, op))
 	}
@@ -101,7 +101,7 @@ func TestReportCircuitBreaker(t *testing.T) {
 			Collection: syntax.NSID("app.bsky.feed.post"),
 			RecordKey:  syntax.RecordKey("abc123"),
 			CID:        &cid1,
-			RecordCBOR: &p1cbor,
+			RecordCBOR: p1cbor,
 		}
 		assert.NoError(eng.ProcessRecordOp(ctx, op))
 	}

--- a/automod/engine/circuit_breaker_test.go
+++ b/automod/engine/circuit_breaker_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -38,6 +39,9 @@ func TestTakedownCircuitBreaker(t *testing.T) {
 
 	cid1 := syntax.CID("cid123")
 	p1 := appbsky.FeedPost{Text: "some post blah"}
+	p1buf := new(bytes.Buffer)
+	assert.NoError(p1.MarshalCBOR(p1buf))
+	p1cbor := p1buf.Bytes()
 
 	// generate double the quote of events; expect to only count the quote worth of actions
 	for i := 0; i < 2*QuotaModTakedownDay; i++ {
@@ -52,7 +56,7 @@ func TestTakedownCircuitBreaker(t *testing.T) {
 			Collection: syntax.NSID("app.bsky.feed.post"),
 			RecordKey:  syntax.RecordKey("abc123"),
 			CID:        &cid1,
-			Value:      &p1,
+			RecordCBOR: &p1cbor,
 		}
 		assert.NoError(eng.ProcessRecordOp(ctx, op))
 	}
@@ -80,6 +84,9 @@ func TestReportCircuitBreaker(t *testing.T) {
 
 	cid1 := syntax.CID("cid123")
 	p1 := appbsky.FeedPost{Text: "some post blah"}
+	p1buf := new(bytes.Buffer)
+	assert.NoError(p1.MarshalCBOR(p1buf))
+	p1cbor := p1buf.Bytes()
 
 	// generate double the quota of events; expect to only count the quota worth of actions
 	for i := 0; i < 2*QuotaModReportDay; i++ {
@@ -94,7 +101,7 @@ func TestReportCircuitBreaker(t *testing.T) {
 			Collection: syntax.NSID("app.bsky.feed.post"),
 			RecordKey:  syntax.RecordKey("abc123"),
 			CID:        &cid1,
-			Value:      &p1,
+			RecordCBOR: &p1cbor,
 		}
 		assert.NoError(eng.ProcessRecordOp(ctx, op))
 	}

--- a/automod/engine/context.go
+++ b/automod/engine/context.go
@@ -52,7 +52,7 @@ type RecordOp struct {
 	Collection syntax.NSID
 	RecordKey  syntax.RecordKey
 	CID        *syntax.CID
-	RecordCBOR *[]byte
+	RecordCBOR []byte
 }
 
 // Originally intended for push notifications, but can also work for any inter-account notification.

--- a/automod/engine/context.go
+++ b/automod/engine/context.go
@@ -52,8 +52,7 @@ type RecordOp struct {
 	Collection syntax.NSID
 	RecordKey  syntax.RecordKey
 	CID        *syntax.CID
-	// NOTE: usually a *pointer*, not the value itself
-	Value any
+	RecordCBOR *[]byte
 }
 
 // Originally intended for push notifications, but can also work for any inter-account notification.
@@ -76,11 +75,11 @@ type NotificationMeta struct {
 func (op *RecordOp) Validate() error {
 	switch op.Action {
 	case CreateOp, UpdateOp:
-		if op.Value == nil || op.CID == nil {
+		if op.RecordCBOR == nil || op.CID == nil {
 			return fmt.Errorf("expected record create/update op to contain both value and CID")
 		}
 	case DeleteOp:
-		if op.Value != nil || op.CID != nil {
+		if op.RecordCBOR != nil || op.CID != nil {
 			return fmt.Errorf("expected record delete op to be empty")
 		}
 	default:

--- a/automod/engine/engine_test.go
+++ b/automod/engine/engine_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -24,13 +25,17 @@ func TestEngineBasics(t *testing.T) {
 	p1 := appbsky.FeedPost{
 		Text: "some post blah",
 	}
+	p1buf := new(bytes.Buffer)
+	assert.NoError(p1.MarshalCBOR(p1buf))
+	p1cbor := p1buf.Bytes()
+
 	op := RecordOp{
 		Action:     CreateOp,
 		DID:        id1.DID,
 		Collection: syntax.NSID("app.bsky.feed.post"),
 		RecordKey:  syntax.RecordKey("abc123"),
 		CID:        &cid1,
-		Value:      &p1,
+		RecordCBOR: &p1cbor,
 	}
 	assert.NoError(eng.ProcessRecordOp(ctx, op))
 
@@ -38,6 +43,9 @@ func TestEngineBasics(t *testing.T) {
 		Text: "some post blah",
 		Tags: []string{"one", "slur"},
 	}
-	op.Value = &p2
+	p2buf := new(bytes.Buffer)
+	assert.NoError(p2.MarshalCBOR(p2buf))
+	p2cbor := p2buf.Bytes()
+	op.RecordCBOR = &p2cbor
 	assert.NoError(eng.ProcessRecordOp(ctx, op))
 }

--- a/automod/engine/engine_test.go
+++ b/automod/engine/engine_test.go
@@ -35,7 +35,7 @@ func TestEngineBasics(t *testing.T) {
 		Collection: syntax.NSID("app.bsky.feed.post"),
 		RecordKey:  syntax.RecordKey("abc123"),
 		CID:        &cid1,
-		RecordCBOR: &p1cbor,
+		RecordCBOR: p1cbor,
 	}
 	assert.NoError(eng.ProcessRecordOp(ctx, op))
 
@@ -46,6 +46,6 @@ func TestEngineBasics(t *testing.T) {
 	p2buf := new(bytes.Buffer)
 	assert.NoError(p2.MarshalCBOR(p2buf))
 	p2cbor := p2buf.Bytes()
-	op.RecordCBOR = &p2cbor
+	op.RecordCBOR = p2cbor
 	assert.NoError(eng.ProcessRecordOp(ctx, op))
 }

--- a/automod/engine/ruleset.go
+++ b/automod/engine/ruleset.go
@@ -33,7 +33,7 @@ func (r *RuleSet) CallRecordRules(c *RecordContext) error {
 	switch c.RecordOp.Collection.String() {
 	case "app.bsky.feed.post":
 		var post appbsky.FeedPost
-		if err := post.UnmarshalCBOR(bytes.NewReader(*c.RecordOp.RecordCBOR)); err != nil {
+		if err := post.UnmarshalCBOR(bytes.NewReader(c.RecordOp.RecordCBOR)); err != nil {
 			return fmt.Errorf("failed to parse app.bsky.feed.post record: %v", err)
 		}
 		for _, f := range r.PostRules {
@@ -44,7 +44,7 @@ func (r *RuleSet) CallRecordRules(c *RecordContext) error {
 		}
 	case "app.bsky.actor.profile":
 		var profile appbsky.ActorProfile
-		if err := profile.UnmarshalCBOR(bytes.NewReader(*c.RecordOp.RecordCBOR)); err != nil {
+		if err := profile.UnmarshalCBOR(bytes.NewReader(c.RecordOp.RecordCBOR)); err != nil {
 			return fmt.Errorf("failed to parse app.bsky.actor.profile record: %v", err)
 		}
 		for _, f := range r.ProfileRules {

--- a/automod/rules/hashtags_test.go
+++ b/automod/rules/hashtags_test.go
@@ -38,7 +38,7 @@ func TestBadHashtagPostRule(t *testing.T) {
 		Collection: syntax.NSID("app.bsky.feed.post"),
 		RecordKey:  syntax.RecordKey("abc123"),
 		CID:        &cid1,
-		RecordCBOR: &p1cbor,
+		RecordCBOR: p1cbor,
 	}
 	c1 := engine.NewRecordContext(ctx, &eng, am1, op)
 	assert.NoError(BadHashtagsPostRule(&c1, &p1))
@@ -52,7 +52,7 @@ func TestBadHashtagPostRule(t *testing.T) {
 	p2buf := new(bytes.Buffer)
 	assert.NoError(p2.MarshalCBOR(p2buf))
 	p2cbor := p2buf.Bytes()
-	op.RecordCBOR = &p2cbor
+	op.RecordCBOR = p2cbor
 	c2 := engine.NewRecordContext(ctx, &eng, am1, op)
 	assert.NoError(BadHashtagsPostRule(&c2, &p2))
 	eff2 := engine.ExtractEffects(&c2.BaseContext)

--- a/automod/rules/hashtags_test.go
+++ b/automod/rules/hashtags_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -28,13 +29,16 @@ func TestBadHashtagPostRule(t *testing.T) {
 	p1 := appbsky.FeedPost{
 		Text: "some post blah",
 	}
+	p1buf := new(bytes.Buffer)
+	assert.NoError(p1.MarshalCBOR(p1buf))
+	p1cbor := p1buf.Bytes()
 	op := engine.RecordOp{
 		Action:     engine.CreateOp,
 		DID:        am1.Identity.DID,
 		Collection: syntax.NSID("app.bsky.feed.post"),
 		RecordKey:  syntax.RecordKey("abc123"),
 		CID:        &cid1,
-		Value:      p1,
+		RecordCBOR: &p1cbor,
 	}
 	c1 := engine.NewRecordContext(ctx, &eng, am1, op)
 	assert.NoError(BadHashtagsPostRule(&c1, &p1))
@@ -45,7 +49,10 @@ func TestBadHashtagPostRule(t *testing.T) {
 		Text: "some post blah",
 		Tags: []string{"one", "slur"},
 	}
-	op.Value = p2
+	p2buf := new(bytes.Buffer)
+	assert.NoError(p2.MarshalCBOR(p2buf))
+	p2cbor := p2buf.Bytes()
+	op.RecordCBOR = &p2cbor
 	c2 := engine.NewRecordContext(ctx, &eng, am1, op)
 	assert.NoError(BadHashtagsPostRule(&c2, &p2))
 	eff2 := engine.ExtractEffects(&c2.BaseContext)

--- a/automod/rules/keyword.go
+++ b/automod/rules/keyword.go
@@ -84,7 +84,7 @@ func BadWordOtherRecordRule(c *automod.RecordContext) error {
 	switch c.RecordOp.Collection.String() {
 	case "app.bsky.graph.list":
 		var list appbsky.GraphList
-		if err := list.UnmarshalCBOR(bytes.NewReader(*c.RecordOp.RecordCBOR)); err != nil {
+		if err := list.UnmarshalCBOR(bytes.NewReader(c.RecordOp.RecordCBOR)); err != nil {
 			return fmt.Errorf("failed to parse app.bsky.graph.list record: %v", err)
 		}
 		name += " " + list.Name
@@ -96,7 +96,7 @@ func BadWordOtherRecordRule(c *automod.RecordContext) error {
 		}
 	case "app.bsky.feed.generator":
 		var generator appbsky.FeedGenerator
-		if err := generator.UnmarshalCBOR(bytes.NewReader(*c.RecordOp.RecordCBOR)); err != nil {
+		if err := generator.UnmarshalCBOR(bytes.NewReader(c.RecordOp.RecordCBOR)); err != nil {
 			return fmt.Errorf("failed to parse app.bsky.feed.generator record: %v", err)
 		}
 		name += " " + generator.DisplayName

--- a/automod/rules/keyword.go
+++ b/automod/rules/keyword.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -82,9 +83,9 @@ func BadWordOtherRecordRule(c *automod.RecordContext) error {
 	text := ""
 	switch c.RecordOp.Collection.String() {
 	case "app.bsky.graph.list":
-		list, ok := c.RecordOp.Value.(*appbsky.GraphList)
-		if !ok {
-			return fmt.Errorf("mismatch between collection (%s) and type", c.RecordOp.Collection)
+		var list appbsky.GraphList
+		if err := list.UnmarshalCBOR(bytes.NewReader(*c.RecordOp.RecordCBOR)); err != nil {
+			return fmt.Errorf("failed to parse app.bsky.graph.list record: %v", err)
 		}
 		name += " " + list.Name
 		if list.Description != nil {
@@ -94,9 +95,9 @@ func BadWordOtherRecordRule(c *automod.RecordContext) error {
 			text += " " + *list.Purpose
 		}
 	case "app.bsky.feed.generator":
-		generator, ok := c.RecordOp.Value.(*appbsky.FeedGenerator)
-		if !ok {
-			return fmt.Errorf("mismatch between collection (%s) and type", c.RecordOp.Collection)
+		var generator appbsky.FeedGenerator
+		if err := generator.UnmarshalCBOR(bytes.NewReader(*c.RecordOp.RecordCBOR)); err != nil {
+			return fmt.Errorf("failed to parse app.bsky.feed.generator record: %v", err)
 		}
 		name += " " + generator.DisplayName
 		if generator.Description != nil {

--- a/automod/rules/keyword_test.go
+++ b/automod/rules/keyword_test.go
@@ -80,7 +80,7 @@ func TestBadWordPostRule(t *testing.T) {
 		Collection: syntax.NSID("app.bsky.feed.post"),
 		RecordKey:  syntax.RecordKey("fagg0t"),
 		CID:        &cid1,
-		RecordCBOR: &p1cbor,
+		RecordCBOR: p1cbor,
 	}
 	c1 := engine.NewRecordContext(ctx, &eng, am1, op)
 	assert.NoError(BadWordRecordKeyRule(&c1))
@@ -100,7 +100,7 @@ func TestBadWordPostRule(t *testing.T) {
 		Collection: syntax.NSID("app.bsky.feed.post"),
 		RecordKey:  syntax.RecordKey("abc123"),
 		CID:        &cid1,
-		RecordCBOR: &p2cbor,
+		RecordCBOR: p2cbor,
 	}
 	c2 := engine.NewRecordContext(ctx, &eng, am1, op2)
 	assert.NoError(BadWordPostRule(&c2, &p2))

--- a/automod/rules/keyword_test.go
+++ b/automod/rules/keyword_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -70,13 +71,16 @@ func TestBadWordPostRule(t *testing.T) {
 	p1 := appbsky.FeedPost{
 		Text: "some post blah",
 	}
+	p1buf := new(bytes.Buffer)
+	assert.NoError(p1.MarshalCBOR(p1buf))
+	p1cbor := p1buf.Bytes()
 	op := engine.RecordOp{
 		Action:     engine.CreateOp,
 		DID:        am1.Identity.DID,
 		Collection: syntax.NSID("app.bsky.feed.post"),
 		RecordKey:  syntax.RecordKey("fagg0t"),
 		CID:        &cid1,
-		Value:      p1,
+		RecordCBOR: &p1cbor,
 	}
 	c1 := engine.NewRecordContext(ctx, &eng, am1, op)
 	assert.NoError(BadWordRecordKeyRule(&c1))
@@ -87,13 +91,16 @@ func TestBadWordPostRule(t *testing.T) {
 	p2 := appbsky.FeedPost{
 		Text: "some post hardestr blah",
 	}
+	p2buf := new(bytes.Buffer)
+	assert.NoError(p2.MarshalCBOR(p2buf))
+	p2cbor := p2buf.Bytes()
 	op2 := engine.RecordOp{
 		Action:     engine.CreateOp,
 		DID:        am1.Identity.DID,
 		Collection: syntax.NSID("app.bsky.feed.post"),
 		RecordKey:  syntax.RecordKey("abc123"),
 		CID:        &cid1,
-		Value:      p1,
+		RecordCBOR: &p2cbor,
 	}
 	c2 := engine.NewRecordContext(ctx, &eng, am1, op2)
 	assert.NoError(BadWordPostRule(&c2, &p2))

--- a/automod/rules/misleading_test.go
+++ b/automod/rules/misleading_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
 	"testing"
@@ -44,13 +45,16 @@ func TestMisleadingURLPostRule(t *testing.T) {
 			},
 		},
 	}
+	p1buf := new(bytes.Buffer)
+	assert.NoError(p1.MarshalCBOR(p1buf))
+	p1cbor := p1buf.Bytes()
 	op := engine.RecordOp{
 		Action:     engine.CreateOp,
 		DID:        am1.Identity.DID,
 		Collection: syntax.NSID("app.bsky.feed.post"),
 		RecordKey:  syntax.RecordKey("abc123"),
 		CID:        &cid1,
-		Value:      p1,
+		RecordCBOR: &p1cbor,
 	}
 	c1 := engine.NewRecordContext(ctx, &eng, am1, op)
 	assert.NoError(MisleadingURLPostRule(&c1, &p1))
@@ -88,13 +92,16 @@ func TestMisleadingMentionPostRule(t *testing.T) {
 			},
 		},
 	}
+	p1buf := new(bytes.Buffer)
+	assert.NoError(p1.MarshalCBOR(p1buf))
+	p1cbor := p1buf.Bytes()
 	op := engine.RecordOp{
 		Action:     engine.CreateOp,
 		DID:        am1.Identity.DID,
 		Collection: syntax.NSID("app.bsky.feed.post"),
 		RecordKey:  syntax.RecordKey("abc123"),
 		CID:        &cid1,
-		Value:      p1,
+		RecordCBOR: &p1cbor,
 	}
 	c1 := engine.NewRecordContext(ctx, &eng, am1, op)
 	assert.NoError(MisleadingMentionPostRule(&c1, &p1))

--- a/automod/rules/misleading_test.go
+++ b/automod/rules/misleading_test.go
@@ -54,7 +54,7 @@ func TestMisleadingURLPostRule(t *testing.T) {
 		Collection: syntax.NSID("app.bsky.feed.post"),
 		RecordKey:  syntax.RecordKey("abc123"),
 		CID:        &cid1,
-		RecordCBOR: &p1cbor,
+		RecordCBOR: p1cbor,
 	}
 	c1 := engine.NewRecordContext(ctx, &eng, am1, op)
 	assert.NoError(MisleadingURLPostRule(&c1, &p1))
@@ -101,7 +101,7 @@ func TestMisleadingMentionPostRule(t *testing.T) {
 		Collection: syntax.NSID("app.bsky.feed.post"),
 		RecordKey:  syntax.RecordKey("abc123"),
 		CID:        &cid1,
-		RecordCBOR: &p1cbor,
+		RecordCBOR: p1cbor,
 	}
 	c1 := engine.NewRecordContext(ctx, &eng, am1, op)
 	assert.NoError(MisleadingMentionPostRule(&c1, &p1))

--- a/cmd/hepa/consumer.go
+++ b/cmd/hepa/consumer.go
@@ -188,7 +188,7 @@ func (s *Server) HandleRepoCommit(ctx context.Context, evt *comatproto.SyncSubsc
 				Collection: collection,
 				RecordKey:  rkey,
 				CID:        &recCID,
-				RecordCBOR: recCBOR,
+				RecordCBOR: *recCBOR,
 			})
 			if err != nil {
 				logger.Error("engine failed to process record", "err", err)

--- a/cmd/hepa/consumer.go
+++ b/cmd/hepa/consumer.go
@@ -161,8 +161,8 @@ func (s *Server) HandleRepoCommit(ctx context.Context, evt *comatproto.SyncSubsc
 		ek := repomgr.EventKind(op.Action)
 		switch ek {
 		case repomgr.EvtKindCreateRecord, repomgr.EvtKindUpdateRecord:
-			// read the record from blocks, and verify CID
-			rc, rec, err := rr.GetRecord(ctx, op.Path)
+			// read the record bytes from blocks, and verify CID
+			rc, recCBOR, err := rr.GetRecordBytes(ctx, op.Path)
 			if err != nil {
 				logger.Error("reading record from event blocks (CAR)", "err", err)
 				break
@@ -188,7 +188,7 @@ func (s *Server) HandleRepoCommit(ctx context.Context, evt *comatproto.SyncSubsc
 				Collection: collection,
 				RecordKey:  rkey,
 				CID:        &recCID,
-				Value:      rec,
+				RecordCBOR: recCBOR,
 			})
 			if err != nil {
 				logger.Error("engine failed to process record", "err", err)
@@ -201,7 +201,7 @@ func (s *Server) HandleRepoCommit(ctx context.Context, evt *comatproto.SyncSubsc
 				Collection: collection,
 				RecordKey:  rkey,
 				CID:        nil,
-				Value:      nil,
+				RecordCBOR: nil,
 			})
 			if err != nil {
 				logger.Error("engine failed to process record", "err", err)


### PR DESCRIPTION
This shifts the external API for automod from taking a pre-parsed "any" struct of a record, to taking CBOR bytes. the motivation is to make it easier to work with content for which the lexicon isn't know at compile time, which will soon become much more common as we allow folks to write arbitrary record types to their repositories, and this content shows up on the relay firehose.

The `atproto/data` package knows how to parse and extract some information from generic atproto record CBOR, so it is able to pull all the blobs (`$type: blob` objects nested within records), and we can switch over to that, which is more generic (and hopefully robust) than doing schema-by-schema extraction.

For firehose content, this is all pretty straight-forward, because the records are already coming in as CBOR. in the capture system, we now do schema-specific parsing, then re-encode as CBOR from the parsed struct, which is kind of weird. and in tests records need to be marshaled to CBOR, which is a bit unfortunate. maybe some helpers would make this more idiomatic?

tested a small amount against prod firehose.