### PR TITLE
relay: bump default repo limit configuration

### DIFF
--- a/bgs/fedmgr.go
+++ b/bgs/fedmgr.go
@@ -72,10 +72,10 @@ func DefaultSlurperOptions() *SlurperOptions {
 	return &SlurperOptions{
 		SSL:                   false,
 		DefaultPerSecondLimit: 50,
-		DefaultPerHourLimit:   1500,
-		DefaultPerDayLimit:    10_000,
+		DefaultPerHourLimit:   2500,
+		DefaultPerDayLimit:    20_000,
 		DefaultCrawlLimit:     rate.Limit(5),
-		DefaultRepoLimit:      10,
+		DefaultRepoLimit:      100,
 	}
 }
 


### PR DESCRIPTION
The main thing here is `DefaultRepoLimit`. Also bumped the other numbers a bit to be consistent.