### PR TITLE
Increase PDS repo fetch timeout

### DIFF
--- a/cmd/bigsky/main.go
+++ b/cmd/bigsky/main.go
@@ -343,6 +343,9 @@ func runBigsky(cctx *cli.Context) error {
 					"x-ratelimit-bypass": rlskip,
 				}
 			}
+		} else {
+			// Generic PDS timeout
+			c.Client.Timeout = time.Minute * 1
 		}
 	}
 	rf.ApplyPDSClientSettings = ix.ApplyPDSClientSettings


### PR DESCRIPTION
Increases the default timeout for generic PDSs when running GetRepo from the Relay.