### PR TITLE
Per-day new PDS limiter to allow less constrained federation

### DIFF
--- a/bgs/admin.go
+++ b/bgs/admin.go
@@ -37,6 +37,33 @@ func (bgs *BGS) handleAdminGetSubsEnabled(e echo.Context) error {
 	})
 }
 
+func (bgs *BGS) handleAdminGetNewPDSPerDayRateLimit(e echo.Context) error {
+	limit := bgs.slurper.GetNewPDSPerDayLimit()
+	return e.JSON(200, map[string]int64{
+		"limit": limit,
+	})
+}
+
+func (bgs *BGS) handleAdminSetNewPDSPerDayRateLimit(e echo.Context) error {
+	limit, err := strconv.ParseInt(e.QueryParam("limit"), 10, 64)
+	if err != nil {
+		return &echo.HTTPError{
+			Code:    400,
+			Message: fmt.Errorf("failed to parse limit: %w", err).Error(),
+		}
+	}
+
+	err = bgs.slurper.SetNewPDSPerDayLimit(limit)
+	if err != nil {
+		return &echo.HTTPError{
+			Code:    500,
+			Message: fmt.Errorf("failed to set new PDS per day rate limit: %w", err).Error(),
+		}
+	}
+
+	return nil
+}
+
 func (bgs *BGS) handleAdminTakeDownRepo(e echo.Context) error {
 	ctx := e.Request().Context()
 

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -331,8 +331,10 @@ func (bgs *BGS) StartWithListener(listen net.Listener) error {
 	// Slurper-related Admin API
 	admin.GET("/subs/getUpstreamConns", bgs.handleAdminGetUpstreamConns)
 	admin.GET("/subs/getEnabled", bgs.handleAdminGetSubsEnabled)
+	admin.GET("/subs/perDayLimit", bgs.handleAdminGetNewPDSPerDayRateLimit)
 	admin.POST("/subs/setEnabled", bgs.handleAdminSetSubsEnabled)
 	admin.POST("/subs/killUpstream", bgs.handleAdminKillUpstreamConn)
+	admin.POST("/subs/setPerDayLimit", bgs.handleAdminSetNewPDSPerDayRateLimit)
 
 	// Domain-related Admin API
 	admin.GET("/subs/listDomainBans", bgs.handleAdminListDomainBans)

--- a/cmd/palomar/docker-compose.yml
+++ b/cmd/palomar/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - "plugins.security.disabled=true"
       - "bootstrap.memory_lock=true" # Disable JVM heap memory swapping
       - "OPENSEARCH_JAVA_OPTS=-Xms4096m -Xmx4096m" # Set min and max JVM heap sizes to at least 50% of system RAM
+      - "OPENSEARCH_INITIAL_ADMIN_PASSWORD=0penSearch-Pal0mar"
     ulimits:
       memlock:
         soft: -1
@@ -43,8 +44,13 @@ services:
       - "PALOMAR_BGS_SYNC_RATE_LIMIT=20"
       - "PALOMAR_INDEX_MAX_CONCURRENCY=5"
       - "DATABASE_URL=sqlite:///data/palomar/search.db"
+      - "PALOMAR_BIND=:3997"
+      - "PALOMAR_METRICS_LISTEN=:3996"
     depends_on:
       - opensearch
+    ports:
+      - "3997:3997"
+      - "3996:3996"
     volumes:
       - type: bind
         source: ../../data

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -167,6 +167,29 @@ func (tp *TestPDS) Run(t *testing.T) {
 func (tp *TestPDS) RequestScraping(t *testing.T, b *TestRelay) {
 	t.Helper()
 
+	err := b.bgs.CreateAdminToken("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("POST", "http://"+b.Host()+"/admin/subs/setPerDayLimit?limit=500", nil)
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test")
+
+	// Send the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	// Check the response
+	if resp.StatusCode != http.StatusOK {
+		t.Fatal("expected 200 OK, got: ", resp.Status)
+	}
+
 	c := &xrpc.Client{Host: "http://" + b.Host()}
 	if err := atproto.SyncRequestCrawl(context.TODO(), c, &atproto.SyncRequestCrawl_Input{Hostname: tp.RawHost()}); err != nil {
 		t.Fatal(err)

--- a/ts/bgs-dash/src/components/Dash/Dash.tsx
+++ b/ts/bgs-dash/src/components/Dash/Dash.tsx
@@ -39,6 +39,8 @@ const Dash: FC<{}> = () => {
   // Slurp Toggle Management
   const [slurpsEnabled, setSlurpsEnabled] = useState<boolean>(true);
   const [canToggleSlurps, setCanToggleSlurps] = useState<boolean>(true);
+  const [newPDSLimit, setNewPDSLimit] = useState<number>(0);
+  const [canSetNewPDSLimit, setCanSetNewPDSLimit] = useState<boolean>(true);
 
   // Notification Management
   const [shouldShowNotification, setShouldShowNotification] =
@@ -213,6 +215,72 @@ const Dash: FC<{}> = () => {
         );
       });
   };
+
+  const getNewPDSRateLimit = () => {
+    fetch(`${RELAY_HOST}/admin/subs/perDayLimit`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${adminToken}`,
+      },
+    })
+      .then((res) => res.json())
+      .then((res) => {
+        if ("error" in res) {
+          setAlertWithTimeout(
+            "failure",
+            `Failed to fetch New PDS rate limit: ${res.error}`,
+            true
+          );
+          return;
+        }
+        setNewPDSLimit(res.limit);
+      })
+      .catch((err) => {
+        setAlertWithTimeout(
+          "failure",
+          `Failed to fetch New PDS rate limit: ${err}`,
+          true
+        );
+      });
+  }
+
+  const setNewPDSRateLimit = (limit: number) => {
+    setCanSetNewPDSLimit(false);
+    fetch(`${RELAY_HOST}/admin/subs/setPerDayLimit?limit=${limit}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${adminToken}`,
+      },
+
+    })
+      .then((res) => {
+        setCanSetNewPDSLimit(true);
+        if (res.status !== 200) {
+          setAlertWithTimeout(
+            "failure",
+            `Failed to set New PDS rate limit: ${res.status}`,
+            true
+          );
+          return;
+        }
+        setAlertWithTimeout(
+          "success",
+          `Successfully set New PDS rate limit to ${limit} / day`,
+          true
+        );
+        setNewPDSLimit(limit);
+      })
+      .catch((err) => {
+        setCanSetNewPDSLimit(true);
+        setAlertWithTimeout(
+          "failure",
+          `Failed to set New PDS rate limit: ${err}`,
+          true
+        );
+      });
+  }
 
   const requestCrawlHost = (host: string) => {
     fetch(`${RELAY_HOST}/xrpc/com.atproto.sync.requestCrawl`, {
@@ -398,10 +466,12 @@ const Dash: FC<{}> = () => {
   useEffect(() => {
     refreshPDSList();
     getSlurpsEnabled();
+    getNewPDSRateLimit();
     // Refresh stats every 10 seconds
     const interval = setInterval(() => {
       refreshPDSList();
       getSlurpsEnabled();
+      getNewPDSRateLimit();
     }, 10 * 1000);
 
     return () => clearInterval(interval);
@@ -424,6 +494,7 @@ const Dash: FC<{}> = () => {
       ) : (
         <></>
       )}
+      <div></div>
       <div className="sm:flex sm:items-center">
         <div className="sm:flex-auto">
           <h1 className="text-2xl font-semibold leading-6 text-gray-900">
@@ -434,7 +505,7 @@ const Dash: FC<{}> = () => {
           </p>
         </div>
 
-        <div className="inline-flex mt-5 sm:mt-0">
+        <div className="inline-flex mt-5 sm:mt-0 flex-col">
           <Switch.Group as="div" className="flex items-center justify-between">
             <span className="flex flex-grow flex-col mr-5">
               <Switch.Label as="span" className="text-gray-900" passive>
@@ -473,6 +544,39 @@ const Dash: FC<{}> = () => {
               />
             </Switch>
           </Switch.Group>
+        </div>
+        <div className="ml-4 flex-row">
+          <div className="flex-none">
+            <label htmlFor="new-pds-rate-limit" className="block text-sm font-medium leading-6 text-gray-900">
+              New PDSs Per Day Limit
+            </label>
+            <div className="mt-2 flex rounded-md shadow-sm">
+
+              <div className="relative flex flex-grow items-stretch focus-within:z-10">
+                <input
+                  type="number"
+                  id="new-pds-rate-limit"
+                  name="new-pds-rate-limit"
+                  className="block w-full rounded-none rounded-l-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+                  value={newPDSLimit}
+                  aria-describedby="rate-limit"
+                  onChange={(e) => {
+                    setNewPDSLimit(parseInt(e.target.value));
+                  }}
+                />
+              </div>
+              <button
+                type="button"
+                className="relative -ml-px inline-flex items-center gap-x-1.5 rounded-r-md px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+                disabled={!canSetNewPDSLimit}
+                onClick={() => {
+                  setNewPDSRateLimit(newPDSLimit);
+                }}
+              >
+                Update
+              </button>
+            </div>
+          </div>
         </div>
 
       </div>

--- a/ts/bgs-dash/src/components/Dash/Dash.tsx
+++ b/ts/bgs-dash/src/components/Dash/Dash.tsx
@@ -545,37 +545,34 @@ const Dash: FC<{}> = () => {
             </Switch>
           </Switch.Group>
         </div>
-        <div className="ml-4 flex-row">
-          <div className="flex-none">
-            <label htmlFor="new-pds-rate-limit" className="block text-sm font-medium leading-6 text-gray-900">
-              New PDSs Per Day Limit
-            </label>
-            <div className="mt-2 flex rounded-md shadow-sm">
-
-              <div className="relative flex flex-grow items-stretch focus-within:z-10">
-                <input
-                  type="number"
-                  id="new-pds-rate-limit"
-                  name="new-pds-rate-limit"
-                  className="block w-full rounded-none rounded-l-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-                  value={newPDSLimit}
-                  aria-describedby="rate-limit"
-                  onChange={(e) => {
-                    setNewPDSLimit(parseInt(e.target.value));
-                  }}
-                />
-              </div>
-              <button
-                type="button"
-                className="relative -ml-px inline-flex items-center gap-x-1.5 rounded-r-md px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-                disabled={!canSetNewPDSLimit}
-                onClick={() => {
-                  setNewPDSRateLimit(newPDSLimit);
+        <div className="ml-4">
+          <label htmlFor="new-pds-rate-limit" className="block text-sm font-medium leading-6 text-gray-900">
+            New PDSs Per Day Limit
+          </label>
+          <div className="mt-2 flex rounded-md shadow-sm">
+            <div className="relative flex flex-grow items-stretch focus-within:z-10">
+              <input
+                type="number"
+                id="new-pds-rate-limit"
+                name="new-pds-rate-limit"
+                className="block w-full rounded-none rounded-l-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+                value={newPDSLimit}
+                aria-describedby="rate-limit"
+                onChange={(e) => {
+                  setNewPDSLimit(parseInt(e.target.value));
                 }}
-              >
-                Update
-              </button>
+              />
             </div>
+            <button
+              type="button"
+              className="relative -ml-px inline-flex items-center gap-x-1.5 rounded-r-md px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+              disabled={!canSetNewPDSLimit}
+              onClick={() => {
+                setNewPDSRateLimit(newPDSLimit);
+              }}
+            >
+              Update
+            </button>
           </div>
         </div>
 

--- a/ts/bgs-dash/src/components/Dash/Dash.tsx
+++ b/ts/bgs-dash/src/components/Dash/Dash.tsx
@@ -504,75 +504,79 @@ const Dash: FC<{}> = () => {
             A list of all PDS connections and their current status.
           </p>
         </div>
-
-        <div className="inline-flex mt-5 sm:mt-0 flex-col">
-          <Switch.Group as="div" className="flex items-center justify-between">
-            <span className="flex flex-grow flex-col mr-5">
-              <Switch.Label as="span" className="text-gray-900" passive>
-                {slurpsEnabled ? (
-                  <ShieldCheckIcon
-                    className="h-5 w-5 mr-2 mb-1 inline-block"
-                    aria-hidden="true"
-                  />
-                ) : (
-                  <ShieldExclamationIcon
-                    className="h-5 w-5 mr-2 mb-1 inline-block"
-                    aria-hidden="true"
-                  />
-                )}
-                <span className="text-md font-medium leading-6">
-                  New Connections {slurpsEnabled ? "Enabled" : "Disabled"}
-                </span>
-              </Switch.Label>
-            </span>
-            <Switch
-              checked={slurpsEnabled}
-              onChange={requestSlurpsEnabledStateChange}
-              disabled={!canToggleSlurps}
-              className={classNames(
-                slurpsEnabled ? "bg-green-600" : "bg-red-400",
-                canToggleSlurps ? "cursor-pointer" : "cursor-not-allowed",
-                "relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-2"
-              )}
-            >
-              <span
-                aria-hidden="true"
+        <div className="flex flex-col mt-5">
+          <div className="inline-flex mt-5 sm:mt-0 flex-col">
+            <Switch.Group as="div" className="flex items-center justify-between">
+              <span className="flex flex-grow flex-col mr-5">
+                <Switch.Label as="span" className="text-gray-900" passive>
+                  {slurpsEnabled ? (
+                    <ShieldCheckIcon
+                      className="h-5 w-5 mr-2 mb-1 inline-block"
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <ShieldExclamationIcon
+                      className="h-5 w-5 mr-2 mb-1 inline-block"
+                      aria-hidden="true"
+                    />
+                  )}
+                  <span className="text-md font-medium leading-6">
+                    New Connections {slurpsEnabled ? "Enabled" : "Disabled"}
+                  </span>
+                </Switch.Label>
+              </span>
+              <Switch
+                checked={slurpsEnabled}
+                onChange={requestSlurpsEnabledStateChange}
+                disabled={!canToggleSlurps}
                 className={classNames(
-                  slurpsEnabled ? "translate-x-5" : "translate-x-0",
-                  "pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                  slurpsEnabled ? "bg-green-600" : "bg-red-400",
+                  canToggleSlurps ? "cursor-pointer" : "cursor-not-allowed",
+                  "relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-2"
                 )}
-              />
-            </Switch>
-          </Switch.Group>
-        </div>
-        <div className="ml-4">
-          <label htmlFor="new-pds-rate-limit" className="block text-sm font-medium leading-6 text-gray-900">
-            New PDSs Per Day Limit
-          </label>
-          <div className="mt-2 flex rounded-md shadow-sm">
-            <div className="relative flex flex-grow items-stretch focus-within:z-10">
-              <input
-                type="number"
-                id="new-pds-rate-limit"
-                name="new-pds-rate-limit"
-                className="block w-full rounded-none rounded-l-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-                value={newPDSLimit}
-                aria-describedby="rate-limit"
-                onChange={(e) => {
-                  setNewPDSLimit(parseInt(e.target.value));
+              >
+                <span
+                  aria-hidden="true"
+                  className={classNames(
+                    slurpsEnabled ? "translate-x-5" : "translate-x-0",
+                    "pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                  )}
+                />
+              </Switch>
+            </Switch.Group>
+          </div>
+          <div className="ml-4">
+            <div className="mt-2 flex rounded-md shadow-sm">
+              <div className="relative flex flex-grow items-stretch focus-within:z-10">
+                <input
+                  type="number"
+                  id="new-pds-rate-limit"
+                  name="new-pds-rate-limit"
+                  // Hides the up/down arrows on number inputs
+                  className="[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none block w-full rounded-none rounded-l-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+                  value={newPDSLimit}
+                  aria-describedby="rate-limit"
+                  onChange={(e) => {
+                    setNewPDSLimit(parseInt(e.target.value));
+                  }}
+                />
+                <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
+                  <span className="text-gray-500 sm:text-sm" id="price-currency">
+                    PDS / Day
+                  </span>
+                </div>
+              </div>
+              <button
+                type="button"
+                className="relative -ml-px inline-flex items-center gap-x-1.5 rounded-r-md px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+                disabled={!canSetNewPDSLimit}
+                onClick={() => {
+                  setNewPDSRateLimit(newPDSLimit);
                 }}
-              />
+              >
+                Update
+              </button>
             </div>
-            <button
-              type="button"
-              className="relative -ml-px inline-flex items-center gap-x-1.5 rounded-r-md px-3 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
-              disabled={!canSetNewPDSLimit}
-              onClick={() => {
-                setNewPDSRateLimit(newPDSLimit);
-              }}
-            >
-              Update
-            </button>
           </div>
         </div>
 
@@ -1287,14 +1291,16 @@ const Dash: FC<{}> = () => {
           </table>
         </div>
       </div>
-      {modalAction && (
-        <ConfirmModal
-          action={modalAction}
-          onConfirm={modalConfirm}
-          onCancel={modalCancel}
-        />
-      )}
-    </div>
+      {
+        modalAction && (
+          <ConfirmModal
+            action={modalAction}
+            onConfirm={modalConfirm}
+            onCancel={modalCancel}
+          />
+        )
+      }
+    </div >
   );
 };
 


### PR DESCRIPTION
This change adds a per-day new PDS limiter (which can be admin overridden) allowing us to loosen the process around federating new PDSs without risk of being overrun with tons of fraudulent PDSs in a short time.

Admin interface updates include a way to view and update this limit:
![CleanShot 2024-04-22 at 11 53 59](https://github.com/bluesky-social/indigo/assets/1617325/0fd5c192-e277-4f37-8ff3-f95420f816f4)
