### PR TITLE
palomar: special-case Japanese text indexing using kuromoji

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,11 @@ cborgen: ## Run codegen tool for CBOR serialization
 run-postgres: .env ## Runs a local postgres instance
 	docker compose -f cmd/bigsky/docker-compose.yml up -d
 
+.PHONY: run-dev-opensearch
+run-dev-opensearch: .env ## Runs a local opensearch instance
+	docker build -f cmd/palomar/Dockerfile.opensearch . -t opensearch-palomar
+	docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "plugins.security.disabled=true" -e "OPENSEARCH_INITIAL_ADMIN_PASSWORD=0penSearch-Pal0mar" opensearch-palomar
+
 .PHONY: run-dev-relay
 run-dev-relay: .env ## Runs 'bigsky' Relay for local dev
 	GOLOG_LOG_LEVEL=info go run ./cmd/bigsky --admin-key localdev 

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ test-short: ## Run tests, skipping slower integration tests
 test-interop: ## Run tests, including local interop (requires services running)
 	go clean -testcache && go test -tags=localinterop ./...
 
+.PHONY: test-search
+test-search: ## Run tests, including local search indexing (requires services running)
+	go clean -testcache && go test -tags=localsearch ./...
+
 .PHONY: coverage-html
 coverage-html: ## Generate test coverage report and open in browser
 	go test ./... -coverpkg=./... -coverprofile=test-coverage.out

--- a/cmd/palomar/Dockerfile.opensearch
+++ b/cmd/palomar/Dockerfile.opensearch
@@ -1,2 +1,3 @@
-FROM opensearchproject/opensearch:2.5.0
+FROM opensearchproject/opensearch:2.13.0
 RUN /usr/share/opensearch/bin/opensearch-plugin install --batch analysis-icu
+RUN /usr/share/opensearch/bin/opensearch-plugin install --batch analysis-kuromoji

--- a/cmd/palomar/README.md
+++ b/cmd/palomar/README.md
@@ -64,10 +64,12 @@ Response:
 
 ## Development Quickstart
 
-Run an ephemeral opensearch instance on local port 9200, with SSL disabled, and the `analysis-icu` plugin installed, using docker:
+Run an ephemeral opensearch instance on local port 9200, with SSL disabled, and the `analysis-icu` and `analysis-kuromoji` plugins installed, using docker:
 
     docker build -f Dockerfile.opensearch . -t opensearch-palomar
-    docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "plugins.security.disabled=true" opensearch-palomar
+
+	# in any non-development system, obviously change this default password
+    docker run -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "plugins.security.disabled=true" -e OPENSEARCH_INITIAL_ADMIN_PASSWORD=0penSearch-Pal0mar opensearch-palomar
 
 See [README.opensearch.md]() for more Opensearch operational tips.
 

--- a/cmd/palomar/README.md
+++ b/cmd/palomar/README.md
@@ -19,7 +19,7 @@ Currently only a simple query string syntax is supported. Double-quotes can surr
 
 Palomar uses environment variables for configuration.
 
-- `ATP_BGS_HOST`: URL of firehose to subscribe to, either global BGS or individual PDS (default: `wss://bsky.social`)
+- `ATP_RELAY_HOST`: URL of firehose to subscribe to, either global Relay or individual PDS (default: `wss://bsky.network`)
 - `ATP_PLC_HOST`: PLC directory for identity lookups (default: `https://plc.directory`)
 - `DATABASE_URL`: connection string for database to persist firehose cursor subscription state
 - `PALOMAR_BIND`: IP/port to have HTTP API listen on (default: `:3999`)

--- a/cmd/palomar/README.opensearch.md
+++ b/cmd/palomar/README.opensearch.md
@@ -1,14 +1,16 @@
 
 # Basic OpenSearch Operations
 
-We use OpenSearch version 2.5+, with the `analysis-icu` plugin. This is included automatically on the AWS hosted version of Opensearch, otherwise you need to install:
+We use OpenSearch version 2.13+, with the `analysis-icu` and `analysis-kuromoji` plugins. These are included automatically on the AWS hosted version of Opensearch, otherwise you need to install:
 
     sudo /usr/share/opensearch/bin/opensearch-plugin install analysis-icu
+    sudo /usr/share/opensearch/bin/opensearch-plugin install analysis-kuromoji
     sudo service opensearch restart
 
 If you are trying to use Elasticsearch 7.10 instead of OpenSearch, you can install the plugin with:
 
     sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
+    sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-kuromoji
     sudo service elasticsearch restart
 
 ## Local Development

--- a/cmd/palomar/main.go
+++ b/cmd/palomar/main.go
@@ -87,10 +87,10 @@ func run(args []string) error {
 			EnvVars: []string{"ES_PROFILE_INDEX"},
 		},
 		&cli.StringFlag{
-			Name:    "atp-bgs-host",
-			Usage:   "hostname and port of BGS to subscribe to",
-			Value:   "wss://bsky.social",
-			EnvVars: []string{"ATP_BGS_HOST"},
+			Name:    "atp-relay-host",
+			Usage:   "hostname and port of Relay to subscribe to",
+			Value:   "wss://bsky.network",
+			EnvVars: []string{"ATP_RELAY_HOST", "ATP_BGS_HOST"},
 		},
 		&cli.StringFlag{
 			Name:    "atp-plc-host",
@@ -141,10 +141,10 @@ var runCmd = &cli.Command{
 			EnvVars: []string{"PALOMAR_METRICS_LISTEN"},
 		},
 		&cli.IntFlag{
-			Name:    "bgs-sync-rate-limit",
-			Usage:   "max repo sync (checkout) requests per second to upstream (BGS)",
+			Name:    "relay-sync-rate-limit",
+			Usage:   "max repo sync (checkout) requests per second to upstream (Relay)",
 			Value:   8,
-			EnvVars: []string{"PALOMAR_BGS_SYNC_RATE_LIMIT"},
+			EnvVars: []string{"PALOMAR_RELAY_SYNC_RATE_LIMIT", "PALOMAR_BGS_SYNC_RATE_LIMIT"},
 		},
 		&cli.IntFlag{
 			Name:    "index-max-concurrency",
@@ -233,11 +233,11 @@ var runCmd = &cli.Command{
 			escli,
 			&dir,
 			search.Config{
-				BGSHost:             cctx.String("atp-bgs-host"),
+				RelayHost:           cctx.String("atp-relay-host"),
 				ProfileIndex:        cctx.String("es-profile-index"),
 				PostIndex:           cctx.String("es-post-index"),
 				Logger:              logger,
-				BGSSyncRateLimit:    cctx.Int("bgs-sync-rate-limit"),
+				RelaySyncRateLimit:  cctx.Int("relay-sync-rate-limit"),
 				IndexMaxConcurrency: cctx.Int("index-max-concurrency"),
 			},
 		)

--- a/cmd/palomar/main.go
+++ b/cmd/palomar/main.go
@@ -65,7 +65,7 @@ func run(args []string) error {
 		&cli.StringFlag{
 			Name:    "elastic-password",
 			Usage:   "elasticsearch password",
-			Value:   "admin",
+			Value:   "0penSearch-Pal0mar",
 			EnvVars: []string{"ES_PASSWORD", "ELASTIC_PASSWORD"},
 		},
 		&cli.StringFlag{

--- a/search/japanese.go
+++ b/search/japanese.go
@@ -1,0 +1,14 @@
+package search
+
+import (
+	"regexp"
+)
+
+// U+3040 - U+30FF: hiragana and katakana (Japanese only)
+// U+FF66 - U+FF9F: half-width katakana (Japanese only)
+var japaneseRegex = regexp.MustCompile(`[\x{3040}-\x{30ff}\x{ff66}-\x{ff9f}]`)
+
+// helper to check if an input string contains any Japanese-specific characters (hiragana or katakana). will not trigger on CJK characters which are not specific to Japanese
+func containsJapanese(text string) bool {
+	return japaneseRegex.MatchString(text)
+}

--- a/search/japanese_test.go
+++ b/search/japanese_test.go
@@ -1,0 +1,23 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJapaneseDetection(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.False(containsJapanese(""))
+	assert.False(containsJapanese("basic english"))
+	assert.False(containsJapanese("basic english"))
+
+	assert.True(containsJapanese("学校から帰って熱いお風呂に入ったら力一杯がんばる"))
+	assert.True(containsJapanese("パリ"))
+	assert.True(containsJapanese("ハリー・ポッター"))
+	assert.True(containsJapanese("some japanese パリ and some english"))
+
+	// CJK, but not japanese-specific
+	assert.False(containsJapanese("熱力学"))
+}

--- a/search/post_schema.json
+++ b/search/post_schema.json
@@ -22,6 +22,32 @@
                     "tokenizer": "icu_tokenizer",
                     "char_filter": [ "icu_normalizer" ],
                     "filter": [ "icu_folding" ]
+                },
+                "textJapanese": {
+                    "type": "custom",
+                    "tokenizer": "kuromoji_tokenizer",
+                    "char_filter": [ "icu_normalizer" ],
+                    "filter": [
+                        "kuromoji_baseform",
+                        "kuromoji_part_of_speech",
+                        "cjk_width",
+                        "ja_stop",
+                        "kuromoji_stemmer",
+                        "lowercase"
+                    ]
+                },
+                "textJapaneseSearch": {
+                    "type": "custom",
+                    "tokenizer": "kuromoji_tokenizer",
+                    "char_filter": [ "icu_normalizer" ],
+                    "filter": [
+                        "kuromoji_baseform",
+                        "kuromoji_part_of_speech",
+                        "cjk_width",
+                        "ja_stop",
+                        "kuromoji_stemmer",
+                        "lowercase"
+                    ]
                 }
             },
             "normalizer": {
@@ -49,6 +75,7 @@
 
         "created_at":     { "type": "date" },
         "text":           { "type": "text", "analyzer": "textIcu", "search_analyzer": "textIcuSearch", "copy_to": "everything" },
+        "text_ja":        { "type": "text", "analyzer": "textJapanese", "search_analyzer": "textJapaneseSearch", "copy_to": "everything_ja" },
         "lang_code":      { "type": "keyword", "normalizer": "default" },
         "lang_code_iso2": { "type": "keyword", "normalizer": "default" },
         "mention_did":    { "type": "keyword", "normalizer": "default" },
@@ -58,12 +85,14 @@
         "reply_root_aturi": { "type": "keyword", "normalizer": "default" },
         "embed_img_count": { "type": "integer" },
         "embed_img_alt_text": { "type": "text", "analyzer": "textIcu", "search_analyzer": "textIcuSearch", "copy_to": "everything" },
+        "embed_img_alt_text_ja": { "type": "text", "analyzer": "textJapanese", "search_analyzer": "textJapaneseSearch", "copy_to": "everything_ja" },
         "self_label":     { "type": "keyword", "normalizer": "default" },
 
         "tag":            { "type": "keyword", "normalizer": "default" },
         "emoji":          { "type": "keyword", "normalizer": "caseSensitive" },
 
         "everything":     { "type": "text", "analyzer": "textIcu", "search_analyzer": "textIcuSearch" },
+        "everything_ja":  { "type": "text", "analyzer": "textJapanese", "search_analyzer": "textJapaneseSearch" },
 
         "lang":           { "type": "alias", "path": "lang_code_iso2" }
     }

--- a/search/query.go
+++ b/search/query.go
@@ -64,10 +64,14 @@ func DoSearchPosts(ctx context.Context, dir identity.Directory, escli *es.Client
 		return nil, err
 	}
 	queryStr, filters := ParseQuery(ctx, dir, q)
+	idx := "everything"
+	if containsJapanese(queryStr) {
+		idx = "everything_ja"
+	}
 	basic := map[string]interface{}{
 		"simple_query_string": map[string]interface{}{
 			"query":            queryStr,
-			"fields":           []string{"everything"},
+			"fields":           []string{idx},
 			"flags":            "AND|NOT|OR|PHRASE|PRECEDENCE|WHITESPACE",
 			"default_operator": "and",
 			"lenient":          true,

--- a/search/query_test.go
+++ b/search/query_test.go
@@ -1,0 +1,200 @@
+package search
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	appbsky "github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+
+	"github.com/ipfs/go-cid"
+	es "github.com/opensearch-project/opensearch-go/v2"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+var (
+	testPostIndex    = "palomar_test_post"
+	testProfileIndex = "palomar_test_profile"
+)
+
+func testEsClient(t *testing.T) *es.Client {
+	cfg := es.Config{
+		Addresses: []string{"http://localhost:9200"},
+		Username:  "admin",
+		Password:  "0penSearch-Pal0mar",
+		CACert:    nil,
+		Transport: &http.Transport{
+			MaxIdleConnsPerHost: 5,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	escli, err := es.NewClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := escli.Info()
+	if err != nil {
+		t.Fatal(err)
+	}
+	info.Body.Close()
+	return escli
+
+}
+
+func testServer(ctx context.Context, t *testing.T, escli *es.Client, dir identity.Directory) *Server {
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv, err := NewServer(
+		db,
+		escli,
+		dir,
+		Config{
+			RelayHost:           "wss://relay.invalid",
+			PostIndex:           testPostIndex,
+			ProfileIndex:        testProfileIndex,
+			Logger:              slog.Default(),
+			RelaySyncRateLimit:  1,
+			IndexMaxConcurrency: 1,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// NOTE: skipping errors
+	resp, _ := srv.escli.Indices.Delete([]string{testPostIndex, testProfileIndex})
+	defer resp.Body.Close()
+	io.ReadAll(resp.Body)
+
+	if err := srv.EnsureIndices(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	return srv
+}
+
+func TestJapaneseRegressions(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+	escli := testEsClient(t)
+	dir := identity.NewMockDirectory()
+	srv := testServer(ctx, t, escli, &dir)
+	ident := identity.Identity{
+		DID:    syntax.DID("did:plc:abc111"),
+		Handle: syntax.Handle("handle.example.com"),
+	}
+
+	res, err := DoSearchPosts(ctx, &dir, escli, testPostIndex, "english", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(0, len(res.Hits.Hits))
+
+	p1 := appbsky.FeedPost{Text: "basic english post", CreatedAt: "2024-01-02T03:04:05.006Z"}
+	assert.NoError(srv.indexPost(ctx, &ident, &p1, "app.bsky.feed.post/3kpnillluoh2y", cid.Undef))
+
+	// https://github.com/bluesky-social/indigo/issues/302
+	p2 := appbsky.FeedPost{Text: "学校から帰って熱いお風呂に入ったら力一杯がんばる", CreatedAt: "2024-01-02T03:04:05.006Z"}
+	assert.NoError(srv.indexPost(ctx, &ident, &p2, "app.bsky.feed.post/3kpnillluo222", cid.Undef))
+	p3 := appbsky.FeedPost{Text: "熱力学", CreatedAt: "2024-01-02T03:04:05.006Z"}
+	assert.NoError(srv.indexPost(ctx, &ident, &p3, "app.bsky.feed.post/3kpnillluo333", cid.Undef))
+	p4 := appbsky.FeedPost{Text: "東京都", CreatedAt: "2024-01-02T03:04:05.006Z"}
+	assert.NoError(srv.indexPost(ctx, &ident, &p4, "app.bsky.feed.post/3kpnillluo444", cid.Undef))
+	p5 := appbsky.FeedPost{Text: "京都", CreatedAt: "2024-01-02T03:04:05.006Z"}
+	assert.NoError(srv.indexPost(ctx, &ident, &p5, "app.bsky.feed.post/3kpnillluo555", cid.Undef))
+	p6 := appbsky.FeedPost{Text: "パリ", CreatedAt: "2024-01-02T03:04:05.006Z"}
+	assert.NoError(srv.indexPost(ctx, &ident, &p6, "app.bsky.feed.post/3kpnillluo666", cid.Undef))
+	p7 := appbsky.FeedPost{Text: "ハリー・ポッター", CreatedAt: "2024-01-02T03:04:05.006Z"}
+	assert.NoError(srv.indexPost(ctx, &ident, &p7, "app.bsky.feed.post/3kpnillluo777", cid.Undef))
+	p8 := appbsky.FeedPost{Text: "ハリ", CreatedAt: "2024-01-02T03:04:05.006Z"}
+	assert.NoError(srv.indexPost(ctx, &ident, &p8, "app.bsky.feed.post/3kpnillluo223", cid.Undef))
+	p9 := appbsky.FeedPost{Text: "multilingual 多言語", CreatedAt: "2024-01-02T03:04:05.006Z"}
+	assert.NoError(srv.indexPost(ctx, &ident, &p9, "app.bsky.feed.post/3kpnillluo224", cid.Undef))
+
+	_, err = srv.escli.Indices.Refresh()
+	assert.NoError(err)
+
+	// expect all to be indexed
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "*", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(9, len(res.Hits.Hits))
+
+	// check that english matches (single post)
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "english", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+
+	// "thermodynamics"; should return only one match
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "熱力学", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+
+	// "Kyoto"; should return only one match
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "京都", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+
+	// "Paris"; should return only one match
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "パリ", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+
+	// should return only one match
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "ハリー", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+
+	// part of a word; should match none
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "ハ", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(0, len(res.Hits.Hits))
+
+	// should match both ways, and together
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "multilingual", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "多言語", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "multilingual 多言語", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "\"multilingual 多言語\"", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+}

--- a/search/query_test.go
+++ b/search/query_test.go
@@ -1,3 +1,5 @@
+//go:build localsearch
+
 package search
 
 import (

--- a/search/server.go
+++ b/search/server.go
@@ -158,9 +158,13 @@ func (s *Server) EnsureIndices(ctx context.Context) error {
 				return err
 			}
 			defer resp.Body.Close()
-			io.ReadAll(resp.Body)
+			errBytes, err := io.ReadAll(resp.Body)
 			if resp.IsError() {
+				s.logger.Error("failed to create index", "index", idx.Name, "response", string(errBytes))
 				return fmt.Errorf("failed to create index")
+			}
+			if err != nil {
+				return err
 			}
 		}
 	}

--- a/search/testdata/transform-post-fixtures.json
+++ b/search/testdata/transform-post-fixtures.json
@@ -186,5 +186,62 @@
   			],
   			"embed_img_count": 2
 		}
+	},
+	{
+		"did": "did:plc:u5cwb2mwiv2bfq53cjufe6yn",
+  		"handle": "handle.example.com",
+		"rkey": "3k4duaz5vfs2b",
+		"cid": "bafyreibjifzpqj6o6wcq3hejh7y4z4z2vmiklkvykc57tw3pcbx3kxifpm",
+		"PostRecord": {
+  			"$type": "app.bsky.feed.post",
+  			"text": "学校から帰って熱いお風呂に入ったら力一杯がんばる",
+  			"createdAt": "2023-08-07T05:46:14.423045Z",
+  			"embed": {
+    			"$type": "app.bsky.embed.images",
+    			"images": [
+      			{
+        			"alt": "brief alt text description of the first image ハリー・ポッター",
+        			"image": {
+          			"$type": "blob",
+          			"ref": {
+            			"$link": "bafkreibabalobzn6cd366ukcsjycp4yymjymgfxcv6xczmlgpemzkz3cfa"
+          			},
+          			"mimeType": "image/webp",
+          			"size": 760898
+        			}
+      			},
+      			{
+        			"alt": "brief alt text description of the second image",
+        			"image": {
+          			"$type": "blob",
+          			"ref": {
+            			"$link": "bafkreif3fouono2i3fmm5moqypwskh3yjtp7snd5hfq5pr453oggygyrte"
+          			},
+          			"mimeType": "image/png",
+          			"size": 13208
+        			}
+      			}
+    			]
+  			}
+		},
+		"doc_id": "did:plc:u5cwb2mwiv2bfq53cjufe6yn_3k4duaz5vfs2b",
+		"PostDoc": {
+            "doc_index_ts": "2006-01-02T15:04:05.000Z",
+  			"did": "did:plc:u5cwb2mwiv2bfq53cjufe6yn",
+  			"handle": "handle.example.com",
+  			"record_rkey": "3k4duaz5vfs2b",
+  			"record_cid": "bafyreibjifzpqj6o6wcq3hejh7y4z4z2vmiklkvykc57tw3pcbx3kxifpm",
+  			"created_at": "2023-08-07T05:46:14.423045Z",
+  			"text": "学校から帰って熱いお風呂に入ったら力一杯がんばる",
+  			"text_ja": "学校から帰って熱いお風呂に入ったら力一杯がんばる",
+  			"embed_img_alt_text": [
+  				"brief alt text description of the first image ハリー・ポッター",
+  				"brief alt text description of the second image"
+  			],
+  			"embed_img_alt_text_ja": [
+  				"brief alt text description of the first image ハリー・ポッター"
+  			],
+  			"embed_img_count": 2
+		}
 	}
 ]


### PR DESCRIPTION
This is just for posts right now, not profiles (descriptions, display name, etc).

I'm somewhat confident in the indexing approach (separate duplicate fields, gated by text detection). And this seems to work ok for simple cases.

I'm not very confident about all-kanji text and indexing, and mixes of Japanese and non-english character sets. For example, Japanese and Korean (CJK), or Japanese and Thai (non-CJK).

One positive thing is that everything is still being indexed in the regular text fields, using the existing analysis pipeline. So we can revert the query changes if needed, or improve some corner cases using query-time-only techniques.

Closes: https://github.com/bluesky-social/indigo/issues/628