### PR TITLE
search: ensure text_ja is optional

### DIFF
--- a/search/transform.go
+++ b/search/transform.go
@@ -34,7 +34,7 @@ type PostDoc struct {
 	RecordCID         string   `json:"record_cid"`
 	CreatedAt         *string  `json:"created_at,omitempty"`
 	Text              string   `json:"text"`
-	TextJA            string   `json:"text_ja,omitempty"`
+	TextJA            *string  `json:"text_ja,omitempty"`
 	LangCode          []string `json:"lang_code,omitempty"`
 	LangCodeIso2      []string `json:"lang_code_iso2,omitempty"`
 	MentionDID        []string `json:"mention_did,omitempty"`
@@ -186,7 +186,7 @@ func TransformPost(post *appbsky.FeedPost, ident *identity.Identity, rkey, cid s
 	}
 
 	if containsJapanese(post.Text) {
-		doc.TextJA = post.Text
+		doc.TextJA = &post.Text
 	}
 
 	if post.CreatedAt != "" {


### PR DESCRIPTION
The `omitempty` logic was probably already working, but this makes it more explicit and the code more readable.

Thanks Jaz!