### PR TITLE
keep going if we encounter corrupted shard files

### DIFF
--- a/carstore/bs.go
+++ b/carstore/bs.go
@@ -1616,7 +1616,7 @@ func (cs *CarStore) compactBucket(ctx context.Context, user models.Uid, b *compB
 		}); err != nil {
 			// If we ever fail to iterate a shard file because its
 			// corrupted, just log an error and skip the shard
-			log.Errorw("iterating blocks in shard", "shard", s.ID, "err", err)
+			log.Errorw("iterating blocks in shard", "shard", s.ID, "err", err, "uid", user)
 		}
 	}
 


### PR DESCRIPTION
If the relay gets shut down very suddenly and things arent properly synced to disk (I think this only happens if there are unexpected power failures on the host machine) then we can get into weird states where some repos have corrupted shard files. 
They keep functioning fine at a high level, but compaction gets impacted and prevented from finishing.

These repos should really just get wiped and resynced, but this change should prevent them from wreaking havoc in the compaction engine.