### PR TITLE
more relay hosting tweaks

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -1616,8 +1616,10 @@ func (bgs *BGS) ResyncPDS(ctx context.Context, pds models.PDS) error {
 				log.Errorw("failed to enqueue crawl for repo during resync", "error", err, "uid", res.ai.Uid, "did", res.ai.Did)
 			}
 		}
-		if i%100_000 == 0 {
-			log.Warnw("checked revs during resync", "num_repos_checked", i, "num_repos_to_crawl", numReposToResync, "took", time.Now().Sub(resync.StatusChangedAt))
+		if i%100 == 0 {
+			if i%10_000 == 0 {
+				log.Warnw("checked revs during resync", "num_repos_checked", i, "num_repos_to_crawl", numReposToResync, "took", time.Now().Sub(resync.StatusChangedAt))
+			}
 			resync.NumReposChecked = i
 			resync.NumReposToResync = numReposToResync
 			bgs.UpdateResync(resync)

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -114,8 +114,8 @@ type BGSConfig struct {
 	MaxQueuePerPDS    int64
 }
 
-func DefaultBGSConfig() BGSConfig {
-	return BGSConfig{
+func DefaultBGSConfig() *BGSConfig {
+	return &BGSConfig{
 		SSL:               true,
 		CompactInterval:   4 * time.Hour,
 		DefaultRepoLimit:  100,
@@ -124,7 +124,11 @@ func DefaultBGSConfig() BGSConfig {
 	}
 }
 
-func NewBGS(db *gorm.DB, ix *indexer.Indexer, repoman *repomgr.RepoManager, evtman *events.EventManager, didr did.Resolver, rf *indexer.RepoFetcher, hr api.HandleResolver, config BGSConfig) (*BGS, error) {
+func NewBGS(db *gorm.DB, ix *indexer.Indexer, repoman *repomgr.RepoManager, evtman *events.EventManager, didr did.Resolver, rf *indexer.RepoFetcher, hr api.HandleResolver, config *BGSConfig) (*BGS, error) {
+
+	if config == nil {
+		config = DefaultBGSConfig()
+	}
 	db.AutoMigrate(User{})
 	db.AutoMigrate(AuthToken{})
 	db.AutoMigrate(models.PDS{})

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -1179,7 +1179,7 @@ func (s *BGS) createExternalUser(ctx context.Context, did string) (*models.Actor
 		peering.Host = durl.Host
 		peering.SSL = (durl.Scheme == "https")
 		peering.CrawlRateLimit = float64(s.slurper.DefaultCrawlLimit)
-		peering.RepoLimit = s.slurper.DefaultPerSecondLimit
+		peering.RateLimit = float64(s.slurper.DefaultPerSecondLimit)
 		peering.HourlyEventLimit = s.slurper.DefaultPerHourLimit
 		peering.DailyEventLimit = s.slurper.DefaultPerDayLimit
 		peering.RepoLimit = s.slurper.DefaultRepoLimit

--- a/bgs/fedmgr.go
+++ b/bgs/fedmgr.go
@@ -41,6 +41,8 @@ type Slurper struct {
 
 	DefaultCrawlLimit rate.Limit
 	DefaultRepoLimit  int64
+	ConcurrencyPerPDS int64
+	MaxQueuePerPDS    int64
 
 	NewPDSPerDayLimiter *slidingwindow.Limiter
 
@@ -66,6 +68,8 @@ type SlurperOptions struct {
 	DefaultPerDayLimit    int64
 	DefaultCrawlLimit     rate.Limit
 	DefaultRepoLimit      int64
+	ConcurrencyPerPDS     int64
+	MaxQueuePerPDS        int64
 }
 
 func DefaultSlurperOptions() *SlurperOptions {
@@ -76,6 +80,8 @@ func DefaultSlurperOptions() *SlurperOptions {
 		DefaultPerDayLimit:    10_000,
 		DefaultCrawlLimit:     rate.Limit(5),
 		DefaultRepoLimit:      10,
+		ConcurrencyPerPDS:     100,
+		MaxQueuePerPDS:        1_000,
 	}
 }
 
@@ -101,6 +107,8 @@ func NewSlurper(db *gorm.DB, cb IndexCallback, opts *SlurperOptions) (*Slurper, 
 		DefaultPerDayLimit:    opts.DefaultPerDayLimit,
 		DefaultCrawlLimit:     opts.DefaultCrawlLimit,
 		DefaultRepoLimit:      opts.DefaultRepoLimit,
+		ConcurrencyPerPDS:     opts.ConcurrencyPerPDS,
+		MaxQueuePerPDS:        opts.MaxQueuePerPDS,
 		ssl:                   opts.SSL,
 		shutdownChan:          make(chan bool),
 		shutdownResult:        make(chan []error),

--- a/cmd/bigsky/README.md
+++ b/cmd/bigsky/README.md
@@ -111,6 +111,8 @@ Some notable configuration env vars to set:
 - `RESOLVE_ADDRESS`: DNS server to use
 - `FORCE_DNS_UDP`: recommend "true"
 - `BGS_COMPACT_INTERVAL`: to control CAR compaction scheduling. for example, "8h" (every 8 hours). Set to "0" to disable automatic compaction.
+- `MAX_CARSTORE_CONNECTIONS` and `MAX_METADB_CONNECTIONS`: number of concurrent SQL database connections
+- `MAX_FETCH_CONCURRENCY`: how many outbound CAR backfill requests to make in parallel
 
 There is a health check endpoint at `/xrpc/_health`. Prometheus metrics are exposed by default on port 2471, path `/metrics`. The service logs fairly verbosely to stderr; use `GOLOG_LOG_LEVEL` to control log volume.
 
@@ -142,4 +144,9 @@ Once you have a set of PDS hosts, you can put the bare hostnames (not URLs: no `
 Just consuming from the firehose for a few hours will only backfill accounts with activity during that period. This is fine to get the backfill process started, but eventually you'll want to do full "resync" of all the repositories on the PDS host to the most recent repo rev version. To enqueue that for all the PDS instances:
 
     # start sync/backfill of all accounts
+	cat hosts.txt | parallel -j1 ./sync_pds.sh {}
+
+Lastly, can monitor progress of any ongoing re-syncs:
+
+    # check sync progress for all hosts
 	cat hosts.txt | parallel -j1 ./sync_pds.sh {}

--- a/cmd/bigsky/main.go
+++ b/cmd/bigsky/main.go
@@ -168,6 +168,21 @@ func run(args []string) error {
 			EnvVars: []string{"BSKY_SOCIAL_RATE_LIMIT_SKIP"},
 			Usage:   "ratelimit bypass secret token for *.bsky.social domains",
 		},
+		&cli.IntFlag{
+			Name:    "default-repo-limit",
+			Value:   100,
+			EnvVars: []string{"RELAY_DEFAULT_REPO_LIMIT"},
+		},
+		&cli.IntFlag{
+			Name:    "concurrency-per-pds",
+			EnvVars: []string{"RELAY_CONCURRENCY_PER_PDS"},
+			Value:   100,
+		},
+		&cli.IntFlag{
+			Name:    "max-queue-per-pds",
+			EnvVars: []string{"RELAY_MAX_QUEUE_PER_PDS"},
+			Value:   1_000,
+		},
 	}
 
 	app.Action = runBigsky
@@ -374,7 +389,13 @@ func runBigsky(cctx *cli.Context) error {
 	}
 
 	log.Infow("constructing bgs")
-	bgs, err := libbgs.NewBGS(db, ix, repoman, evtman, cachedidr, rf, hr, !cctx.Bool("crawl-insecure-ws"), cctx.Duration("compact-interval"))
+	bgsConfig := libbgs.DefaultBGSConfig()
+	bgsConfig.SSL = !cctx.Bool("crawl-insecure-ws")
+	bgsConfig.CompactInterval = cctx.Duration("compact-interval")
+	bgsConfig.ConcurrencyPerPDS = cctx.Int64("concurrency-per-pds")
+	bgsConfig.MaxQueuePerPDS = cctx.Int64("max-queue-per-pds")
+	bgsConfig.DefaultRepoLimit = cctx.Int64("default-repo-limit")
+	bgs, err := libbgs.NewBGS(db, ix, repoman, evtman, cachedidr, rf, hr, bgsConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/bigsky/sync_status_pds.sh
+++ b/cmd/bigsky/sync_status_pds.sh
@@ -19,6 +19,6 @@ if test -z "$1"; then
     exit -1
 fi
 
-echo "POST resync $1"
-http --ignore-stdin post https://${RELAY_HOST}/admin/pds/resync Authorization:"Bearer ${RELAY_ADMIN_KEY}" \
+echo "GET resync $1"
+http --ignore-stdin --pretty all get https://${RELAY_HOST}/admin/pds/resync Authorization:"Bearer ${RELAY_ADMIN_KEY}" \
 	host==$1

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -582,7 +582,9 @@ func SetupRelay(ctx context.Context, didr plc.PLCClient) (*TestRelay, error) {
 
 	tr := &api.TestHandleResolver{}
 
-	b, err := bgs.NewBGS(maindb, ix, repoman, evtman, didr, rf, tr, false, time.Hour*4)
+	bgsConfig := bgs.DefaultBGSConfig()
+	bgsConfig.SSL = false
+	b, err := bgs.NewBGS(maindb, ix, repoman, evtman, didr, rf, tr, bgsConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This has some low-impact doc and scripts changes, and a couple actually-impactful changes to Relay code:

- I think fixes a bug/type with per-PDS, per-second event rate limits
- wires through some concurrency and limit values as env vars; should not impact the default behaviors
- updates PDS resync numbers (in database and results from API) much more frequently, but doesn't log for all those updates. only impacts actual PDS resync processes