### PR TITLE
search: allow at-prefixed handle with "from:"

### DIFF
--- a/search/parse_query.go
+++ b/search/parse_query.go
@@ -43,7 +43,11 @@ func ParseQuery(ctx context.Context, dir identity.Directory, raw string) (string
 			continue
 		}
 		if strings.HasPrefix(p, "from:") && len(p) > 6 {
-			handle, err := syntax.ParseHandle(p[5:])
+			h := p[5:]
+			if h[0] == '@' {
+				h = h[1:]
+			}
+			handle, err := syntax.ParseHandle(h)
 			if err != nil {
 				keep = append(keep, p)
 				continue

--- a/search/parse_query_test.go
+++ b/search/parse_query_test.go
@@ -55,4 +55,9 @@ func TestParseQuery(t *testing.T) {
 	q, f = ParseQuery(ctx, &dir, p6)
 	assert.Equal(`some other stuff`, q)
 	assert.Equal(2, len(f))
+
+	p7 := "known from:@known.example.com"
+	q, f = ParseQuery(ctx, &dir, p7)
+	assert.Equal("known", q)
+	assert.Equal(1, len(f))
 }


### PR DESCRIPTION
has a bit of test coverage which gives me confidence, but haven't done any other testings. blast radius seems small.

closes: https://github.com/bluesky-social/atproto/issues/2028