### PR TITLE
palomar: refactor query string parsing; updates to schemas and transform

### DIFF
--- a/api/bsky/actorsearchActorsTypeahead.go
+++ b/api/bsky/actorsearchActorsTypeahead.go
@@ -19,13 +19,15 @@ type ActorSearchActorsTypeahead_Output struct {
 //
 // q: Search query prefix; not a full query string.
 // term: DEPRECATED: use 'q' instead.
-func ActorSearchActorsTypeahead(ctx context.Context, c *xrpc.Client, limit int64, q string, term string) (*ActorSearchActorsTypeahead_Output, error) {
+// viewer: DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking.
+func ActorSearchActorsTypeahead(ctx context.Context, c *xrpc.Client, limit int64, q string, term string, viewer string) (*ActorSearchActorsTypeahead_Output, error) {
 	var out ActorSearchActorsTypeahead_Output
 
 	params := map[string]interface{}{
-		"limit": limit,
-		"q":     q,
-		"term":  term,
+		"limit":  limit,
+		"q":      q,
+		"term":   term,
+		"viewer": viewer,
 	}
 	if err := c.Do(ctx, xrpc.Query, "", "app.bsky.actor.searchActorsTypeahead", params, nil, &out); err != nil {
 		return nil, err

--- a/api/bsky/feedsearchPosts.go
+++ b/api/bsky/feedsearchPosts.go
@@ -20,15 +20,33 @@ type FeedSearchPosts_Output struct {
 
 // FeedSearchPosts calls the XRPC method "app.bsky.feed.searchPosts".
 //
+// author: Filter to posts by the given account. Handles are resolved to DID before query-time.
 // cursor: Optional pagination mechanism; may not necessarily allow scrolling through entire result set.
+// domain: Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization.
+// lang: Filter to posts in the given language. Expected to be based on post language field, though server may override language detection.
+// mentions: Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions.
 // q: Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended.
-func FeedSearchPosts(ctx context.Context, c *xrpc.Client, cursor string, limit int64, q string) (*FeedSearchPosts_Output, error) {
+// since: Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD).
+// sort: Specifies the ranking order of results.
+// tag: Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching.
+// until: Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD).
+// url: Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching.
+func FeedSearchPosts(ctx context.Context, c *xrpc.Client, author string, cursor string, domain string, lang string, limit int64, mentions string, q string, since string, sort string, tag []string, until string, url string) (*FeedSearchPosts_Output, error) {
 	var out FeedSearchPosts_Output
 
 	params := map[string]interface{}{
-		"cursor": cursor,
-		"limit":  limit,
-		"q":      q,
+		"author":   author,
+		"cursor":   cursor,
+		"domain":   domain,
+		"lang":     lang,
+		"limit":    limit,
+		"mentions": mentions,
+		"q":        q,
+		"since":    since,
+		"sort":     sort,
+		"tag":      tag,
+		"until":    until,
+		"url":      url,
 	}
 	if err := c.Do(ctx, xrpc.Query, "", "app.bsky.feed.searchPosts", params, nil, &out); err != nil {
 		return nil, err

--- a/api/bsky/unspeccedsearchActorsSkeleton.go
+++ b/api/bsky/unspeccedsearchActorsSkeleton.go
@@ -23,7 +23,8 @@ type UnspeccedSearchActorsSkeleton_Output struct {
 // cursor: Optional pagination mechanism; may not necessarily allow scrolling through entire result set.
 // q: Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended. For typeahead search, only simple term match is supported, not full syntax.
 // typeahead: If true, acts as fast/simple 'typeahead' query.
-func UnspeccedSearchActorsSkeleton(ctx context.Context, c *xrpc.Client, cursor string, limit int64, q string, typeahead bool) (*UnspeccedSearchActorsSkeleton_Output, error) {
+// viewer: DID of the account making the request (not included for public/unauthenticated queries). Used to boost followed accounts in ranking.
+func UnspeccedSearchActorsSkeleton(ctx context.Context, c *xrpc.Client, cursor string, limit int64, q string, typeahead bool, viewer string) (*UnspeccedSearchActorsSkeleton_Output, error) {
 	var out UnspeccedSearchActorsSkeleton_Output
 
 	params := map[string]interface{}{
@@ -31,6 +32,7 @@ func UnspeccedSearchActorsSkeleton(ctx context.Context, c *xrpc.Client, cursor s
 		"limit":     limit,
 		"q":         q,
 		"typeahead": typeahead,
+		"viewer":    viewer,
 	}
 	if err := c.Do(ctx, xrpc.Query, "", "app.bsky.unspecced.searchActorsSkeleton", params, nil, &out); err != nil {
 		return nil, err

--- a/api/bsky/unspeccedsearchPostsSkeleton.go
+++ b/api/bsky/unspeccedsearchPostsSkeleton.go
@@ -20,15 +20,35 @@ type UnspeccedSearchPostsSkeleton_Output struct {
 
 // UnspeccedSearchPostsSkeleton calls the XRPC method "app.bsky.unspecced.searchPostsSkeleton".
 //
+// author: Filter to posts by the given account. Handles are resolved to DID before query-time.
 // cursor: Optional pagination mechanism; may not necessarily allow scrolling through entire result set.
+// domain: Filter to posts with URLs (facet links or embeds) linking to the given domain (hostname). Server may apply hostname normalization.
+// lang: Filter to posts in the given language. Expected to be based on post language field, though server may override language detection.
+// mentions: Filter to posts which mention the given account. Handles are resolved to DID before query-time. Only matches rich-text facet mentions.
 // q: Search query string; syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended.
-func UnspeccedSearchPostsSkeleton(ctx context.Context, c *xrpc.Client, cursor string, limit int64, q string) (*UnspeccedSearchPostsSkeleton_Output, error) {
+// since: Filter results for posts after the indicated datetime (inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYYY-MM-DD).
+// sort: Specifies the ranking order of results.
+// tag: Filter to posts with the given tag (hashtag), based on rich-text facet or tag field. Do not include the hash (#) prefix. Multiple tags can be specified, with 'AND' matching.
+// until: Filter results for posts before the indicated datetime (not inclusive). Expected to use 'sortAt' timestamp, which may not match 'createdAt'. Can be a datetime, or just an ISO date (YYY-MM-DD).
+// url: Filter to posts with links (facet links or embeds) pointing to this URL. Server may apply URL normalization or fuzzy matching.
+// viewer: DID of the account making the request (not included for public/unauthenticated queries). Used for 'from:me' queries.
+func UnspeccedSearchPostsSkeleton(ctx context.Context, c *xrpc.Client, author string, cursor string, domain string, lang string, limit int64, mentions string, q string, since string, sort string, tag []string, until string, url string, viewer string) (*UnspeccedSearchPostsSkeleton_Output, error) {
 	var out UnspeccedSearchPostsSkeleton_Output
 
 	params := map[string]interface{}{
-		"cursor": cursor,
-		"limit":  limit,
-		"q":      q,
+		"author":   author,
+		"cursor":   cursor,
+		"domain":   domain,
+		"lang":     lang,
+		"limit":    limit,
+		"mentions": mentions,
+		"q":        q,
+		"since":    since,
+		"sort":     sort,
+		"tag":      tag,
+		"until":    until,
+		"url":      url,
+		"viewer":   viewer,
 	}
 	if err := c.Do(ctx, xrpc.Query, "", "app.bsky.unspecced.searchPostsSkeleton", params, nil, &out); err != nil {
 		return nil, err

--- a/cmd/palomar/main.go
+++ b/cmd/palomar/main.go
@@ -329,9 +329,11 @@ var searchPostCmd = &cli.Command{
 			identity.DefaultDirectory(), // TODO: parse PLC arg
 			escli,
 			cctx.String("es-post-index"),
-			strings.Join(cctx.Args().Slice(), " "),
-			0,
-			20,
+			&search.PostSearchParams{
+				Query:  strings.Join(cctx.Args().Slice(), " "),
+				Offset: 0,
+				Size:   20,
+			},
 		)
 		if err != nil {
 			return err
@@ -359,8 +361,10 @@ var searchProfileCmd = &cli.Command{
 				context.Background(),
 				escli,
 				cctx.String("es-profile-index"),
-				strings.Join(cctx.Args().Slice(), " "),
-				10,
+				&search.ActorSearchParams{
+					Query: strings.Join(cctx.Args().Slice(), " "),
+					Size:  10,
+				},
 			)
 			if err != nil {
 				return err
@@ -372,9 +376,11 @@ var searchProfileCmd = &cli.Command{
 				identity.DefaultDirectory(), // TODO: parse PLC arg
 				escli,
 				cctx.String("es-profile-index"),
-				strings.Join(cctx.Args().Slice(), " "),
-				0,
-				20,
+				&search.ActorSearchParams{
+					Query:  strings.Join(cctx.Args().Slice(), " "),
+					Offset: 0,
+					Size:   20,
+				},
 			)
 			if err != nil {
 				return err

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 )
 
 require (
+	github.com/PuerkitoBio/purell v1.2.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/go-redis/redis v6.15.9+incompatible // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ contrib.go.opencensus.io/exporter/prometheus v0.4.2/go.mod h1:dvEHbiKmgvbr5pjaF9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/PuerkitoBio/purell v1.2.1 h1:QsZ4TjvwiMpat6gBCBxEQI0rcS9ehtkKtSpiUnd9N28=
+github.com/PuerkitoBio/purell v1.2.1/go.mod h1:ZwHcC/82TOaovDi//J/804umJFFmbOHPngi8iYYv/Eo=
 github.com/RussellLuo/slidingwindow v0.0.0-20200528002341-535bb99d338b h1:5/++qT1/z812ZqBvqQt6ToRswSuPZ/B33m6xVHRzADU=
 github.com/RussellLuo/slidingwindow v0.0.0-20200528002341-535bb99d338b/go.mod h1:4+EPqMRApwwE/6yo6CxiHoSnBzjRr3jsqer7frxP8y4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/search/handlers.go
+++ b/search/handlers.go
@@ -76,6 +76,120 @@ func (s *Server) handleSearchPostsSkeleton(e echo.Context) error {
 		})
 	}
 
+	params := PostSearchParams{
+		Query: q,
+		// TODO: parse/validate the sort options here?
+		Sort:   e.QueryParam("sort"),
+		Domain: e.QueryParam("domain"),
+		URL:    e.QueryParam("url"),
+	}
+
+	viewerStr := e.QueryParam("viewer")
+	if viewerStr != "" {
+		d, err := syntax.ParseDID(viewerStr)
+		if err != nil {
+			return e.JSON(400, map[string]any{
+				"error":   "BadRequest",
+				"message": fmt.Sprintf("invalid DID for 'viewer': %s", err),
+			})
+		}
+		params.Viewer = &d
+	}
+	authorStr := e.QueryParam("author")
+	if authorStr != "" {
+		atid, err := syntax.ParseAtIdentifier(authorStr)
+		if err != nil {
+			return &echo.HTTPError{
+				Code:    400,
+				Message: fmt.Sprintf("invalid DID for 'author': %s", err),
+			}
+		}
+		if atid.IsHandle() {
+			ident, err := s.dir.Lookup(context.TODO(), *atid)
+			if err != nil {
+				return e.JSON(400, map[string]any{
+					"error":   "BadRequest",
+					"message": fmt.Sprintf("invalid Handle for 'author': %s", err),
+				})
+			}
+			params.Author = &ident.DID
+		} else {
+			d, err := atid.AsDID()
+			if err != nil {
+				return err
+			}
+			params.Author = &d
+		}
+	}
+
+	mentionsStr := e.QueryParam("mentions")
+	if mentionsStr != "" {
+		atid, err := syntax.ParseAtIdentifier(mentionsStr)
+		if err != nil {
+			return &echo.HTTPError{
+				Code:    400,
+				Message: fmt.Sprintf("invalid DID for 'mentions': %s", err),
+			}
+		}
+		if atid.IsHandle() {
+			ident, err := s.dir.Lookup(context.TODO(), *atid)
+			if err != nil {
+				return e.JSON(400, map[string]any{
+					"error":   "BadRequest",
+					"message": fmt.Sprintf("invalid Handle for 'mentions': %s", err),
+				})
+			}
+			params.Mentions = &ident.DID
+		} else {
+			d, err := atid.AsDID()
+			if err != nil {
+				return err
+			}
+			params.Mentions = &d
+		}
+	}
+
+	sinceStr := e.QueryParam("since")
+	if sinceStr != "" {
+		dt, err := syntax.ParseDatetime(sinceStr)
+		if err != nil {
+			return e.JSON(400, map[string]any{
+				"error":   "BadRequest",
+				"message": fmt.Sprintf("invalid Datetime for 'since': %s", err),
+			})
+		}
+		params.Since = &dt
+	}
+
+	untilStr := e.QueryParam("until")
+	if untilStr != "" {
+		dt, err := syntax.ParseDatetime(untilStr)
+		if err != nil {
+			return e.JSON(400, map[string]any{
+				"error":   "BadRequest",
+				"message": fmt.Sprintf("invalid Datetime for 'until': %s", err),
+			})
+		}
+		params.Until = &dt
+	}
+
+	langStr := e.QueryParam("lang")
+	if langStr != "" {
+		l, err := syntax.ParseLanguage(langStr)
+		if err != nil {
+			return e.JSON(400, map[string]any{
+				"error":   "BadRequest",
+				"message": fmt.Sprintf("invalid Language for 'lang': %s", err),
+			})
+		}
+		params.Lang = &l
+	}
+	// TODO: could be multiple tag params; guess we should "bind"?
+	tagStr := e.QueryParam("tag")
+	if tagStr != "" {
+		params.Tags = []string{tagStr}
+	}
+
 	offset, limit, err := parseCursorLimit(e)
 	if err != nil {
 		span.SetAttributes(attribute.String("error", fmt.Sprintf("invalid cursor/limit: %s", err)))
@@ -83,9 +197,11 @@ func (s *Server) handleSearchPostsSkeleton(e echo.Context) error {
 		return err
 	}
 
+	params.Offset = offset
+	params.Size = limit
 	span.SetAttributes(attribute.Int("offset", offset), attribute.Int("limit", limit))
 
-	out, err := s.SearchPosts(ctx, q, offset, limit)
+	out, err := s.SearchPosts(ctx, &params)
 	if err != nil {
 		span.SetAttributes(attribute.String("error", fmt.Sprintf("failed to SearchPosts: %s", err)))
 		span.SetStatus(codes.Error, err.Error())
@@ -106,7 +222,8 @@ func (s *Server) handleSearchActorsSkeleton(e echo.Context) error {
 	q := strings.TrimSpace(e.QueryParam("q"))
 	if q == "" {
 		return e.JSON(400, map[string]any{
-			"error": "must pass non-empty search query",
+			"error":   "BadRequest",
+			"message": "must pass non-empty search query",
 		})
 	}
 
@@ -122,13 +239,32 @@ func (s *Server) handleSearchActorsSkeleton(e echo.Context) error {
 		typeahead = true
 	}
 
+	params := ActorSearchParams{
+		Query:     q,
+		Typeahead: typeahead,
+		Offset:    offset,
+		Size:      limit,
+	}
+
+	viewerStr := e.QueryParam("viewer")
+	if viewerStr != "" {
+		d, err := syntax.ParseDID(viewerStr)
+		if err != nil {
+			return e.JSON(400, map[string]any{
+				"error":   "BadRequest",
+				"message": fmt.Sprintf("invalid DID for 'viewer': %s", err),
+			})
+		}
+		params.Viewer = &d
+	}
+
 	span.SetAttributes(
 		attribute.Int("offset", offset),
 		attribute.Int("limit", limit),
 		attribute.Bool("typeahead", typeahead),
 	)
 
-	out, err := s.SearchProfiles(ctx, q, typeahead, offset, limit)
+	out, err := s.SearchProfiles(ctx, &params)
 	if err != nil {
 		span.SetAttributes(attribute.String("error", fmt.Sprintf("failed to SearchProfiles: %s", err)))
 		span.SetStatus(codes.Error, err.Error())
@@ -193,11 +329,11 @@ func (s *Server) handleIndexRepos(e echo.Context) error {
 	})
 }
 
-func (s *Server) SearchPosts(ctx context.Context, q string, offset, size int) (*appbsky.UnspeccedSearchPostsSkeleton_Output, error) {
+func (s *Server) SearchPosts(ctx context.Context, params *PostSearchParams) (*appbsky.UnspeccedSearchPostsSkeleton_Output, error) {
 	ctx, span := tracer.Start(ctx, "SearchPosts")
 	defer span.End()
 
-	resp, err := DoSearchPosts(ctx, s.dir, s.escli, s.postIndex, q, offset, size)
+	resp, err := DoSearchPosts(ctx, s.dir, s.escli, s.postIndex, params)
 	if err != nil {
 		return nil, err
 	}
@@ -220,8 +356,8 @@ func (s *Server) SearchPosts(ctx context.Context, q string, offset, size int) (*
 	}
 
 	out := appbsky.UnspeccedSearchPostsSkeleton_Output{Posts: posts}
-	if len(posts) == size && (offset+size) < 10000 {
-		s := fmt.Sprintf("%d", offset+size)
+	if len(posts) == params.Size && (params.Offset+params.Size) < 10000 {
+		s := fmt.Sprintf("%d", params.Offset+params.Size)
 		out.Cursor = &s
 	}
 	if resp.Hits.Total.Relation == "eq" {
@@ -231,16 +367,16 @@ func (s *Server) SearchPosts(ctx context.Context, q string, offset, size int) (*
 	return &out, nil
 }
 
-func (s *Server) SearchProfiles(ctx context.Context, q string, typeahead bool, offset, size int) (*appbsky.UnspeccedSearchActorsSkeleton_Output, error) {
+func (s *Server) SearchProfiles(ctx context.Context, params *ActorSearchParams) (*appbsky.UnspeccedSearchActorsSkeleton_Output, error) {
 	ctx, span := tracer.Start(ctx, "SearchProfiles")
 	defer span.End()
 
 	var resp *EsSearchResponse
 	var err error
-	if typeahead {
-		resp, err = DoSearchProfilesTypeahead(ctx, s.escli, s.profileIndex, q, size)
+	if params.Typeahead {
+		resp, err = DoSearchProfilesTypeahead(ctx, s.escli, s.profileIndex, params)
 	} else {
-		resp, err = DoSearchProfiles(ctx, s.dir, s.escli, s.profileIndex, q, offset, size)
+		resp, err = DoSearchProfiles(ctx, s.dir, s.escli, s.profileIndex, params)
 	}
 	if err != nil {
 		return nil, err
@@ -264,8 +400,8 @@ func (s *Server) SearchProfiles(ctx context.Context, q string, typeahead bool, o
 	}
 
 	out := appbsky.UnspeccedSearchActorsSkeleton_Output{Actors: actors}
-	if len(actors) == size && (offset+size) < 10000 {
-		s := fmt.Sprintf("%d", offset+size)
+	if len(actors) == params.Size && (params.Offset+params.Size) < 10000 {
+		s := fmt.Sprintf("%d", params.Offset+params.Size)
 		out.Cursor = &s
 	}
 	if resp.Hits.Total.Relation == "eq" {

--- a/search/handlers.go
+++ b/search/handlers.go
@@ -185,9 +185,9 @@ func (s *Server) handleSearchPostsSkeleton(e echo.Context) error {
 		params.Lang = &l
 	}
 	// TODO: could be multiple tag params; guess we should "bind"?
-	tagStr := e.QueryParam("tag")
-	if tagStr != "" {
-		params.Tags = []string{tagStr}
+	tags := e.Request().URL.Query()["tags"]
+	if len(tags) > 0 {
+		params.Tags = tags
 	}
 
 	offset, limit, err := parseCursorLimit(e)

--- a/search/parse_query.go
+++ b/search/parse_query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
@@ -97,10 +98,17 @@ func ParsePostQuery(ctx context.Context, dir identity.Directory, raw string) Pos
 			}
 			continue
 		case "since", "until":
-			// TODO: special-case handle dates?
-			dt, err := syntax.ParseDatetimeLenient(tokParts[1])
-			if err != nil {
-				continue
+			var dt syntax.Datetime
+			// first try just date
+			date, err := time.Parse(time.DateOnly, tokParts[1])
+			if nil == err {
+				dt = syntax.Datetime(date.Format(syntax.AtprotoDatetimeLayout))
+			} else {
+				// fallback to formal atproto datetime format
+				dt, err = syntax.ParseDatetimeLenient(tokParts[1])
+				if err != nil {
+					continue
+				}
 			}
 			if tokParts[0] == "since" {
 				params.Since = &dt

--- a/search/parse_query.go
+++ b/search/parse_query.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ParseQuery takes a query string and pulls out some facet patterns ("from:handle.net") as filters
-func ParsePostQuery(ctx context.Context, dir identity.Directory, raw string) PostSearchParams {
+func ParsePostQuery(ctx context.Context, dir identity.Directory, raw string, viewer *syntax.DID) PostSearchParams {
 	quoted := false
 	parts := strings.FieldsFunc(raw, func(r rune) bool {
 		if r == '"' {
@@ -65,6 +65,14 @@ func ParsePostQuery(ctx context.Context, dir identity.Directory, raw string) Pos
 			// TODO: not really clear what to do here; treating like a mention doesn't really make sense?
 		case "from", "to", "mentions":
 			raw := tokParts[1]
+			if raw == "me" {
+				if viewer != nil && tokParts[0] == "from" {
+					params.Author = viewer
+				} else if viewer != nil {
+					params.Mentions = viewer
+				}
+				continue
+			}
 			if strings.HasPrefix(raw, "@") && len(raw) > 1 {
 				raw = raw[1:]
 			}

--- a/search/parse_query_test.go
+++ b/search/parse_query_test.go
@@ -19,45 +19,62 @@ func TestParseQuery(t *testing.T) {
 		DID:    syntax.DID("did:plc:abc222"),
 	})
 
-	var q string
-	var f []map[string]interface{}
+	var p PostSearchParams
 
-	q, f = ParseQuery(ctx, &dir, "")
-	assert.Equal("", q)
-	assert.Empty(f)
+	p = ParsePostQuery(ctx, &dir, "")
+	assert.Equal("*", p.Query)
+	assert.Empty(p.Filters())
 
-	p1 := "some +test \"with phrase\" -ok"
-	q, f = ParseQuery(ctx, &dir, p1)
-	assert.Equal(p1, q)
-	assert.Empty(f)
+	q1 := "some +test \"with phrase\" -ok"
+	p = ParsePostQuery(ctx, &dir, q1)
+	assert.Equal(q1, p.Query)
+	assert.Empty(p.Filters())
 
-	p2 := "missing from:missing.example.com"
-	q, f = ParseQuery(ctx, &dir, p2)
-	assert.Equal("missing", q)
-	assert.Empty(f)
+	q2 := "missing from:missing.example.com"
+	p = ParsePostQuery(ctx, &dir, q2)
+	assert.Equal("missing", p.Query)
+	assert.Empty(p.Filters())
 
-	p3 := "known from:known.example.com"
-	q, f = ParseQuery(ctx, &dir, p3)
-	assert.Equal("known", q)
-	assert.Equal(1, len(f))
+	q3 := "known from:known.example.com"
+	p = ParsePostQuery(ctx, &dir, q3)
+	assert.Equal("known", p.Query)
+	assert.NotNil(p.Author)
+	if p.Author != nil {
+		assert.Equal("did:plc:abc222", p.Author.String())
+	}
 
-	p4 := "from:known.example.com"
-	q, f = ParseQuery(ctx, &dir, p4)
-	assert.Equal("*", q)
-	assert.Equal(1, len(f))
+	q4 := "from:known.example.com"
+	p = ParsePostQuery(ctx, &dir, q4)
+	assert.Equal("*", p.Query)
+	assert.Equal(1, len(p.Filters()))
 
-	p5 := `from:known.example.com "multi word phrase" coolio blorg`
-	q, f = ParseQuery(ctx, &dir, p5)
-	assert.Equal(`"multi word phrase" coolio blorg`, q)
-	assert.Equal(1, len(f))
+	q5 := `from:known.example.com "multi word phrase" coolio blorg`
+	p = ParsePostQuery(ctx, &dir, q5)
+	assert.Equal(`"multi word phrase" coolio blorg`, p.Query)
+	assert.NotNil(p.Author)
+	if p.Author != nil {
+		assert.Equal("did:plc:abc222", p.Author.String())
+	}
+	assert.Equal(1, len(p.Filters()))
 
-	p6 := `from:known.example.com #cool_tag some other stuff`
-	q, f = ParseQuery(ctx, &dir, p6)
-	assert.Equal(`some other stuff`, q)
-	assert.Equal(2, len(f))
+	q6 := `from:known.example.com #cool_tag some other stuff`
+	p = ParsePostQuery(ctx, &dir, q6)
+	assert.Equal(`some other stuff`, p.Query)
+	assert.NotNil(p.Author)
+	if p.Author != nil {
+		assert.Equal("did:plc:abc222", p.Author.String())
+	}
+	assert.Equal([]string{"cool_tag"}, p.Tags)
+	assert.Equal(2, len(p.Filters()))
 
-	p7 := "known from:@known.example.com"
-	q, f = ParseQuery(ctx, &dir, p7)
-	assert.Equal("known", q)
-	assert.Equal(1, len(f))
+	q7 := "known from:@known.example.com"
+	p = ParsePostQuery(ctx, &dir, q7)
+	assert.Equal("known", p.Query)
+	assert.NotNil(p.Author)
+	if p.Author != nil {
+		assert.Equal("did:plc:abc222", p.Author.String())
+	}
+	assert.Equal(1, len(p.Filters()))
+
+	// TODO: more parsing tests: bare handles, to:, since:, until:, URL, domain:, lang
 }

--- a/search/post_schema.json
+++ b/search/post_schema.json
@@ -79,8 +79,6 @@
         "lang_code":      { "type": "keyword", "normalizer": "default" },
         "lang_code_iso2": { "type": "keyword", "normalizer": "default" },
         "mention_did":    { "type": "keyword", "normalizer": "default" },
-        "link_url":       { "type": "keyword", "normalizer": "default" },
-        "embed_url":      { "type": "keyword", "normalizer": "default" },
         "embed_aturi":    { "type": "keyword", "normalizer": "default" },
         "reply_root_aturi": { "type": "keyword", "normalizer": "default" },
         "embed_img_count": { "type": "integer" },
@@ -88,8 +86,12 @@
         "embed_img_alt_text_ja": { "type": "text", "analyzer": "textJapanese", "search_analyzer": "textJapaneseSearch", "copy_to": "everything_ja" },
         "self_label":     { "type": "keyword", "normalizer": "default" },
 
+        "url":            { "type": "keyword", "normalizer": "default" },
+        "domain":         { "type": "keyword", "normalizer": "default" },
         "tag":            { "type": "keyword", "normalizer": "default" },
         "emoji":          { "type": "keyword", "normalizer": "caseSensitive" },
+
+        "likesFuzzy":     { "type": "int" },
 
         "everything":     { "type": "text", "analyzer": "textIcu", "search_analyzer": "textIcuSearch" },
         "everything_ja":  { "type": "text", "analyzer": "textJapanese", "search_analyzer": "textJapaneseSearch" },

--- a/search/post_schema.json
+++ b/search/post_schema.json
@@ -91,7 +91,7 @@
         "tag":            { "type": "keyword", "normalizer": "default" },
         "emoji":          { "type": "keyword", "normalizer": "caseSensitive" },
 
-        "likesFuzzy":     { "type": "int" },
+        "likesFuzzy":     { "type": "integer" },
 
         "everything":     { "type": "text", "analyzer": "textIcu", "search_analyzer": "textIcuSearch" },
         "everything_ja":  { "type": "text", "analyzer": "textJapanese", "search_analyzer": "textJapaneseSearch" },

--- a/search/profile_schema.json
+++ b/search/profile_schema.json
@@ -58,6 +58,8 @@
         "has_avatar":     { "type": "boolean" },
         "has_banner":     { "type": "boolean" },
 
+        "pagerank":       { "type": "float" },
+
         "typeahead":      { "type": "search_as_you_type", "analyzer": "textIcu", "search_analyzer": "textIcuSearch" },
         "everything":     { "type": "text", "analyzer": "textIcu", "search_analyzer": "textIcuSearch" }
     }

--- a/search/profile_schema.json
+++ b/search/profile_schema.json
@@ -52,6 +52,8 @@
         "img_alt_text":   { "type": "text", "analyzer": "textIcu", "search_analyzer": "textIcuSearch", "copy_to": "everything" },
         "self_label":     { "type": "keyword", "normalizer": "default" },
 
+        "url":            { "type": "keyword", "normalizer": "default" },
+        "domain":         { "type": "keyword", "normalizer": "default" },
         "tag":            { "type": "keyword", "normalizer": "default" },
         "emoji":          { "type": "keyword", "normalizer": "caseSensitive" },
 
@@ -59,6 +61,7 @@
         "has_banner":     { "type": "boolean" },
 
         "pagerank":       { "type": "float" },
+        "followersFuzzy": { "type": "int" },
 
         "typeahead":      { "type": "search_as_you_type", "analyzer": "textIcu", "search_analyzer": "textIcuSearch" },
         "everything":     { "type": "text", "analyzer": "textIcu", "search_analyzer": "textIcuSearch" }

--- a/search/profile_schema.json
+++ b/search/profile_schema.json
@@ -61,7 +61,7 @@
         "has_banner":     { "type": "boolean" },
 
         "pagerank":       { "type": "float" },
-        "followersFuzzy": { "type": "int" },
+        "followersFuzzy": { "type": "integer" },
 
         "typeahead":      { "type": "search_as_you_type", "analyzer": "textIcu", "search_analyzer": "textIcuSearch" },
         "everything":     { "type": "text", "analyzer": "textIcu", "search_analyzer": "textIcuSearch" }

--- a/search/query.go
+++ b/search/query.go
@@ -213,11 +213,9 @@ func DoSearchProfiles(ctx context.Context, dir identity.Directory, escli *es.Cli
 		return nil, err
 	}
 
-	// TODO: have a ParseProfileQuery function?
-	params := ParsePostQuery(ctx, dir, q)
 	basic := map[string]interface{}{
 		"simple_query_string": map[string]interface{}{
-			"query":            params.Query,
+			"query":            q,
 			"fields":           []string{"everything"},
 			"flags":            "AND|NOT|OR|PHRASE|PRECEDENCE|WHITESPACE",
 			"default_operator": "and",
@@ -235,7 +233,6 @@ func DoSearchProfiles(ctx context.Context, dir identity.Directory, escli *es.Cli
 					map[string]interface{}{"term": map[string]interface{}{"has_banner": true}},
 				},
 				"minimum_should_match": 0,
-				"filter":               params.Filters(),
 				"boost":                0.5,
 			},
 		},

--- a/search/query.go
+++ b/search/query.go
@@ -72,6 +72,36 @@ type ActorSearchParams struct {
 	Size      int         `json:"size"`
 }
 
+// Merges params from another param object in to this one. Intended to meld parsed query with HTTP query params, so not all functionality is supported, and priority is with the "current" object
+func (p *PostSearchParams) Update(other *PostSearchParams) {
+	p.Query = other.Query
+	if p.Author == nil {
+		p.Author = other.Author
+	}
+	if p.Since == nil {
+		p.Since = other.Since
+	}
+	if p.Until == nil {
+		p.Until = other.Until
+	}
+	if p.Mentions == nil {
+		p.Mentions = other.Mentions
+	}
+	if p.Lang == nil {
+		p.Lang = other.Lang
+	}
+	if p.Domain == "" {
+		p.Domain = other.Domain
+	}
+	if p.URL == "" {
+		p.URL = other.URL
+	}
+	if len(p.Tags) == 0 {
+		p.Tags = other.Tags
+	}
+}
+
+// turns search params in to actual elasticsearch/opensearch filter DSL
 func (p *PostSearchParams) Filters() []map[string]interface{} {
 	var filters []map[string]interface{}
 

--- a/search/query.go
+++ b/search/query.go
@@ -201,7 +201,7 @@ func DoSearchPosts(ctx context.Context, dir identity.Directory, escli *es.Client
 	if err := checkParams(params.Offset, params.Size); err != nil {
 		return nil, err
 	}
-	queryStringParams := ParsePostQuery(ctx, dir, params.Query)
+	queryStringParams := ParsePostQuery(ctx, dir, params.Query, params.Viewer)
 	params.Update(&queryStringParams)
 	idx := "everything"
 	if containsJapanese(params.Query) {

--- a/search/query.go
+++ b/search/query.go
@@ -123,7 +123,7 @@ func (p *PostSearchParams) Filters() []map[string]interface{} {
 
 	if p.URL != "" {
 		filters = append(filters, map[string]interface{}{
-			"term": map[string]interface{}{"url": p.URL},
+			"term": map[string]interface{}{"url": NormalizeLossyURL(p.URL)},
 		})
 	}
 

--- a/search/query.go
+++ b/search/query.go
@@ -67,7 +67,7 @@ type PostSearchParams struct {
 type ActorSearchParams struct {
 	Query     string      `json:"q"`
 	Typeahead bool        `json:"typeahead"`
-	Account   *syntax.DID `json:"account"`
+	Viewer    *syntax.DID `json:"viewer"`
 	Offset    int         `json:"offset"`
 	Size      int         `json:"size"`
 }

--- a/search/query.go
+++ b/search/query.go
@@ -107,20 +107,29 @@ func (p *PostSearchParams) Filters() []map[string]interface{} {
 
 	if p.Author != nil {
 		filters = append(filters, map[string]interface{}{
-			"term": map[string]interface{}{"did": p.Author.String()},
+			"term": map[string]interface{}{"did": map[string]interface{}{
+				"value":            p.Author.String(),
+				"case_insensitive": true,
+			}},
 		})
 	}
 
 	if p.Mentions != nil {
 		filters = append(filters, map[string]interface{}{
-			"term": map[string]interface{}{"mention_did": p.Mentions.String()},
+			"term": map[string]interface{}{"mention_did": map[string]interface{}{
+				"value":            p.Mentions.String(),
+				"case_insensitive": true,
+			}},
 		})
 	}
 
 	if p.Lang != nil {
 		// TODO: extracting just the 2-char code would be good
 		filters = append(filters, map[string]interface{}{
-			"term": map[string]interface{}{"lang_code_iso2": p.Lang.String()},
+			"term": map[string]interface{}{"lang_code_iso2": map[string]interface{}{
+				"value":            p.Lang.String(),
+				"case_insensitive": true,
+			}},
 		})
 	}
 
@@ -144,22 +153,21 @@ func (p *PostSearchParams) Filters() []map[string]interface{} {
 		})
 	}
 
-	if p.Lang != nil {
-		// TODO: extracting just the 2-char code would be good
-		filters = append(filters, map[string]interface{}{
-			"term": map[string]interface{}{"lang_code_iso2": p.Lang.String()},
-		})
-	}
-
 	if p.URL != "" {
 		filters = append(filters, map[string]interface{}{
-			"term": map[string]interface{}{"url": NormalizeLossyURL(p.URL)},
+			"term": map[string]interface{}{"url": map[string]interface{}{
+				"value":            NormalizeLossyURL(p.URL),
+				"case_insensitive": true,
+			}},
 		})
 	}
 
 	if p.Domain != "" {
 		filters = append(filters, map[string]interface{}{
-			"term": map[string]interface{}{"domain": p.Domain},
+			"term": map[string]interface{}{"domain": map[string]interface{}{
+				"value":            p.Domain,
+				"case_insensitive": true,
+			}},
 		})
 	}
 

--- a/search/query.go
+++ b/search/query.go
@@ -51,22 +51,26 @@ type PostSearchResult struct {
 }
 
 type PostSearchQuery struct {
-	Query  string     `json:"query"`
-	Offset int        `json:"offset"`
-	Size   int        `json:"size"`
-	From   *time.Time `json:"from"`
-	To     *time.Time `json:"to"`
-	Actors []string   `json:"actors"`
-	Tags   []string   `json:"tags"`
-	Langs  []string   `json:"langs"`
+	Query    string           `json:"q"`
+	Sort     string           `json:"sort"`
+	Author   *syntax.DID      `json:"author"`
+	Since    *syntax.Datetime `json:"since"`
+	Until    *syntax.Datetime `json:"until"`
+	Mentions *syntax.DID      `json:"mentions"`
+	Lang     *syntax.Language `json:"lang"`
+	Domain   string           `json:"domain"`
+	URL      string           `json:"url"`
+	Tag      string           `json:"tag"`
+	Offset   int              `json:"offset"`
+	Size     int              `json:"size"`
 }
 
 type ActorSearchQuery struct {
-	Query     string   `json:"query"`
-	Following []string `json:"following"`
-	Offset    int      `json:"offset"`
-	Size      int      `json:"size"`
-	Typeahead bool     `json:"typeahead"`
+	Query     string      `json:"q"`
+	Typeahead bool        `json:"typeahead"`
+	Account   *syntax.DID `json:"account"`
+	Offset    int         `json:"offset"`
+	Size      int         `json:"size"`
 }
 
 func checkParams(offset, size int) error {

--- a/search/query.go
+++ b/search/query.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log/slog"
+	"time"
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
@@ -47,6 +48,25 @@ type PostSearchResult struct {
 	Cid  string     `json:"cid"`
 	User UserResult `json:"user"`
 	Post any        `json:"post"`
+}
+
+type PostSearchQuery struct {
+	Query  string     `json:"query"`
+	Offset int        `json:"offset"`
+	Size   int        `json:"size"`
+	From   *time.Time `json:"from"`
+	To     *time.Time `json:"to"`
+	Actors []string   `json:"actors"`
+	Tags   []string   `json:"tags"`
+	Langs  []string   `json:"langs"`
+}
+
+type ActorSearchQuery struct {
+	Query     string   `json:"query"`
+	Following []string `json:"following"`
+	Offset    int      `json:"offset"`
+	Size      int      `json:"size"`
+	Typeahead bool     `json:"typeahead"`
 }
 
 func checkParams(offset, size int) error {

--- a/search/query_test.go
+++ b/search/query_test.go
@@ -339,6 +339,16 @@ func TestParsedQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(1, len(res.Hits.Hits))
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "post #Trick", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "post #trick #allMustMatch", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(0, len(res.Hits.Hits))
 
 	// mention query
 	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "@other.example.com", 0, 20)

--- a/search/query_test.go
+++ b/search/query_test.go
@@ -200,3 +200,201 @@ func TestJapaneseRegressions(t *testing.T) {
 	}
 	assert.Equal(1, len(res.Hits.Hits))
 }
+
+func TestParsedQuery(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+	escli := testEsClient(t)
+	dir := identity.NewMockDirectory()
+	srv := testServer(ctx, t, escli, &dir)
+	ident := identity.Identity{
+		DID:    syntax.DID("did:plc:abc111"),
+		Handle: syntax.Handle("handle.example.com"),
+	}
+	other := identity.Identity{
+		DID:    syntax.DID("did:plc:abc222"),
+		Handle: syntax.Handle("other.example.com"),
+	}
+	dir.Insert(ident)
+	dir.Insert(other)
+
+	res, err := DoSearchPosts(ctx, &dir, escli, testPostIndex, "english", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(0, len(res.Hits.Hits))
+
+	p1 := appbsky.FeedPost{Text: "basic english post", CreatedAt: "2024-01-02T03:04:05.006Z"}
+	assert.NoError(srv.indexPost(ctx, &ident, &p1, "app.bsky.feed.post/3kpnillluoh2y", cid.Undef))
+	p2 := appbsky.FeedPost{Text: "another english post", CreatedAt: "2024-01-02T03:04:05.006Z"}
+	assert.NoError(srv.indexPost(ctx, &ident, &p2, "app.bsky.feed.post/3kpnilllu2222", cid.Undef))
+	p3 := appbsky.FeedPost{
+		Text:      "#cat post with hashtag",
+		CreatedAt: "2024-01-02T03:04:05.006Z",
+		Facets: []*appbsky.RichtextFacet{
+			&appbsky.RichtextFacet{
+				Features: []*appbsky.RichtextFacet_Features_Elem{
+					&appbsky.RichtextFacet_Features_Elem{
+						RichtextFacet_Tag: &appbsky.RichtextFacet_Tag{
+							Tag: "trick",
+						},
+					},
+				},
+				Index: &appbsky.RichtextFacet_ByteSlice{
+					ByteStart: 0,
+					ByteEnd:   4,
+				},
+			},
+		},
+	}
+	assert.NoError(srv.indexPost(ctx, &ident, &p3, "app.bsky.feed.post/3kpnilllu3333", cid.Undef))
+	p4 := appbsky.FeedPost{
+		Text:      "@other.example.com post with mention",
+		CreatedAt: "2024-01-02T03:04:05.006Z",
+		Facets: []*appbsky.RichtextFacet{
+			&appbsky.RichtextFacet{
+				Features: []*appbsky.RichtextFacet_Features_Elem{
+					&appbsky.RichtextFacet_Features_Elem{
+						RichtextFacet_Mention: &appbsky.RichtextFacet_Mention{
+							Did: "did:plc:abc222",
+						},
+					},
+				},
+				Index: &appbsky.RichtextFacet_ByteSlice{
+					ByteStart: 0,
+					ByteEnd:   18,
+				},
+			},
+		},
+	}
+	assert.NoError(srv.indexPost(ctx, &ident, &p4, "app.bsky.feed.post/3kpnilllu4444", cid.Undef))
+	p5 := appbsky.FeedPost{
+		Text:      "https://bsky.app... post with hashtag #cat",
+		CreatedAt: "2024-01-02T03:04:05.006Z",
+		Facets: []*appbsky.RichtextFacet{
+			&appbsky.RichtextFacet{
+				Features: []*appbsky.RichtextFacet_Features_Elem{
+					&appbsky.RichtextFacet_Features_Elem{
+						RichtextFacet_Link: &appbsky.RichtextFacet_Link{
+							Uri: "htTPS://www.en.wikipedia.org/wiki/CBOR?q=3&a=1&utm_campaign=123",
+						},
+					},
+				},
+				Index: &appbsky.RichtextFacet_ByteSlice{
+					ByteStart: 0,
+					ByteEnd:   19,
+				},
+			},
+		},
+	}
+	assert.NoError(srv.indexPost(ctx, &ident, &p5, "app.bsky.feed.post/3kpnilllu5555", cid.Undef))
+	p6 := appbsky.FeedPost{
+		Text:      "post with lang (deutsch)",
+		CreatedAt: "2024-01-02T03:04:05.006Z",
+		Langs:     []string{"ja", "de-DE"},
+	}
+	assert.NoError(srv.indexPost(ctx, &ident, &p6, "app.bsky.feed.post/3kpnilllu6666", cid.Undef))
+	p7 := appbsky.FeedPost{Text: "post with old date", CreatedAt: "2020-05-03T03:04:05.006Z"}
+	assert.NoError(srv.indexPost(ctx, &ident, &p7, "app.bsky.feed.post/3kpnilllu7777", cid.Undef))
+
+	_, err = srv.escli.Indices.Refresh()
+	assert.NoError(err)
+
+	// expect all to be indexed
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "*", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(7, len(res.Hits.Hits))
+
+	// check that english matches both
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "english", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(2, len(res.Hits.Hits))
+
+	// phrase only matches one
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "\"basic english\"", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+
+	// posts-by
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "from:handle.example.com", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(7, len(res.Hits.Hits))
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "from:@handle.example.com", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(7, len(res.Hits.Hits))
+
+	// hashtag query
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "post #trick", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+
+	// mention query
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "@other.example.com", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+
+	// URL and domain queries
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "https://en.wikipedia.org/wiki/CBOR?a=1&q=3", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "\"https://en.wikipedia.org/wiki/CBOR?a=1&q=3\"", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(0, len(res.Hits.Hits))
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "https://en.wikipedia.org/wiki/CBOR", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(0, len(res.Hits.Hits))
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "domain:en.wikipedia.org", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+
+	// lang filter
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "lang:de", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+
+	// date range filters
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "since:2023-01-01T00:00:00Z", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(6, len(res.Hits.Hits))
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "since:2023-01-01", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(6, len(res.Hits.Hits))
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "until:2023-01-01", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(1, len(res.Hits.Hits))
+	res, err = DoSearchPosts(ctx, &dir, escli, testPostIndex, "until:asdf", 0, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(7, len(res.Hits.Hits))
+}

--- a/search/testdata/transform-post-fixtures.json
+++ b/search/testdata/transform-post-fixtures.json
@@ -11,7 +11,7 @@
   			"embed": {
     			"$type": "app.bsky.embed.external",
     			"external": {
-      			"uri": "https://bsky.app",
+      			"uri": "https://www.bsky.app:443/index.html",
       			"title": "Bluesky Social",
       			"description": "See what's next.",
       			"thumb": {
@@ -70,7 +70,7 @@
       			"features": [
         			{
           			"$type": "app.bsky.richtext.facet#link",
-          			"uri": "https://en.wikipedia.org/wiki/CBOR"
+          			"uri": "https://en.wikipedia.org/wiki/CBOR?utm_campaign=123"
         			}
       			]
     			},

--- a/search/testdata/transform-post-fixtures.json
+++ b/search/testdata/transform-post-fixtures.json
@@ -34,7 +34,8 @@
   			"record_cid": "bafyreibjifzpqj6o6wcq3hejh7y4z4z2vmiklkvykc57tw3pcbx3kxifpm",
   			"created_at": "2023-08-07T05:46:14.423045Z",
   			"text": "post which embeds an external URL as a card",
-  			"embed_url": "https://bsky.app",
+  			"url": ["https://bsky.app"],
+  			"domain": ["bsky.app"],
   			"embed_img_count": 0
 		}
 	},
@@ -123,12 +124,13 @@
   			"created_at": "2023-08-07T05:46:14.423045Z",
   			"text": "longer example with #some #hashtags, emoji \u2620 \ud83d\ude42 \ud83c\udf85\ud83c\udfff, flags \ud83c\uddf8\ud83c\udde8 ",
   			"reply_root_aturi": "at://did:plc:u5cwb2mwiv2bfq53cjufe6yn/app.bsky.feed.post/3k43tv4rft22g",
-  			"link_url": [ "https://en.wikipedia.org/wiki/CBOR" ],
   			"mention_did": [ "did:plc:ewvi7nxzyoun6zhxrhs64oiz" ],
   			"embed_aturi": "at://did:plc:u5cwb2mwiv2bfq53cjufe6yn/app.bsky.feed.post/3k44deefqdk2g",
   			"lang_code": ["th", "en-US"],
   			"lang_code_iso2": ["th", "en"],
             "self_label": ["nudity"],
+  			"url": [ "https://en.wikipedia.org/wiki/CBOR" ],
+  			"domain": [ "en.wikipedia.org" ],
   			"tag": ["some", "thing"],
   			"emoji": ["\u2620", "\ud83d\ude42", "\ud83c\udf85\ud83c\udfff", "\ud83c\uddf8\ud83c\udde8"],
   			"embed_img_count": 0

--- a/search/transform.go
+++ b/search/transform.go
@@ -37,7 +37,7 @@ type PostDoc struct {
 	RecordCID         string   `json:"record_cid"`
 	CreatedAt         *string  `json:"created_at,omitempty"`
 	Text              string   `json:"text"`
-	TextJA            string   `json:"text_ja,omitempty"`
+	TextJA            *string  `json:"text_ja,omitempty"`
 	LangCode          []string `json:"lang_code,omitempty"`
 	LangCodeIso2      []string `json:"lang_code_iso2,omitempty"`
 	MentionDID        []string `json:"mention_did,omitempty"`
@@ -196,7 +196,7 @@ func TransformPost(post *appbsky.FeedPost, ident *identity.Identity, rkey, cid s
 	}
 
 	if containsJapanese(post.Text) {
-		doc.TextJA = post.Text
+		doc.TextJA = &post.Text
 	}
 
 	if post.CreatedAt != "" {

--- a/search/transform.go
+++ b/search/transform.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"log/slog"
+	"net/url"
 	"strings"
 	"time"
 
@@ -21,6 +22,8 @@ type ProfileDoc struct {
 	Description *string  `json:"description,omitempty"`
 	ImgAltText  []string `json:"img_alt_text,omitempty"`
 	SelfLabel   []string `json:"self_label,omitempty"`
+	URL         []string `json:"url,omitempty"`
+	Domain      []string `json:"domain,omitempty"`
 	Tag         []string `json:"tag,omitempty"`
 	Emoji       []string `json:"emoji,omitempty"`
 	HasAvatar   bool     `json:"has_avatar"`
@@ -38,14 +41,14 @@ type PostDoc struct {
 	LangCode          []string `json:"lang_code,omitempty"`
 	LangCodeIso2      []string `json:"lang_code_iso2,omitempty"`
 	MentionDID        []string `json:"mention_did,omitempty"`
-	LinkURL           []string `json:"link_url,omitempty"`
-	EmbedURL          *string  `json:"embed_url,omitempty"`
 	EmbedATURI        *string  `json:"embed_aturi,omitempty"`
 	ReplyRootATURI    *string  `json:"reply_root_aturi,omitempty"`
 	EmbedImgCount     int      `json:"embed_img_count"`
 	EmbedImgAltText   []string `json:"embed_img_alt_text,omitempty"`
 	EmbedImgAltTextJA []string `json:"embed_img_alt_text_ja,omitempty"`
 	SelfLabel         []string `json:"self_label,omitempty"`
+	URL               []string `json:"url,omitempty"`
+	Domain            []string `json:"domain,omitempty"`
 	Tag               []string `json:"tag,omitempty"`
 	Emoji             []string `json:"emoji,omitempty"`
 }
@@ -117,14 +120,14 @@ func TransformPost(post *appbsky.FeedPost, ident *identity.Identity, rkey, cid s
 		}
 	}
 	var mentionDIDs []string
-	var linkURLs []string
+	var urls []string
 	for _, facet := range post.Facets {
 		for _, feat := range facet.Features {
 			if feat.RichtextFacet_Mention != nil {
 				mentionDIDs = append(mentionDIDs, feat.RichtextFacet_Mention.Did)
 			}
 			if feat.RichtextFacet_Link != nil {
-				linkURLs = append(linkURLs, feat.RichtextFacet_Link.Uri)
+				urls = append(urls, feat.RichtextFacet_Link.Uri)
 			}
 		}
 	}
@@ -132,9 +135,8 @@ func TransformPost(post *appbsky.FeedPost, ident *identity.Identity, rkey, cid s
 	if post.Reply != nil {
 		replyRootATURI = &(post.Reply.Root.Uri)
 	}
-	var embedURL *string
 	if post.Embed != nil && post.Embed.EmbedExternal != nil {
-		embedURL = &post.Embed.EmbedExternal.External.Uri
+		urls = append(urls, post.Embed.EmbedExternal.External.Uri)
 	}
 	var embedATURI *string
 	if post.Embed != nil && post.Embed.EmbedRecord != nil {
@@ -164,6 +166,14 @@ func TransformPost(post *appbsky.FeedPost, ident *identity.Identity, rkey, cid s
 		}
 	}
 
+	var domains []string
+	for _, raw := range urls {
+		u, err := url.Parse(raw)
+		if nil == err {
+			domains = append(domains, u.Hostname())
+		}
+	}
+
 	doc := PostDoc{
 		DocIndexTs:        syntax.DatetimeNow().String(),
 		DID:               ident.DID.String(),
@@ -173,14 +183,14 @@ func TransformPost(post *appbsky.FeedPost, ident *identity.Identity, rkey, cid s
 		LangCode:          post.Langs,
 		LangCodeIso2:      langCodeIso2,
 		MentionDID:        mentionDIDs,
-		LinkURL:           linkURLs,
-		EmbedURL:          embedURL,
 		EmbedATURI:        embedATURI,
 		ReplyRootATURI:    replyRootATURI,
 		EmbedImgCount:     embedImgCount,
 		EmbedImgAltText:   embedImgAltText,
 		EmbedImgAltTextJA: embedImgAltTextJA,
 		SelfLabel:         selfLabels,
+		URL:               urls,
+		Domain:            domains,
 		Tag:               parsePostTags(post),
 		Emoji:             parseEmojis(post.Text),
 	}

--- a/search/transform.go
+++ b/search/transform.go
@@ -167,8 +167,10 @@ func TransformPost(post *appbsky.FeedPost, ident *identity.Identity, rkey, cid s
 	}
 
 	var domains []string
-	for _, raw := range urls {
-		u, err := url.Parse(raw)
+	for i, raw := range urls {
+		clean := NormalizeLossyURL(raw)
+		urls[i] = clean
+		u, err := url.Parse(clean)
 		if nil == err {
 			domains = append(domains, u.Hostname())
 		}

--- a/search/url.go
+++ b/search/url.go
@@ -42,6 +42,9 @@ func NormalizeLossyURL(raw string) string {
 
 	// remove tracking params
 	u, err := url.Parse(clean)
+	if err != nil {
+		return clean
+	}
 	if u.RawQuery == "" {
 		return clean
 	}

--- a/search/url.go
+++ b/search/url.go
@@ -1,0 +1,58 @@
+package search
+
+import (
+	"net/url"
+
+	"github.com/PuerkitoBio/purell"
+)
+
+var trackingParams = []string{
+	"__s",
+	"_ga",
+	"campaign_id",
+	"ceid",
+	"emci",
+	"emdi",
+	"fbclid",
+	"gclid",
+	"hootPostID",
+	"mc_eid",
+	"mkclid",
+	"mkt_tok",
+	"msclkid",
+	"pk_campaign",
+	"pk_kwd",
+	"sessionid",
+	"sourceid",
+	"utm_campaign",
+	"utm_content",
+	"utm_id",
+	"utm_medium",
+	"utm_source",
+	"utm_term",
+	"xpid",
+}
+
+// aggressively normalizes URL, for search indexing and matching. it is possible the URL won't be directly functional after this normalization
+func NormalizeLossyURL(raw string) string {
+	clean, err := purell.NormalizeURLString(raw, purell.FlagsUsuallySafeGreedy|purell.FlagRemoveDirectoryIndex|purell.FlagRemoveFragment|purell.FlagRemoveDuplicateSlashes|purell.FlagRemoveWWW|purell.FlagSortQuery)
+	if err != nil {
+		return raw
+	}
+
+	// remove tracking params
+	u, err := url.Parse(clean)
+	if u.RawQuery == "" {
+		return clean
+	}
+	params := u.Query()
+
+	// there is probably a more efficient way to do this
+	for _, p := range trackingParams {
+		if params.Has(p) {
+			params.Del(p)
+		}
+	}
+	u.RawQuery = params.Encode()
+	return u.String()
+}

--- a/search/url_test.go
+++ b/search/url_test.go
@@ -1,0 +1,33 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeLossyURL(t *testing.T) {
+	assert := assert.New(t)
+
+	fixtures := []struct {
+		orig  string
+		clean string
+	}{
+		{orig: "", clean: ""},
+		{orig: "asdf", clean: "asdf"},
+		{orig: "HTTP://bSky.app:80/index.html", clean: "http://bsky.app"},
+		{orig: "https://example.com/thing?c=123&utm_campaign=blah&a=first", clean: "https://example.com/thing?a=first&c=123"},
+		{orig: "https://example.com/thing?c=123&utm_campaign=blah&a=first", clean: "https://example.com/thing?a=first&c=123"},
+		{orig: "http://example.com/foo//bar.html", clean: "http://example.com/foo/bar.html"},
+		{orig: "http://example.com/bar.html#section1", clean: "http://example.com/bar.html"},
+		{orig: "http://example.com/foo/", clean: "http://example.com/foo"},
+		{orig: "http://example.com/", clean: "http://example.com"},
+		{orig: "http://example.com/%7Efoo", clean: "http://example.com/~foo"},
+		{orig: "http://example.com/foo/./bar/baz/../qux", clean: "http://example.com/foo/bar/qux"},
+		{orig: "http://www.example.com/", clean: "http://example.com"},
+	}
+
+	for _, fix := range fixtures {
+		assert.Equal(fix.clean, NormalizeLossyURL(fix.orig))
+	}
+}


### PR DESCRIPTION
TODO:

- [x] normalize URLs: maybe with `purell`, maybe stripping tracking parameters
- [x] date-level queries
- [x] add end-to-end tests (similar to japanese queries)
- [x] implement "merge" of query params (parsed and actual params)
- [x] run lexgen and wire up actual query params
- [x] `from:me` post search behavior (server-side, using viewer param)
- [ ] alternate post "sort" order (top vs. latest)

Closes: https://github.com/bluesky-social/indigo/issues/191
Closes: https://github.com/bluesky-social/indigo/issues/593