### PR TITLE
identity: remove ParsedPublicKey caching; tweak get/parsing method names and doc-comments

### DIFF
--- a/atproto/identity/base_directory.go
+++ b/atproto/identity/base_directory.go
@@ -53,11 +53,6 @@ func (d *BaseDirectory) LookupHandle(ctx context.Context, h syntax.Handle) (*Ide
 	}
 	ident.Handle = declared
 
-	// optimistic pre-parsing of public key
-	pk, err := ident.PublicKey()
-	if nil == err {
-		ident.ParsedPublicKey = pk
-	}
 	return &ident, nil
 }
 
@@ -88,11 +83,6 @@ func (d *BaseDirectory) LookupDID(ctx context.Context, did syntax.DID) (*Identit
 		}
 	}
 
-	// optimistic pre-parsing of public key
-	pk, err := ident.PublicKey()
-	if nil == err {
-		ident.ParsedPublicKey = pk
-	}
 	return &ident, nil
 }
 

--- a/atproto/identity/identity.go
+++ b/atproto/identity/identity.go
@@ -91,9 +91,6 @@ type Identity struct {
 	AlsoKnownAs []string
 	Services    map[string]Service
 	Keys        map[string]Key
-
-	// If a valid atproto repo signing public key was parsed, it can be cached here. This is a nullable/optional field (crypto.PublicKey is an interface). Calling code should use [Identity.PublicKey] instead of accessing this member.
-	ParsedPublicKey crypto.PublicKey
 }
 
 type Key struct {
@@ -161,9 +158,6 @@ func ParseIdentity(doc *DIDDocument) Identity {
 //
 // Note that [crypto.PublicKey] is an interface, not a concrete type.
 func (i *Identity) PublicKey() (crypto.PublicKey, error) {
-	if i.ParsedPublicKey != nil {
-		return i.ParsedPublicKey, nil
-	}
 	if i.Keys == nil {
 		return nil, fmt.Errorf("identity has no atproto public key attached")
 	}
@@ -176,9 +170,6 @@ func (i *Identity) PublicKey() (crypto.PublicKey, error) {
 //
 // Note that [crypto.PublicKey] is an interface, not a concrete type.
 func (i *Identity) PublicKeyFor(forKey string) (crypto.PublicKey, error) {
-	if i.ParsedPublicKey != nil {
-		return i.ParsedPublicKey, nil
-	}
 	if i.Keys == nil {
 		return nil, fmt.Errorf("identity has no atproto public key attached")
 	}

--- a/atproto/identity/identity.go
+++ b/atproto/identity/identity.go
@@ -201,14 +201,25 @@ func (i *Identity) GetPublicKey(id string) (crypto.PublicKey, error) {
 	}
 }
 
-// The home PDS endpoint for this account, if one is included in identity metadata (returns empty string if not found).
+// The home PDS endpoint for this identity, if one is included in the DID document.
 //
-// The endpoint should be an HTTP URL with method, hostname, and optional port, and (usually) no path segments.
+// The endpoint should be an HTTP URL with method, hostname, and optional port. It may or may not include path segments.
+//
+// Returns an empty string if the serivce isn't found, or if the URL fails to parse.
 func (i *Identity) PDSEndpoint() string {
+	return i.GetServiceEndpoint("atproto_pds")
+}
+
+// Returns the service endpoint URL for specified service ID (the fragment part of identifier, not including the hash symbol).
+//
+// The endpoint should be an HTTP URL with method, hostname, and optional port. It may or may not include path segments.
+//
+// Returns an empty string if the serivce isn't found, or if the URL fails to parse.
+func (i *Identity) GetServiceEndpoint(id string) string {
 	if i.Services == nil {
 		return ""
 	}
-	endpoint, ok := i.Services["atproto_pds"]
+	endpoint, ok := i.Services[id]
 	if !ok {
 		return ""
 	}

--- a/atproto/identity/redisdir/redis_directory.go
+++ b/atproto/identity/redisdir/redis_directory.go
@@ -112,7 +112,6 @@ func (d *RedisDirectory) updateHandle(ctx context.Context, h syntax.Handle) (*ha
 		return &he, nil
 	}
 
-	ident.ParsedPublicKey = nil
 	entry := identityEntry{
 		Updated:  time.Now(),
 		Identity: ident,
@@ -195,10 +194,6 @@ func (d *RedisDirectory) ResolveHandle(ctx context.Context, h syntax.Handle) (sy
 
 func (d *RedisDirectory) updateDID(ctx context.Context, did syntax.DID) (*identityEntry, error) {
 	ident, err := d.Inner.LookupDID(ctx, did)
-	// wipe parsed public key; it's a waste of space and can't serialize
-	if nil == err {
-		ident.ParsedPublicKey = nil
-	}
 	// persist the identity lookup error, instead of processing it immediately
 	entry := identityEntry{
 		Updated:  time.Now(),

--- a/automod/capture/capture.go
+++ b/automod/capture/capture.go
@@ -26,8 +26,6 @@ func CaptureRecent(ctx context.Context, eng *automod.Engine, atid syntax.AtIdent
 		}
 	}
 
-	// clear any pre-parsed key, which would fail to marshal as JSON
-	ident.ParsedPublicKey = nil
 	am, err := eng.GetAccountMeta(ctx, ident)
 	if err != nil {
 		return nil, err

--- a/automod/capture/testdata/capture_atprotocom.json
+++ b/automod/capture/testdata/capture_atprotocom.json
@@ -18,8 +18,7 @@
           "Type": "Multikey",
           "PublicKeyMultibase": "zQ3shunBKsXixLxKtC5qeSG9E4J5RkGN57im31pcTzbNQnm5w"
         }
-      },
-      "ParsedPublicKey": null
+      }
     },
     "Profile": {
       "HasAvatar": true,

--- a/automod/engine/fetch_account_meta.go
+++ b/automod/engine/fetch_account_meta.go
@@ -16,9 +16,6 @@ func (e *Engine) GetAccountMeta(ctx context.Context, ident *identity.Identity) (
 
 	logger := e.Logger.With("did", ident.DID.String())
 
-	// wipe parsed public key; it's a waste of space and can't serialize
-	ident.ParsedPublicKey = nil
-
 	// fallback in case client wasn't configured (eg, testing)
 	if e.BskyClient == nil {
 		logger.Warn("skipping account meta hydration")

--- a/automod/rules/quick.go
+++ b/automod/rules/quick.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bluesky-social/indigo/automod"
 )
 
-var botLinkStrings = []string{"ainna13762491", "LINK押して", "→ https://tiny.one/"}
+var botLinkStrings = []string{"ainna13762491", "LINK押して", "→ https://tiny", "⇒ http://tiny"}
 var botSpamTLDs = []string{".today", ".life"}
 var botSpamStrings = []string{"515-9719"}
 

--- a/automod/rules/testdata/capture_hackerdarkweb.json
+++ b/automod/rules/testdata/capture_hackerdarkweb.json
@@ -18,8 +18,7 @@
           "Type": "Multikey",
           "PublicKeyMultibase": "zQ3sha9ULLgA6zyJmk1z2uDkpkSs4Ypou33RE8XuhwWtSHF75"
         }
-      },
-      "ParsedPublicKey": null
+      }
     },
     "Profile": {
       "HasAvatar": true,


### PR DESCRIPTION
The main thing here is removing the cached ("pre-parsed") key in the identity doc. I think this was non-trivial overhead when doing lots of lookups, and required manual override when serializing (actually caching!) the objects. I don't think we relied on the key parse caching for performance anywhere; if actual profiling shows we need it, should add as a private field, or cache externally.

`PublicKeyFor` read a bit weird and non-idiomatic to my eyes so I updated to `GetPublicKey(id)`, and added a service endpoint equivalent. If this is too nit-picky or the method is being used a bunch elsewhere (branches?) can revert that bit.