### PR TITLE
gosky: default localhost relay, not sandbox

### DIFF
--- a/cmd/gosky/bgs.go
+++ b/cmd/gosky/bgs.go
@@ -22,7 +22,7 @@ var bgsAdminCmd = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:  "bgs",
-			Value: "https://bgs.bsky-sandbox.dev",
+			Value: "http://localhost:2470",
 		},
 	},
 	Subcommands: []*cli.Command{


### PR DESCRIPTION
motivation here is that we are shutting down sandbox. pointing it at prod feels like it would be confusing for other devs.