### PR TITLE
com.atproto.account.createInviteCode has been renamed to com.atproto.server.createInviteCode

### DIFF
--- a/xrpc/xrpc.go
+++ b/xrpc/xrpc.go
@@ -184,7 +184,7 @@ func (c *Client) Do(ctx context.Context, kind XRPCRequestType, inpenc string, me
 	}
 
 	// use admin auth if we have it configured and are doing a request that requires it
-	if c.AdminToken != nil && (strings.HasPrefix(method, "com.atproto.admin.") || strings.HasPrefix(method, "tools.ozone.") || method == "com.atproto.account.createInviteCode" || method == "com.atproto.server.createInviteCodes") {
+	if c.AdminToken != nil && (strings.HasPrefix(method, "com.atproto.admin.") || strings.HasPrefix(method, "tools.ozone.") || method == "com.atproto.server.createInviteCode" || method == "com.atproto.server.createInviteCodes") {
 		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("admin:"+*c.AdminToken)))
 	} else if c.Auth != nil {
 		req.Header.Set("Authorization", "Bearer "+c.Auth.AccessJwt)


### PR DESCRIPTION
https://github.com/bluesky-social/atproto/blob/main/lexicons/com/atproto/server/createInviteCode.json