### PR TITLE
backfill: use constants for bufferedOp.kind

### DIFF
--- a/backfill/backfill_test.go
+++ b/backfill/backfill_test.go
@@ -63,15 +63,15 @@ func TestBackfill(t *testing.T) {
 			t.Fatal(err)
 		}
 		if s.State() == backfill.StateInProgress {
-			bf.BufferOp(ctx, testRepos[0], "delete", "app.bsky.feed.follow/1", nil, &cid.Undef)
-			bf.BufferOp(ctx, testRepos[0], "delete", "app.bsky.feed.follow/2", nil, &cid.Undef)
-			bf.BufferOp(ctx, testRepos[0], "delete", "app.bsky.feed.follow/3", nil, &cid.Undef)
-			bf.BufferOp(ctx, testRepos[0], "delete", "app.bsky.feed.follow/4", nil, &cid.Undef)
-			bf.BufferOp(ctx, testRepos[0], "delete", "app.bsky.feed.follow/5", nil, &cid.Undef)
+			bf.BufferOp(ctx, testRepos[0], repomgr.EvtKindDeleteRecord, "app.bsky.feed.follow/1", nil, &cid.Undef)
+			bf.BufferOp(ctx, testRepos[0], repomgr.EvtKindDeleteRecord, "app.bsky.feed.follow/2", nil, &cid.Undef)
+			bf.BufferOp(ctx, testRepos[0], repomgr.EvtKindDeleteRecord, "app.bsky.feed.follow/3", nil, &cid.Undef)
+			bf.BufferOp(ctx, testRepos[0], repomgr.EvtKindDeleteRecord, "app.bsky.feed.follow/4", nil, &cid.Undef)
+			bf.BufferOp(ctx, testRepos[0], repomgr.EvtKindDeleteRecord, "app.bsky.feed.follow/5", nil, &cid.Undef)
 
-			bf.BufferOp(ctx, testRepos[0], "create", "app.bsky.feed.follow/1", nil, &cid.Undef)
+			bf.BufferOp(ctx, testRepos[0], repomgr.EvtKindCreateRecord, "app.bsky.feed.follow/1", nil, &cid.Undef)
 
-			bf.BufferOp(ctx, testRepos[0], "update", "app.bsky.feed.follow/1", nil, &cid.Undef)
+			bf.BufferOp(ctx, testRepos[0], repomgr.EvtKindUpdateRecord, "app.bsky.feed.follow/1", nil, &cid.Undef)
 
 			break
 		}

--- a/backfill/gormstore.go
+++ b/backfill/gormstore.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bluesky-social/indigo/repomgr"
 	"github.com/ipfs/go-cid"
 	"gorm.io/gorm"
 )
@@ -328,7 +329,7 @@ func (j *Gormjob) SetState(ctx context.Context, state string) error {
 	return j.db.Save(j.dbj).Error
 }
 
-func (j *Gormjob) FlushBufferedOps(ctx context.Context, fn func(kind, rev, path string, rec *[]byte, cid *cid.Cid) error) error {
+func (j *Gormjob) FlushBufferedOps(ctx context.Context, fn func(kind repomgr.EventKind, rev, path string, rec *[]byte, cid *cid.Cid) error) error {
 	// TODO: this will block any events for this repo while this flush is ongoing, is that okay?
 	j.lk.Lock()
 	defer j.lk.Unlock()

--- a/backfill/memstore.go
+++ b/backfill/memstore.go
@@ -6,11 +6,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bluesky-social/indigo/repomgr"
 	"github.com/ipfs/go-cid"
 )
 
 type bufferedOp struct {
-	kind string
+	kind repomgr.EventKind
 	path string
 	rec  *[]byte
 	cid  *cid.Cid
@@ -81,7 +82,7 @@ func (s *Memstore) EnqueueJobWithState(repo, state string) error {
 	return nil
 }
 
-func (s *Memstore) BufferOp(ctx context.Context, repo string, since *string, rev, kind, path string, rec *[]byte, cid *cid.Cid) (bool, error) {
+func (s *Memstore) BufferOp(ctx context.Context, repo string, since *string, rev string, kind repomgr.EventKind, path string, rec *[]byte, cid *cid.Cid) (bool, error) {
 	s.lk.Lock()
 
 	// If the job doesn't exist, we can't buffer an op for it
@@ -199,7 +200,7 @@ func (j *Memjob) SetRev(ctx context.Context, rev string) error {
 	return nil
 }
 
-func (j *Memjob) FlushBufferedOps(ctx context.Context, fn func(kind, rev, path string, rec *[]byte, cid *cid.Cid) error) error {
+func (j *Memjob) FlushBufferedOps(ctx context.Context, fn func(kind repomgr.EventKind, rev, path string, rec *[]byte, cid *cid.Cid) error) error {
 	panic("TODO: copy what we end up doing from the gormstore")
 	/*
 		j.lk.Lock()


### PR DESCRIPTION
(Part of https://github.com/bluesky-social/indigo/issues/638)

This utilizes constants from the `repomgr` package for buffered operations.
This was already the case, actually, as they were used [here](https://github.com/bluesky-social/indigo/blob/main/backfill/backfill.go#L241), I just added them throughout the code.

They're also used to check the operations emitted by the firehose: https://github.com/bluesky-social/indigo/blob/main/backfill/backfill.go#L469-L471
The firehose, in turn, uses the events emitted by the repo manager for the `Action` field in firehose events: https://github.com/bluesky-social/indigo/blob/main/indexer/indexer.go#L83-L94
This brings us full circle:
Repo manager emits diff operations -> firehose repo commit ops `.Action` -> backfill buffered op `.kind`

Notably, the constants are also given in the lexicon: https://github.com/bluesky-social/atproto/blob/main/lexicons/com/atproto/sync/subscribeRepos.json#L178
But `lexgen` does not generate constants for them.

The test in `backfill_test.go` is broken, but I changed the constants anyway.