### PR TITLE
update more BGS/Relay terminology

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -3,7 +3,7 @@
 
 Run with, eg, `go run ./cmd/bigsky`):
 
-- `cmd/bigsky`: BGS+indexer daemon
+- `cmd/bigsky`: Relay+indexer daemon
 - `cmd/palomar`: search indexer and query servcie (OpenSearch)
 - `cmd/gosky`: client CLI for talking to a PDS
 - `cmd/lexgen`: codegen tool for lexicons (Lexicon JSON to Go package)
@@ -25,7 +25,7 @@ Packages:
 - `atproto/syntax`: string types and parsers for identifiers, datetimes, etc
 - `atproto/identity`: DID and handle resolution
 - `automod`: moderation and anti-spam rules engine
-- `bgs`: server implementation for crawling, etc
+- `bgs`: relay server implementation for crawling, etc
 - `carstore`: library for storing repo data in CAR files on disk, plus a metadata SQL db
 - `events`: types, codegen CBOR helpers, and persistence for event feeds
 - `indexer`: aggregator, handling like counts etc in SQL database
@@ -45,7 +45,8 @@ Packages:
 
 ## Jargon
 
-- BGS: Big Graph Service (or Server), which centrals crawls/consumes content from "all" PDSs and re-broadcasts as a firehose
+- Relay: service which crawls/consumes content from "all" PDSs and re-broadcasts as a firehose
+- BGS: Big Graph Service, previous name for what is now "Relay"
 - PDS: Personal Data Server (or Service), which stores user atproto repositories and acts as a user agent in the network
 - CLI: Command Line Tool
 - CBOR: a binary serialization format, smilar to JSON
@@ -89,12 +90,12 @@ When debugging websocket streams, the `websocat` tool (rust) can be helpful. CBO
     # consume repo events from PDS
     websocat ws://localhost:4989/events
 
-    # consume repo events from BGS
+    # consume repo events from Relay
     websocat ws://localhost:2470/events
 
-Send the BGS a ding-dong:
+Send the Relay a ding-dong:
 
-    # tell BGS to consume from PDS
+    # tell Relay to consume from PDS
     http --json post localhost:2470/add-target host="localhost:4989"
 
 Set the log level to be more verbose, using an env variable:
@@ -114,7 +115,7 @@ The `bsky.auth` file is the default place that `gosky` and other client commands
 
 ## Integrated Development
 
-Sometimes it is helpful to run a PLC, PDS, BGS, and other components, all locally on your laptop, across languages. This section describes one setup for this.
+Sometimes it is helpful to run a PLC, PDS, Relay, and other components, all locally on your laptop, across languages. This section describes one setup for this.
 
 First, you need PostgreSQL running locally. This could be via docker, or the following commands assume some kind of debian/ubuntu setup with a postgres server package installed and running.
 
@@ -139,9 +140,9 @@ Checkout the `atproto` repo in another terminal and run:
 
     make run-dev-pds
 
-In this repo (indigo), start a BGS, in two separate terminals:
+In this repo (indigo), start a Relay, in two separate terminals:
 
-    make run-dev-bgs
+    make run-dev-relay
 
 In a final terminal, run fakermaker to inject data into the system:
 

--- a/Makefile
+++ b/Makefile
@@ -78,17 +78,17 @@ cborgen: ## Run codegen tool for CBOR serialization
 run-postgres: .env ## Runs a local postgres instance
 	docker compose -f cmd/bigsky/docker-compose.yml up -d
 
-.PHONY: run-dev-bgs
-run-dev-bgs: .env ## Runs 'bigsky' BGS for local dev
+.PHONY: run-dev-relay
+run-dev-relay: .env ## Runs 'bigsky' Relay for local dev
 	GOLOG_LOG_LEVEL=info go run ./cmd/bigsky --admin-key localdev 
 # --crawl-insecure-ws 
 
-.PHONY: build-bgs-image
-build-bgs-image: ## Builds 'bigsky' BGS docker image
+.PHONY: build-relay-image
+build-relay-image: ## Builds 'bigsky' Relay docker image
 	docker build -t bigsky -f cmd/bigsky/Dockerfile .
 
-.PHONY: run-bgs-image
-run-bgs-image:
+.PHONY: run-relay-image
+run-relay-image:
 	docker run -p 2470:2470 bigsky /bigsky --admin-key localdev
 # --crawl-insecure-ws 
 

--- a/cmd/bigsky/Dockerfile
+++ b/cmd/bigsky/Dockerfile
@@ -45,5 +45,5 @@ EXPOSE 2470
 CMD ["/bigsky"]
 
 LABEL org.opencontainers.image.source=https://github.com/bluesky-social/indigo
-LABEL org.opencontainers.image.description="ATP Big Graph Server (BGS)"
+LABEL org.opencontainers.image.description="ATP Relay (aka BGS)"
 LABEL org.opencontainers.image.licenses=MIT

--- a/cmd/bigsky/README.md
+++ b/cmd/bigsky/README.md
@@ -1,6 +1,6 @@
 
-bigsky: A Big Graph Server (BGS)
-================================
+bigsky: Big Graph Server (BGS), aka Relay
+=========================================
 
 ## Database Setup
 

--- a/cmd/hepa/main.go
+++ b/cmd/hepa/main.go
@@ -41,10 +41,10 @@ func run(args []string) error {
 
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
-			Name:    "atp-bgs-host",
-			Usage:   "hostname and port of BGS to subscribe to",
+			Name:    "atp-relay-host",
+			Usage:   "hostname and port of Relay to subscribe to",
 			Value:   "wss://bsky.network",
-			EnvVars: []string{"ATP_BGS_HOST"},
+			EnvVars: []string{"ATP_RELAY_HOST", "ATP_BGS_HOST"},
 		},
 		&cli.StringFlag{
 			Name:    "atp-plc-host",
@@ -219,7 +219,7 @@ var runCmd = &cli.Command{
 		srv, err := NewServer(
 			dir,
 			Config{
-				BGSHost:             cctx.String("atp-bgs-host"),
+				RelayHost:           cctx.String("atp-relay-host"),
 				BskyHost:            cctx.String("atp-bsky-host"),
 				Logger:              logger,
 				ModHost:             cctx.String("atp-mod-host"),
@@ -286,7 +286,7 @@ func configEphemeralServer(cctx *cli.Context) (*Server, error) {
 	return NewServer(
 		dir,
 		Config{
-			BGSHost:             cctx.String("atp-bgs-host"),
+			RelayHost:           cctx.String("atp-relay-host"),
 			BskyHost:            cctx.String("atp-bsky-host"),
 			Logger:              logger,
 			ModHost:             cctx.String("atp-mod-host"),

--- a/cmd/hepa/server.go
+++ b/cmd/hepa/server.go
@@ -27,7 +27,7 @@ import (
 )
 
 type Server struct {
-	bgshost             string
+	relayHost           string
 	firehoseParallelism int
 	logger              *slog.Logger
 	engine              *automod.Engine
@@ -41,7 +41,7 @@ type Server struct {
 }
 
 type Config struct {
-	BGSHost             string
+	RelayHost           string
 	BskyHost            string
 	ModHost             string
 	ModAdminToken       string
@@ -67,9 +67,9 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 		}))
 	}
 
-	bgsws := config.BGSHost
-	if !strings.HasPrefix(bgsws, "ws") {
-		return nil, fmt.Errorf("specified bgs host must include 'ws://' or 'wss://'")
+	relayws := config.RelayHost
+	if !strings.HasPrefix(relayws, "ws") {
+		return nil, fmt.Errorf("specified relay host must include 'ws://' or 'wss://'")
 	}
 
 	// TODO: this isn't a very robust way to handle a persistent client
@@ -206,7 +206,7 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 	}
 
 	s := &Server{
-		bgshost:             config.BGSHost,
+		relayHost:           config.RelayHost,
 		firehoseParallelism: config.FirehoseParallelism,
 		logger:              logger,
 		engine:              &engine,

--- a/cmd/supercollider/main.go
+++ b/cmd/supercollider/main.go
@@ -86,7 +86,7 @@ func main() {
 
 	app := cli.App{
 		Name:    "supercollider",
-		Usage:   "atproto event noise-maker for BGS load testing",
+		Usage:   "atproto event noise-maker for Relay load testing",
 		Version: versioninfo.Short(),
 	}
 

--- a/testing/integ_test.go
+++ b/testing/integ_test.go
@@ -23,16 +23,16 @@ func init() {
 	log.SetAllLoggers(log.LevelInfo)
 }
 
-func TestBGSBasic(t *testing.T) {
+func TestRelayBasic(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping BGS test in 'short' test mode")
+		t.Skip("skipping Relay test in 'short' test mode")
 	}
 	assert := assert.New(t)
 	didr := TestPLC(t)
 	p1 := MustSetupPDS(t, ".tpds", didr)
 	p1.Run(t)
 
-	b1 := MustSetupBGS(t, didr)
+	b1 := MustSetupRelay(t, didr)
 	b1.Run(t)
 
 	b1.tr.TrialHosts = []string{p1.RawHost()}
@@ -114,9 +114,9 @@ func socialSim(t *testing.T, users []*TestUser, postiter, likeiter int) []*atpro
 	return posts
 }
 
-func TestBGSMultiPDS(t *testing.T) {
+func TestRelayMultiPDS(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping BGS test in 'short' test mode")
+		t.Skip("skipping Relay test in 'short' test mode")
 	}
 	//t.Skip("test too sleepy to run in CI for now")
 
@@ -129,7 +129,7 @@ func TestBGSMultiPDS(t *testing.T) {
 	p2 := MustSetupPDS(t, ".pdsdos", didr)
 	p2.Run(t)
 
-	b1 := MustSetupBGS(t, didr)
+	b1 := MustSetupRelay(t, didr)
 	b1.Run(t)
 
 	b1.tr.TrialHosts = []string{p1.RawHost(), p2.RawHost()}
@@ -158,7 +158,7 @@ func TestBGSMultiPDS(t *testing.T) {
 
 	users[0].Reply(t, p2posts[0], p2posts[0], "what a wonderful life")
 
-	// now if we make posts on pds 2, the bgs will not hear about those new posts
+	// now if we make posts on pds 2, the relay will not hear about those new posts
 
 	p2posts2 := socialSim(t, users2, 10, 10)
 
@@ -168,12 +168,12 @@ func TestBGSMultiPDS(t *testing.T) {
 	p2.BumpLimits(t, b1)
 	time.Sleep(time.Millisecond * 50)
 
-	// Now, the bgs will discover a gap, and have to catch up somehow
+	// Now, the relay will discover a gap, and have to catch up somehow
 	socialSim(t, users2, 1, 0)
 
 	time.Sleep(time.Second)
 
-	// we expect the bgs to learn about posts that it did not directly see from
+	// we expect the relay to learn about posts that it did not directly see from
 	// repos its already partially scraped, as long as its seen *something* after the missing post
 	// this is the 'catchup' process
 	ctx := context.Background()
@@ -183,9 +183,9 @@ func TestBGSMultiPDS(t *testing.T) {
 	}
 }
 
-func TestBGSMultiGap(t *testing.T) {
+func TestRelayMultiGap(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping BGS test in 'short' test mode")
+		t.Skip("skipping Relay test in 'short' test mode")
 	}
 	//t.Skip("test too sleepy to run in CI for now")
 	assert := assert.New(t)
@@ -197,7 +197,7 @@ func TestBGSMultiGap(t *testing.T) {
 	p2 := MustSetupPDS(t, ".pdsdos", didr)
 	p2.Run(t)
 
-	b1 := MustSetupBGS(t, didr)
+	b1 := MustSetupRelay(t, didr)
 	b1.Run(t)
 
 	b1.tr.TrialHosts = []string{p1.RawHost(), p2.RawHost()}
@@ -223,7 +223,7 @@ func TestBGSMultiGap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// now if we make posts on pds 2, the bgs will not hear about those new posts
+	// now if we make posts on pds 2, the relay will not hear about those new posts
 
 	p2posts2 := socialSim(t, users2, 10, 0)
 
@@ -233,12 +233,12 @@ func TestBGSMultiGap(t *testing.T) {
 	p2.BumpLimits(t, b1)
 	time.Sleep(time.Second * 2)
 
-	// Now, the bgs will discover a gap, and have to catch up somehow
+	// Now, the relay will discover a gap, and have to catch up somehow
 	socialSim(t, users2, 1, 0)
 
 	time.Sleep(time.Second * 2)
 
-	// we expect the bgs to learn about posts that it did not directly see from
+	// we expect the relay to learn about posts that it did not directly see from
 	// repos its already partially scraped, as long as its seen *something* after the missing post
 	// this is the 'catchup' process
 	_, err = b1.bgs.Index.GetPost(ctx, p2posts2[4].Uri)
@@ -255,7 +255,7 @@ func TestHandleChange(t *testing.T) {
 	p1 := MustSetupPDS(t, ".pdsuno", didr)
 	p1.Run(t)
 
-	b1 := MustSetupBGS(t, didr)
+	b1 := MustSetupRelay(t, didr)
 	b1.Run(t)
 
 	b1.tr.TrialHosts = []string{p1.RawHost()}
@@ -268,7 +268,7 @@ func TestHandleChange(t *testing.T) {
 
 	u := p1.MustNewUser(t, usernames[0]+".pdsuno")
 
-	// if the handle changes before the bgs processes the first event, things
+	// if the handle changes before the relay processes the first event, things
 	// get a little weird
 	time.Sleep(time.Millisecond * 50)
 	//socialSim(t, []*testUser{u}, 10, 0)
@@ -285,9 +285,9 @@ func TestHandleChange(t *testing.T) {
 	fmt.Println(idevt.RepoIdentity)
 }
 
-func TestBGSTakedown(t *testing.T) {
+func TestRelayTakedown(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping BGS test in 'short' test mode")
+		t.Skip("skipping Relay test in 'short' test mode")
 	}
 	assert := assert.New(t)
 	_ = assert
@@ -296,7 +296,7 @@ func TestBGSTakedown(t *testing.T) {
 	p1 := MustSetupPDS(t, ".tpds", didr)
 	p1.Run(t)
 
-	b1 := MustSetupBGS(t, didr)
+	b1 := MustSetupRelay(t, didr)
 	b1.Run(t)
 
 	b1.tr.TrialHosts = []string{p1.RawHost()}
@@ -371,11 +371,11 @@ func commitFromSlice(t *testing.T, slice []byte, rcid cid.Cid) *repo.SignedCommi
 
 func TestDomainBans(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping BGS test in 'short' test mode")
+		t.Skip("skipping Relay test in 'short' test mode")
 	}
 	didr := TestPLC(t)
 
-	b1 := MustSetupBGS(t, didr)
+	b1 := MustSetupRelay(t, didr)
 	b1.Run(t)
 
 	b1.BanDomain(t, "foo.com")
@@ -409,16 +409,16 @@ func TestDomainBans(t *testing.T) {
 	}
 }
 
-func TestBGSHandleEmptyEvent(t *testing.T) {
+func TestRelayHandleEmptyEvent(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping BGS test in 'short' test mode")
+		t.Skip("skipping Relay test in 'short' test mode")
 	}
 	assert := assert.New(t)
 	didr := TestPLC(t)
 	p1 := MustSetupPDS(t, ".tpds", didr)
 	p1.Run(t)
 
-	b1 := MustSetupBGS(t, didr)
+	b1 := MustSetupRelay(t, didr)
 	b1.Run(t)
 
 	b1.tr.TrialHosts = []string{p1.RawHost()}


### PR DESCRIPTION
not very high-priority, but noticed these doing some palomar work and did a cleanup.

didn't want to touch the actual bgs package and bigsky code base.

the CLI arg parsing stuff makes it easy to keep the old env vars around, which means this shouldn't impact deploys with old config.