### PR TITLE
automod: refactor 'admin' and Ozone clients

### DIFF
--- a/automod/engine/engine.go
+++ b/automod/engine/engine.go
@@ -35,9 +35,11 @@ type Engine struct {
 	Flags     flagstore.FlagStore
 	// unlike the other sub-modules, this field (Notifier) may be nil
 	Notifier Notifier
-	// use to fetch public account metadata from AppView
+	// use to fetch public account metadata from AppView; no auth
 	BskyClient *xrpc.Client
-	// used to persist moderation actions in mod service (optional)
+	// used to persist moderation actions in ozone moderation service; optional, admin auth
+	OzoneClient *xrpc.Client
+	// used to fetch private account metadata from PDS or entryway; optional, admin auth
 	AdminClient *xrpc.Client
 	// used to fetch blobs from upstream PDS instances
 	BlobClient *http.Client

--- a/automod/engine/persist.go
+++ b/automod/engine/persist.go
@@ -77,14 +77,14 @@ func (eng *Engine) persistAccountModActions(c *AccountContext) error {
 	}
 
 	// if we can't actually talk to service, bail out early
-	if eng.AdminClient == nil {
+	if eng.OzoneClient == nil {
 		if anyModActions {
 			c.Logger.Warn("not persisting actions, mod service client not configured")
 		}
 		return nil
 	}
 
-	xrpcc := eng.AdminClient
+	xrpcc := eng.OzoneClient
 
 	if len(newLabels) > 0 {
 		c.Logger.Info("labeling record", "newLabels", newLabels)
@@ -166,8 +166,8 @@ func (eng *Engine) persistRecordModActions(c *RecordContext) error {
 
 	atURI := c.RecordOp.ATURI().String()
 	newLabels := dedupeStrings(c.effects.RecordLabels)
-	if len(newLabels) > 0 && eng.AdminClient != nil {
-		rv, err := toolsozone.ModerationGetRecord(ctx, eng.AdminClient, c.RecordOp.CID.String(), c.RecordOp.ATURI().String())
+	if len(newLabels) > 0 && eng.OzoneClient != nil {
+		rv, err := toolsozone.ModerationGetRecord(ctx, eng.OzoneClient, c.RecordOp.CID.String(), c.RecordOp.ATURI().String())
 		if err != nil {
 			c.Logger.Warn("failed to fetch private record metadata", "err", err)
 		} else {
@@ -234,7 +234,7 @@ func (eng *Engine) persistRecordModActions(c *RecordContext) error {
 		return nil
 	}
 
-	if eng.AdminClient == nil {
+	if eng.OzoneClient == nil {
 		c.Logger.Warn("not persisting actions because mod service client not configured")
 		return nil
 	}
@@ -249,7 +249,7 @@ func (eng *Engine) persistRecordModActions(c *RecordContext) error {
 		Uri: atURI,
 	}
 
-	xrpcc := eng.AdminClient
+	xrpcc := eng.OzoneClient
 	if len(newLabels) > 0 {
 		c.Logger.Info("labeling record", "newLabels", newLabels)
 		for _, val := range newLabels {


### PR DESCRIPTION
We don't actually need the "ozone" client to have a session via password; it just uses admin auth and provides DID as CreatedBy arg when emitting events. It can also talk directly to the Ozone instance.

The PDS admin client also is admin-auth only, and talks to entryway (optional).