### PR TITLE
automod consuming ozone events

### DIFF
--- a/api/ozone/moderationdefs.go
+++ b/api/ozone/moderationdefs.go
@@ -143,6 +143,18 @@ type ModerationDefs_ModEventMute struct {
 	DurationInHours int64 `json:"durationInHours" cborgen:"durationInHours"`
 }
 
+// ModerationDefs_ModEventMuteReporter is a "modEventMuteReporter" in the tools.ozone.moderation.defs schema.
+//
+// # Mute incoming reports from an account
+//
+// RECORDTYPE: ModerationDefs_ModEventMuteReporter
+type ModerationDefs_ModEventMuteReporter struct {
+	LexiconTypeID string  `json:"$type,const=tools.ozone.moderation.defs#modEventMuteReporter" cborgen:"$type,const=tools.ozone.moderation.defs#modEventMuteReporter"`
+	Comment       *string `json:"comment,omitempty" cborgen:"comment,omitempty"`
+	// durationInHours: Indicates how long the account should remain muted.
+	DurationInHours int64 `json:"durationInHours" cborgen:"durationInHours"`
+}
+
 // ModerationDefs_ModEventReport is a "modEventReport" in the tools.ozone.moderation.defs schema.
 //
 // # Report a subject
@@ -151,7 +163,9 @@ type ModerationDefs_ModEventMute struct {
 type ModerationDefs_ModEventReport struct {
 	LexiconTypeID string  `json:"$type,const=tools.ozone.moderation.defs#modEventReport" cborgen:"$type,const=tools.ozone.moderation.defs#modEventReport"`
 	Comment       *string `json:"comment,omitempty" cborgen:"comment,omitempty"`
-	ReportType    *string `json:"reportType" cborgen:"reportType"`
+	// isReporterMuted: Set to true if the reporter was muted from reporting at the time of the event. These reports won't impact the reviewState of the subject.
+	IsReporterMuted *bool   `json:"isReporterMuted,omitempty" cborgen:"isReporterMuted,omitempty"`
+	ReportType      *string `json:"reportType" cborgen:"reportType"`
 }
 
 // ModerationDefs_ModEventResolveAppeal is a "modEventResolveAppeal" in the tools.ozone.moderation.defs schema.
@@ -214,6 +228,17 @@ type ModerationDefs_ModEventUnmute struct {
 	Comment *string `json:"comment,omitempty" cborgen:"comment,omitempty"`
 }
 
+// ModerationDefs_ModEventUnmuteReporter is a "modEventUnmuteReporter" in the tools.ozone.moderation.defs schema.
+//
+// # Unmute incoming reports from an account
+//
+// RECORDTYPE: ModerationDefs_ModEventUnmuteReporter
+type ModerationDefs_ModEventUnmuteReporter struct {
+	LexiconTypeID string `json:"$type,const=tools.ozone.moderation.defs#modEventUnmuteReporter" cborgen:"$type,const=tools.ozone.moderation.defs#modEventUnmuteReporter"`
+	// comment: Describe reasoning behind the reversal.
+	Comment *string `json:"comment,omitempty" cborgen:"comment,omitempty"`
+}
+
 // ModerationDefs_ModEventView is a "modEventView" in the tools.ozone.moderation.defs schema.
 type ModerationDefs_ModEventView struct {
 	CreatedAt       string                               `json:"createdAt" cborgen:"createdAt"`
@@ -245,9 +270,13 @@ type ModerationDefs_ModEventViewDetail_Event struct {
 	ModerationDefs_ModEventAcknowledge     *ModerationDefs_ModEventAcknowledge
 	ModerationDefs_ModEventEscalate        *ModerationDefs_ModEventEscalate
 	ModerationDefs_ModEventMute            *ModerationDefs_ModEventMute
+	ModerationDefs_ModEventUnmute          *ModerationDefs_ModEventUnmute
+	ModerationDefs_ModEventMuteReporter    *ModerationDefs_ModEventMuteReporter
+	ModerationDefs_ModEventUnmuteReporter  *ModerationDefs_ModEventUnmuteReporter
 	ModerationDefs_ModEventEmail           *ModerationDefs_ModEventEmail
 	ModerationDefs_ModEventResolveAppeal   *ModerationDefs_ModEventResolveAppeal
 	ModerationDefs_ModEventDivert          *ModerationDefs_ModEventDivert
+	ModerationDefs_ModEventTag             *ModerationDefs_ModEventTag
 }
 
 func (t *ModerationDefs_ModEventViewDetail_Event) MarshalJSON() ([]byte, error) {
@@ -283,6 +312,18 @@ func (t *ModerationDefs_ModEventViewDetail_Event) MarshalJSON() ([]byte, error) 
 		t.ModerationDefs_ModEventMute.LexiconTypeID = "tools.ozone.moderation.defs#modEventMute"
 		return json.Marshal(t.ModerationDefs_ModEventMute)
 	}
+	if t.ModerationDefs_ModEventUnmute != nil {
+		t.ModerationDefs_ModEventUnmute.LexiconTypeID = "tools.ozone.moderation.defs#modEventUnmute"
+		return json.Marshal(t.ModerationDefs_ModEventUnmute)
+	}
+	if t.ModerationDefs_ModEventMuteReporter != nil {
+		t.ModerationDefs_ModEventMuteReporter.LexiconTypeID = "tools.ozone.moderation.defs#modEventMuteReporter"
+		return json.Marshal(t.ModerationDefs_ModEventMuteReporter)
+	}
+	if t.ModerationDefs_ModEventUnmuteReporter != nil {
+		t.ModerationDefs_ModEventUnmuteReporter.LexiconTypeID = "tools.ozone.moderation.defs#modEventUnmuteReporter"
+		return json.Marshal(t.ModerationDefs_ModEventUnmuteReporter)
+	}
 	if t.ModerationDefs_ModEventEmail != nil {
 		t.ModerationDefs_ModEventEmail.LexiconTypeID = "tools.ozone.moderation.defs#modEventEmail"
 		return json.Marshal(t.ModerationDefs_ModEventEmail)
@@ -294,6 +335,10 @@ func (t *ModerationDefs_ModEventViewDetail_Event) MarshalJSON() ([]byte, error) 
 	if t.ModerationDefs_ModEventDivert != nil {
 		t.ModerationDefs_ModEventDivert.LexiconTypeID = "tools.ozone.moderation.defs#modEventDivert"
 		return json.Marshal(t.ModerationDefs_ModEventDivert)
+	}
+	if t.ModerationDefs_ModEventTag != nil {
+		t.ModerationDefs_ModEventTag.LexiconTypeID = "tools.ozone.moderation.defs#modEventTag"
+		return json.Marshal(t.ModerationDefs_ModEventTag)
 	}
 	return nil, fmt.Errorf("cannot marshal empty enum")
 }
@@ -328,6 +373,15 @@ func (t *ModerationDefs_ModEventViewDetail_Event) UnmarshalJSON(b []byte) error 
 	case "tools.ozone.moderation.defs#modEventMute":
 		t.ModerationDefs_ModEventMute = new(ModerationDefs_ModEventMute)
 		return json.Unmarshal(b, t.ModerationDefs_ModEventMute)
+	case "tools.ozone.moderation.defs#modEventUnmute":
+		t.ModerationDefs_ModEventUnmute = new(ModerationDefs_ModEventUnmute)
+		return json.Unmarshal(b, t.ModerationDefs_ModEventUnmute)
+	case "tools.ozone.moderation.defs#modEventMuteReporter":
+		t.ModerationDefs_ModEventMuteReporter = new(ModerationDefs_ModEventMuteReporter)
+		return json.Unmarshal(b, t.ModerationDefs_ModEventMuteReporter)
+	case "tools.ozone.moderation.defs#modEventUnmuteReporter":
+		t.ModerationDefs_ModEventUnmuteReporter = new(ModerationDefs_ModEventUnmuteReporter)
+		return json.Unmarshal(b, t.ModerationDefs_ModEventUnmuteReporter)
 	case "tools.ozone.moderation.defs#modEventEmail":
 		t.ModerationDefs_ModEventEmail = new(ModerationDefs_ModEventEmail)
 		return json.Unmarshal(b, t.ModerationDefs_ModEventEmail)
@@ -337,6 +391,9 @@ func (t *ModerationDefs_ModEventViewDetail_Event) UnmarshalJSON(b []byte) error 
 	case "tools.ozone.moderation.defs#modEventDivert":
 		t.ModerationDefs_ModEventDivert = new(ModerationDefs_ModEventDivert)
 		return json.Unmarshal(b, t.ModerationDefs_ModEventDivert)
+	case "tools.ozone.moderation.defs#modEventTag":
+		t.ModerationDefs_ModEventTag = new(ModerationDefs_ModEventTag)
+		return json.Unmarshal(b, t.ModerationDefs_ModEventTag)
 
 	default:
 		return nil
@@ -403,9 +460,13 @@ type ModerationDefs_ModEventView_Event struct {
 	ModerationDefs_ModEventAcknowledge     *ModerationDefs_ModEventAcknowledge
 	ModerationDefs_ModEventEscalate        *ModerationDefs_ModEventEscalate
 	ModerationDefs_ModEventMute            *ModerationDefs_ModEventMute
+	ModerationDefs_ModEventUnmute          *ModerationDefs_ModEventUnmute
+	ModerationDefs_ModEventMuteReporter    *ModerationDefs_ModEventMuteReporter
+	ModerationDefs_ModEventUnmuteReporter  *ModerationDefs_ModEventUnmuteReporter
 	ModerationDefs_ModEventEmail           *ModerationDefs_ModEventEmail
 	ModerationDefs_ModEventResolveAppeal   *ModerationDefs_ModEventResolveAppeal
 	ModerationDefs_ModEventDivert          *ModerationDefs_ModEventDivert
+	ModerationDefs_ModEventTag             *ModerationDefs_ModEventTag
 }
 
 func (t *ModerationDefs_ModEventView_Event) MarshalJSON() ([]byte, error) {
@@ -441,6 +502,18 @@ func (t *ModerationDefs_ModEventView_Event) MarshalJSON() ([]byte, error) {
 		t.ModerationDefs_ModEventMute.LexiconTypeID = "tools.ozone.moderation.defs#modEventMute"
 		return json.Marshal(t.ModerationDefs_ModEventMute)
 	}
+	if t.ModerationDefs_ModEventUnmute != nil {
+		t.ModerationDefs_ModEventUnmute.LexiconTypeID = "tools.ozone.moderation.defs#modEventUnmute"
+		return json.Marshal(t.ModerationDefs_ModEventUnmute)
+	}
+	if t.ModerationDefs_ModEventMuteReporter != nil {
+		t.ModerationDefs_ModEventMuteReporter.LexiconTypeID = "tools.ozone.moderation.defs#modEventMuteReporter"
+		return json.Marshal(t.ModerationDefs_ModEventMuteReporter)
+	}
+	if t.ModerationDefs_ModEventUnmuteReporter != nil {
+		t.ModerationDefs_ModEventUnmuteReporter.LexiconTypeID = "tools.ozone.moderation.defs#modEventUnmuteReporter"
+		return json.Marshal(t.ModerationDefs_ModEventUnmuteReporter)
+	}
 	if t.ModerationDefs_ModEventEmail != nil {
 		t.ModerationDefs_ModEventEmail.LexiconTypeID = "tools.ozone.moderation.defs#modEventEmail"
 		return json.Marshal(t.ModerationDefs_ModEventEmail)
@@ -452,6 +525,10 @@ func (t *ModerationDefs_ModEventView_Event) MarshalJSON() ([]byte, error) {
 	if t.ModerationDefs_ModEventDivert != nil {
 		t.ModerationDefs_ModEventDivert.LexiconTypeID = "tools.ozone.moderation.defs#modEventDivert"
 		return json.Marshal(t.ModerationDefs_ModEventDivert)
+	}
+	if t.ModerationDefs_ModEventTag != nil {
+		t.ModerationDefs_ModEventTag.LexiconTypeID = "tools.ozone.moderation.defs#modEventTag"
+		return json.Marshal(t.ModerationDefs_ModEventTag)
 	}
 	return nil, fmt.Errorf("cannot marshal empty enum")
 }
@@ -486,6 +563,15 @@ func (t *ModerationDefs_ModEventView_Event) UnmarshalJSON(b []byte) error {
 	case "tools.ozone.moderation.defs#modEventMute":
 		t.ModerationDefs_ModEventMute = new(ModerationDefs_ModEventMute)
 		return json.Unmarshal(b, t.ModerationDefs_ModEventMute)
+	case "tools.ozone.moderation.defs#modEventUnmute":
+		t.ModerationDefs_ModEventUnmute = new(ModerationDefs_ModEventUnmute)
+		return json.Unmarshal(b, t.ModerationDefs_ModEventUnmute)
+	case "tools.ozone.moderation.defs#modEventMuteReporter":
+		t.ModerationDefs_ModEventMuteReporter = new(ModerationDefs_ModEventMuteReporter)
+		return json.Unmarshal(b, t.ModerationDefs_ModEventMuteReporter)
+	case "tools.ozone.moderation.defs#modEventUnmuteReporter":
+		t.ModerationDefs_ModEventUnmuteReporter = new(ModerationDefs_ModEventUnmuteReporter)
+		return json.Unmarshal(b, t.ModerationDefs_ModEventUnmuteReporter)
 	case "tools.ozone.moderation.defs#modEventEmail":
 		t.ModerationDefs_ModEventEmail = new(ModerationDefs_ModEventEmail)
 		return json.Unmarshal(b, t.ModerationDefs_ModEventEmail)
@@ -495,6 +581,9 @@ func (t *ModerationDefs_ModEventView_Event) UnmarshalJSON(b []byte) error {
 	case "tools.ozone.moderation.defs#modEventDivert":
 		t.ModerationDefs_ModEventDivert = new(ModerationDefs_ModEventDivert)
 		return json.Unmarshal(b, t.ModerationDefs_ModEventDivert)
+	case "tools.ozone.moderation.defs#modEventTag":
+		t.ModerationDefs_ModEventTag = new(ModerationDefs_ModEventTag)
+		return json.Unmarshal(b, t.ModerationDefs_ModEventTag)
 
 	default:
 		return nil
@@ -585,6 +674,7 @@ type ModerationDefs_RecordViewNotFound struct {
 // RECORDTYPE: ModerationDefs_RepoView
 type ModerationDefs_RepoView struct {
 	LexiconTypeID   string                                 `json:"$type,const=tools.ozone.moderation.defs#repoView" cborgen:"$type,const=tools.ozone.moderation.defs#repoView"`
+	DeactivatedAt   *string                                `json:"deactivatedAt,omitempty" cborgen:"deactivatedAt,omitempty"`
 	Did             string                                 `json:"did" cborgen:"did"`
 	Email           *string                                `json:"email,omitempty" cborgen:"email,omitempty"`
 	Handle          string                                 `json:"handle" cborgen:"handle"`
@@ -598,6 +688,7 @@ type ModerationDefs_RepoView struct {
 
 // ModerationDefs_RepoViewDetail is a "repoViewDetail" in the tools.ozone.moderation.defs schema.
 type ModerationDefs_RepoViewDetail struct {
+	DeactivatedAt    *string                                  `json:"deactivatedAt,omitempty" cborgen:"deactivatedAt,omitempty"`
 	Did              string                                   `json:"did" cborgen:"did"`
 	Email            *string                                  `json:"email,omitempty" cborgen:"email,omitempty"`
 	EmailConfirmedAt *string                                  `json:"emailConfirmedAt,omitempty" cborgen:"emailConfirmedAt,omitempty"`
@@ -630,18 +721,19 @@ type ModerationDefs_SubjectStatusView struct {
 	CreatedAt string `json:"createdAt" cborgen:"createdAt"`
 	Id        int64  `json:"id" cborgen:"id"`
 	// lastAppealedAt: Timestamp referencing when the author of the subject appealed a moderation action
-	LastAppealedAt    *string                                   `json:"lastAppealedAt,omitempty" cborgen:"lastAppealedAt,omitempty"`
-	LastReportedAt    *string                                   `json:"lastReportedAt,omitempty" cborgen:"lastReportedAt,omitempty"`
-	LastReviewedAt    *string                                   `json:"lastReviewedAt,omitempty" cborgen:"lastReviewedAt,omitempty"`
-	LastReviewedBy    *string                                   `json:"lastReviewedBy,omitempty" cborgen:"lastReviewedBy,omitempty"`
-	MuteUntil         *string                                   `json:"muteUntil,omitempty" cborgen:"muteUntil,omitempty"`
-	ReviewState       *string                                   `json:"reviewState" cborgen:"reviewState"`
-	Subject           *ModerationDefs_SubjectStatusView_Subject `json:"subject" cborgen:"subject"`
-	SubjectBlobCids   []string                                  `json:"subjectBlobCids,omitempty" cborgen:"subjectBlobCids,omitempty"`
-	SubjectRepoHandle *string                                   `json:"subjectRepoHandle,omitempty" cborgen:"subjectRepoHandle,omitempty"`
-	SuspendUntil      *string                                   `json:"suspendUntil,omitempty" cborgen:"suspendUntil,omitempty"`
-	Tags              []string                                  `json:"tags,omitempty" cborgen:"tags,omitempty"`
-	Takendown         *bool                                     `json:"takendown,omitempty" cborgen:"takendown,omitempty"`
+	LastAppealedAt     *string                                   `json:"lastAppealedAt,omitempty" cborgen:"lastAppealedAt,omitempty"`
+	LastReportedAt     *string                                   `json:"lastReportedAt,omitempty" cborgen:"lastReportedAt,omitempty"`
+	LastReviewedAt     *string                                   `json:"lastReviewedAt,omitempty" cborgen:"lastReviewedAt,omitempty"`
+	LastReviewedBy     *string                                   `json:"lastReviewedBy,omitempty" cborgen:"lastReviewedBy,omitempty"`
+	MuteReportingUntil *string                                   `json:"muteReportingUntil,omitempty" cborgen:"muteReportingUntil,omitempty"`
+	MuteUntil          *string                                   `json:"muteUntil,omitempty" cborgen:"muteUntil,omitempty"`
+	ReviewState        *string                                   `json:"reviewState" cborgen:"reviewState"`
+	Subject            *ModerationDefs_SubjectStatusView_Subject `json:"subject" cborgen:"subject"`
+	SubjectBlobCids    []string                                  `json:"subjectBlobCids,omitempty" cborgen:"subjectBlobCids,omitempty"`
+	SubjectRepoHandle  *string                                   `json:"subjectRepoHandle,omitempty" cborgen:"subjectRepoHandle,omitempty"`
+	SuspendUntil       *string                                   `json:"suspendUntil,omitempty" cborgen:"suspendUntil,omitempty"`
+	Tags               []string                                  `json:"tags,omitempty" cborgen:"tags,omitempty"`
+	Takendown          *bool                                     `json:"takendown,omitempty" cborgen:"takendown,omitempty"`
 	// updatedAt: Timestamp referencing when the last update was made to the moderation status of the subject
 	UpdatedAt string `json:"updatedAt" cborgen:"updatedAt"`
 }

--- a/api/ozone/moderationemitEvent.go
+++ b/api/ozone/moderationemitEvent.go
@@ -30,8 +30,10 @@ type ModerationEmitEvent_Input_Event struct {
 	ModerationDefs_ModEventLabel           *ModerationDefs_ModEventLabel
 	ModerationDefs_ModEventReport          *ModerationDefs_ModEventReport
 	ModerationDefs_ModEventMute            *ModerationDefs_ModEventMute
-	ModerationDefs_ModEventReverseTakedown *ModerationDefs_ModEventReverseTakedown
 	ModerationDefs_ModEventUnmute          *ModerationDefs_ModEventUnmute
+	ModerationDefs_ModEventMuteReporter    *ModerationDefs_ModEventMuteReporter
+	ModerationDefs_ModEventUnmuteReporter  *ModerationDefs_ModEventUnmuteReporter
+	ModerationDefs_ModEventReverseTakedown *ModerationDefs_ModEventReverseTakedown
 	ModerationDefs_ModEventEmail           *ModerationDefs_ModEventEmail
 	ModerationDefs_ModEventTag             *ModerationDefs_ModEventTag
 }
@@ -65,13 +67,21 @@ func (t *ModerationEmitEvent_Input_Event) MarshalJSON() ([]byte, error) {
 		t.ModerationDefs_ModEventMute.LexiconTypeID = "tools.ozone.moderation.defs#modEventMute"
 		return json.Marshal(t.ModerationDefs_ModEventMute)
 	}
-	if t.ModerationDefs_ModEventReverseTakedown != nil {
-		t.ModerationDefs_ModEventReverseTakedown.LexiconTypeID = "tools.ozone.moderation.defs#modEventReverseTakedown"
-		return json.Marshal(t.ModerationDefs_ModEventReverseTakedown)
-	}
 	if t.ModerationDefs_ModEventUnmute != nil {
 		t.ModerationDefs_ModEventUnmute.LexiconTypeID = "tools.ozone.moderation.defs#modEventUnmute"
 		return json.Marshal(t.ModerationDefs_ModEventUnmute)
+	}
+	if t.ModerationDefs_ModEventMuteReporter != nil {
+		t.ModerationDefs_ModEventMuteReporter.LexiconTypeID = "tools.ozone.moderation.defs#modEventMuteReporter"
+		return json.Marshal(t.ModerationDefs_ModEventMuteReporter)
+	}
+	if t.ModerationDefs_ModEventUnmuteReporter != nil {
+		t.ModerationDefs_ModEventUnmuteReporter.LexiconTypeID = "tools.ozone.moderation.defs#modEventUnmuteReporter"
+		return json.Marshal(t.ModerationDefs_ModEventUnmuteReporter)
+	}
+	if t.ModerationDefs_ModEventReverseTakedown != nil {
+		t.ModerationDefs_ModEventReverseTakedown.LexiconTypeID = "tools.ozone.moderation.defs#modEventReverseTakedown"
+		return json.Marshal(t.ModerationDefs_ModEventReverseTakedown)
 	}
 	if t.ModerationDefs_ModEventEmail != nil {
 		t.ModerationDefs_ModEventEmail.LexiconTypeID = "tools.ozone.moderation.defs#modEventEmail"
@@ -111,12 +121,18 @@ func (t *ModerationEmitEvent_Input_Event) UnmarshalJSON(b []byte) error {
 	case "tools.ozone.moderation.defs#modEventMute":
 		t.ModerationDefs_ModEventMute = new(ModerationDefs_ModEventMute)
 		return json.Unmarshal(b, t.ModerationDefs_ModEventMute)
-	case "tools.ozone.moderation.defs#modEventReverseTakedown":
-		t.ModerationDefs_ModEventReverseTakedown = new(ModerationDefs_ModEventReverseTakedown)
-		return json.Unmarshal(b, t.ModerationDefs_ModEventReverseTakedown)
 	case "tools.ozone.moderation.defs#modEventUnmute":
 		t.ModerationDefs_ModEventUnmute = new(ModerationDefs_ModEventUnmute)
 		return json.Unmarshal(b, t.ModerationDefs_ModEventUnmute)
+	case "tools.ozone.moderation.defs#modEventMuteReporter":
+		t.ModerationDefs_ModEventMuteReporter = new(ModerationDefs_ModEventMuteReporter)
+		return json.Unmarshal(b, t.ModerationDefs_ModEventMuteReporter)
+	case "tools.ozone.moderation.defs#modEventUnmuteReporter":
+		t.ModerationDefs_ModEventUnmuteReporter = new(ModerationDefs_ModEventUnmuteReporter)
+		return json.Unmarshal(b, t.ModerationDefs_ModEventUnmuteReporter)
+	case "tools.ozone.moderation.defs#modEventReverseTakedown":
+		t.ModerationDefs_ModEventReverseTakedown = new(ModerationDefs_ModEventReverseTakedown)
+		return json.Unmarshal(b, t.ModerationDefs_ModEventReverseTakedown)
 	case "tools.ozone.moderation.defs#modEventEmail":
 		t.ModerationDefs_ModEventEmail = new(ModerationDefs_ModEventEmail)
 		return json.Unmarshal(b, t.ModerationDefs_ModEventEmail)

--- a/api/ozone/moderationqueryStatuses.go
+++ b/api/ozone/moderationqueryStatuses.go
@@ -22,13 +22,14 @@ type ModerationQueryStatuses_Output struct {
 // comment: Search subjects by keyword from comments
 // includeMuted: By default, we don't include muted subjects in the results. Set this to true to include them.
 // lastReviewedBy: Get all subject statuses that were reviewed by a specific moderator
+// onlyMuted: When set to true, only muted subjects and reporters will be returned.
 // reportedAfter: Search subjects reported after a given timestamp
 // reportedBefore: Search subjects reported before a given timestamp
 // reviewState: Specify when fetching subjects in a certain state
 // reviewedAfter: Search subjects reviewed after a given timestamp
 // reviewedBefore: Search subjects reviewed before a given timestamp
 // takendown: Get subjects that were taken down
-func ModerationQueryStatuses(ctx context.Context, c *xrpc.Client, appealed bool, comment string, cursor string, excludeTags []string, ignoreSubjects []string, includeMuted bool, lastReviewedBy string, limit int64, reportedAfter string, reportedBefore string, reviewState string, reviewedAfter string, reviewedBefore string, sortDirection string, sortField string, subject string, tags []string, takendown bool) (*ModerationQueryStatuses_Output, error) {
+func ModerationQueryStatuses(ctx context.Context, c *xrpc.Client, appealed bool, comment string, cursor string, excludeTags []string, ignoreSubjects []string, includeMuted bool, lastReviewedBy string, limit int64, onlyMuted bool, reportedAfter string, reportedBefore string, reviewState string, reviewedAfter string, reviewedBefore string, sortDirection string, sortField string, subject string, tags []string, takendown bool) (*ModerationQueryStatuses_Output, error) {
 	var out ModerationQueryStatuses_Output
 
 	params := map[string]interface{}{
@@ -40,6 +41,7 @@ func ModerationQueryStatuses(ctx context.Context, c *xrpc.Client, appealed bool,
 		"includeMuted":   includeMuted,
 		"lastReviewedBy": lastReviewedBy,
 		"limit":          limit,
+		"onlyMuted":      onlyMuted,
 		"reportedAfter":  reportedAfter,
 		"reportedBefore": reportedBefore,
 		"reviewState":    reviewState,

--- a/automod/cachestore/cachestore_redis.go
+++ b/automod/cachestore/cachestore_redis.go
@@ -16,13 +16,14 @@ type RedisCacheStore struct {
 var _ CacheStore = (*RedisCacheStore)(nil)
 
 func NewRedisCacheStore(redisURL string, ttl time.Duration) (*RedisCacheStore, error) {
+	ctx := context.Background()
 	opt, err := redis.ParseURL(redisURL)
 	if err != nil {
 		return nil, err
 	}
 	rdb := redis.NewClient(opt)
 	// check redis connection
-	_, err = rdb.Ping(context.TODO()).Result()
+	_, err = rdb.Ping(ctx).Result()
 	if err != nil {
 		return nil, err
 	}

--- a/automod/countstore/countstore_redis.go
+++ b/automod/countstore/countstore_redis.go
@@ -15,13 +15,14 @@ type RedisCountStore struct {
 }
 
 func NewRedisCountStore(redisURL string) (*RedisCountStore, error) {
+	ctx := context.Background()
 	opt, err := redis.ParseURL(redisURL)
 	if err != nil {
 		return nil, err
 	}
 	rdb := redis.NewClient(opt)
 	// check redis connection
-	_, err = rdb.Ping(context.TODO()).Result()
+	_, err = rdb.Ping(ctx).Result()
 	if err != nil {
 		return nil, err
 	}

--- a/automod/engine/account_meta.go
+++ b/automod/engine/account_meta.go
@@ -18,6 +18,9 @@ type AccountMeta struct {
 	FollowsCount         int64
 	PostsCount           int64
 	Takendown            bool
+	Deactivated          bool
+	// best effort public interpretation of account creation timestamp. not always available, and may be inaccurate/inconsistent for now.
+	CreatedAt *time.Time
 }
 
 type ProfileSummary struct {
@@ -30,4 +33,5 @@ type AccountPrivate struct {
 	Email          string
 	EmailConfirmed bool
 	IndexedAt      time.Time
+	AccountTags    []string
 }

--- a/automod/engine/context.go
+++ b/automod/engine/context.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	toolsozone "github.com/bluesky-social/indigo/api/ozone"
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 )
@@ -37,6 +38,20 @@ type RecordContext struct {
 	// TODO: could consider adding commit-level metadata here. probably nullable if so, commit-level metadata isn't always available. might be best to do a separate event/context type for that
 }
 
+type OzoneEventContext struct {
+	BaseContext
+
+	Event OzoneEvent
+
+	// Moderator team member (for ozone internal events) or account that created a report or appeal
+	CreatorAccount AccountMeta
+
+	SubjectAccount AccountMeta
+
+	// If the subject of the event is a record, this is the record metadata
+	SubjectRecord *RecordMeta
+}
+
 var (
 	CreateOp = "create"
 	UpdateOp = "update"
@@ -53,6 +68,26 @@ type RecordOp struct {
 	RecordKey  syntax.RecordKey
 	CID        *syntax.CID
 	RecordCBOR []byte
+}
+
+// Immutable
+type RecordMeta struct {
+	DID        syntax.DID
+	Collection syntax.NSID
+	RecordKey  syntax.RecordKey
+	CID        *syntax.CID
+	// TODO: RecordCBOR []byte? optional?
+}
+
+type OzoneEvent struct {
+	EventType  string
+	EventID    int64
+	CreatedAt  syntax.Datetime
+	CreatedBy  syntax.DID
+	SubjectDID syntax.DID
+	SubjectURI *syntax.ATURI
+	// TODO: SubjectBlobs []syntax.CID
+	Event toolsozone.ModerationDefs_ModEventView_Event
 }
 
 // Originally intended for push notifications, but can also work for any inter-account notification.

--- a/automod/engine/context.go
+++ b/automod/engine/context.go
@@ -38,15 +38,16 @@ type RecordContext struct {
 	// TODO: could consider adding commit-level metadata here. probably nullable if so, commit-level metadata isn't always available. might be best to do a separate event/context type for that
 }
 
+// Represents an ozone event on a subject account.
+//
+// TODO: for ozone events with a record subject (not account subject), should we extend RecordContext instead?
 type OzoneEventContext struct {
-	BaseContext
+	AccountContext
 
 	Event OzoneEvent
 
 	// Moderator team member (for ozone internal events) or account that created a report or appeal
 	CreatorAccount AccountMeta
-
-	SubjectAccount AccountMeta
 
 	// If the subject of the event is a record, this is the record metadata
 	SubjectRecord *RecordMeta
@@ -213,6 +214,28 @@ func (c *AccountContext) GetAccountRelationship(other syntax.DID) AccountRelatio
 		return AccountRelationship{DID: other}
 	}
 	return *rel
+}
+
+// fetch account metadata for the given DID. if there is any problem with lookup, returns nil.
+//
+// TODO: should this take an AtIdentifier instead?
+func (c *BaseContext) GetAccountMeta(did syntax.DID) *AccountMeta {
+
+	ident, err := c.engine.Directory.LookupDID(c.Ctx, did)
+	if err != nil {
+		if nil == c.Err {
+			c.Err = err
+		}
+		return nil
+	}
+	am, err := c.engine.GetAccountMeta(c.Ctx, ident)
+	if err != nil {
+		if nil == c.Err {
+			c.Err = err
+		}
+		return nil
+	}
+	return am
 }
 
 // update effects (indirect) ======

--- a/automod/engine/engine_ozone.go
+++ b/automod/engine/engine_ozone.go
@@ -130,16 +130,18 @@ func NewOzoneEventContext(ctx context.Context, eng *Engine, eventView *toolsozon
 	}
 
 	return &OzoneEventContext{
-		BaseContext: BaseContext{
-			Ctx:     ctx,
-			Err:     nil,
-			Logger:  eng.Logger.With("eventID", evt.EventID, "ozoneEventType", evt.EventType, "creatorDID", evt.CreatedBy, "subjectDID", evt.SubjectDID),
-			engine:  eng,
-			effects: &Effects{},
+		AccountContext: AccountContext{
+			BaseContext: BaseContext{
+				Ctx:     ctx,
+				Err:     nil,
+				Logger:  eng.Logger.With("eventID", evt.EventID, "ozoneEventType", evt.EventType, "creatorDID", evt.CreatedBy, "subjectDID", evt.SubjectDID),
+				engine:  eng,
+				effects: &Effects{},
+			},
+			Account: *accountMeta,
 		},
 		Event:          evt,
 		CreatorAccount: *creatorMeta,
-		SubjectAccount: *accountMeta,
 		SubjectRecord:  recordMeta,
 	}, nil
 }
@@ -191,12 +193,10 @@ func (eng *Engine) ProcessOzoneEvent(ctx context.Context, eventView *toolsozone.
 			eng.Logger.Error("failed to purge identity cache", "err", err, "did", ec.Event.SubjectDID)
 		}
 	}
-	/* XXX:
-	if err := eng.persistRecordModActions(ec); err != nil {
+	if err := eng.persistAccountModActions(&ec.AccountContext); err != nil {
 		eventErrorCount.WithLabelValues("ozoneEvent").Inc()
 		return fmt.Errorf("failed to persist actions for ozone event: %w", err)
 	}
-	*/
 	if err := eng.persistCounters(ctx, ec.effects); err != nil {
 		eventErrorCount.WithLabelValues("ozoneEvent").Inc()
 		return fmt.Errorf("failed to persist counts for ozone event: %w", err)

--- a/automod/engine/fetch_account_meta.go
+++ b/automod/engine/fetch_account_meta.go
@@ -7,6 +7,7 @@ import (
 
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
+	toolsozone "github.com/bluesky-social/indigo/api/ozone"
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 )
@@ -42,46 +43,28 @@ func (e *Engine) GetAccountMeta(ctx context.Context, ident *identity.Identity) (
 
 	// doing a "full" fetch from here on
 	accountMetaFetches.Inc()
+	am := AccountMeta{
+		Identity: ident,
+	}
 
+	// automod-internal "flags"
 	flags, err := e.Flags.Get(ctx, ident.DID.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed checking account flag cache: %w", err)
 	}
+	am.AccountFlags = flags
 
 	// fetch account metadata from AppView
 	pv, err := appbsky.ActorGetProfile(ctx, e.BskyClient, ident.DID.String())
 	if err != nil {
 		logger.Warn("account profile lookup failed", "err", err)
-		am := AccountMeta{
-			Identity: ident,
-			// Profile
-			// AccountLabels
-			// AccountNegatedLabels
-			AccountFlags: flags,
-		}
 		return &am, nil
 	}
 
-	var labels []string
-	var negLabels []string
-	for _, lbl := range pv.Labels {
-		if lbl.Neg != nil && *lbl.Neg == true {
-			negLabels = append(negLabels, lbl.Val)
-		} else {
-			labels = append(labels, lbl.Val)
-		}
-	}
-
-	am := AccountMeta{
-		Identity: ident,
-		Profile: ProfileSummary{
-			HasAvatar:   pv.Avatar != nil,
-			Description: pv.Description,
-			DisplayName: pv.DisplayName,
-		},
-		AccountLabels:        dedupeStrings(labels),
-		AccountNegatedLabels: dedupeStrings(negLabels),
-		AccountFlags:         flags,
+	am.Profile = ProfileSummary{
+		HasAvatar:   pv.Avatar != nil,
+		Description: pv.Description,
+		DisplayName: pv.DisplayName,
 	}
 	if pv.PostsCount != nil {
 		am.PostsCount = *pv.PostsCount
@@ -93,10 +76,61 @@ func (e *Engine) GetAccountMeta(ctx context.Context, ident *identity.Identity) (
 		am.FollowsCount = *pv.FollowsCount
 	}
 
-	if e.AdminClient != nil {
+	var labels []string
+	var negLabels []string
+	for _, lbl := range pv.Labels {
+		if lbl.Neg != nil && *lbl.Neg == true {
+			negLabels = append(negLabels, lbl.Val)
+		} else {
+			labels = append(labels, lbl.Val)
+		}
+	}
+	am.AccountLabels = dedupeStrings(labels)
+	am.AccountNegatedLabels = dedupeStrings(negLabels)
+
+	if pv.CreatedAt != nil {
+		ts, err := syntax.ParseDatetimeTime(*pv.CreatedAt)
+		if err != nil {
+			logger.Warn("invalid profile createdAt", "err", err, "createdAt", pv.CreatedAt)
+		} else {
+			am.CreatedAt = &ts
+		}
+	}
+
+	// first attempt to fetch private account metadata from Ozone
+	if e.OzoneClient != nil {
+		rd, err := toolsozone.ModerationGetRepo(ctx, e.OzoneClient, ident.DID.String())
+		if err != nil {
+			logger.Warn("failed to fetch private account metadata from Ozone", "err", err)
+		} else {
+			ap := AccountPrivate{}
+			if rd.Email != nil && *rd.Email != "" {
+				ap.Email = *rd.Email
+			}
+			if rd.EmailConfirmedAt != nil && *rd.EmailConfirmedAt != "" {
+				ap.EmailConfirmed = true
+			}
+			ts, err := syntax.ParseDatetimeTime(rd.IndexedAt)
+			if err != nil {
+				return nil, fmt.Errorf("bad account IndexedAt: %w", err)
+			}
+			ap.IndexedAt = ts
+			if rd.DeactivatedAt != nil {
+				am.Deactivated = true
+			}
+			if rd.Moderation != nil && rd.Moderation.SubjectStatus != nil {
+				if rd.Moderation.SubjectStatus.Takendown != nil && *rd.Moderation.SubjectStatus.Takendown == true {
+					am.Takendown = true
+				}
+				ap.AccountTags = dedupeStrings(rd.Moderation.SubjectStatus.Tags)
+			}
+			am.Private = &ap
+		}
+	} else if e.AdminClient != nil {
+		// fall back to PDS/entryway fetching; less metadata available
 		pv, err := comatproto.AdminGetAccountInfo(ctx, e.AdminClient, ident.DID.String())
 		if err != nil {
-			logger.Warn("failed to fetch private account metadata", "err", err)
+			logger.Warn("failed to fetch private account metadata from PDS/entryway", "err", err)
 		} else {
 			ap := AccountPrivate{}
 			if pv.Email != nil && *pv.Email != "" {

--- a/automod/engine/persist.go
+++ b/automod/engine/persist.go
@@ -169,6 +169,7 @@ func (eng *Engine) persistRecordModActions(c *RecordContext) error {
 	if len(newLabels) > 0 && eng.OzoneClient != nil {
 		rv, err := toolsozone.ModerationGetRecord(ctx, eng.OzoneClient, c.RecordOp.CID.String(), c.RecordOp.ATURI().String())
 		if err != nil {
+			// NOTE: there is a frequent 4xx error here from Ozone because this record has not been indexed yet
 			c.Logger.Warn("failed to fetch private record metadata", "err", err)
 		} else {
 			var existingLabels []string

--- a/automod/engine/ruleset.go
+++ b/automod/engine/ruleset.go
@@ -18,6 +18,7 @@ type RuleSet struct {
 	IdentityRules     []IdentityRuleFunc
 	BlobRules         []BlobRuleFunc
 	NotificationRules []NotificationRuleFunc
+	OzoneEventRules   []OzoneEventRuleFunc
 }
 
 // Executes all the various record-related rules. Only dispatches execution, does no other de-dupe or pre/post processing.
@@ -93,6 +94,16 @@ func (r *RuleSet) CallNotificationRules(c *NotificationContext) error {
 		err := f(c)
 		if err != nil {
 			c.Logger.Error("notification rule execution failed", "err", err)
+		}
+	}
+	return nil
+}
+
+func (r *RuleSet) CallOzoneEventRules(c *OzoneEventContext) error {
+	for _, f := range r.OzoneEventRules {
+		err := f(c)
+		if err != nil {
+			c.Logger.Error("ozone event rule execution failed", "err", err)
 		}
 	}
 	return nil

--- a/automod/engine/ruletypes.go
+++ b/automod/engine/ruletypes.go
@@ -11,3 +11,4 @@ type PostRuleFunc = func(c *RecordContext, post *appbsky.FeedPost) error
 type ProfileRuleFunc = func(c *RecordContext, profile *appbsky.ActorProfile) error
 type BlobRuleFunc = func(c *RecordContext, blob lexutil.LexBlob, data []byte) error
 type NotificationRuleFunc = func(c *NotificationContext) error
+type OzoneEventRuleFunc = func(c *OzoneEventContext) error

--- a/automod/flagstore/flagstore_redis.go
+++ b/automod/flagstore/flagstore_redis.go
@@ -13,13 +13,14 @@ type RedisFlagStore struct {
 }
 
 func NewRedisFlagStore(redisURL string) (*RedisFlagStore, error) {
+	ctx := context.Background()
 	opt, err := redis.ParseURL(redisURL)
 	if err != nil {
 		return nil, err
 	}
 	rdb := redis.NewClient(opt)
 	// check redis connection
-	_, err = rdb.Ping(context.TODO()).Result()
+	_, err = rdb.Ping(ctx).Result()
 	if err != nil {
 		return nil, err
 	}

--- a/automod/pkg.go
+++ b/automod/pkg.go
@@ -14,6 +14,7 @@ type SlackNotifier = engine.SlackNotifier
 
 type AccountContext = engine.AccountContext
 type RecordContext = engine.RecordContext
+type OzoneEventContext = engine.OzoneEventContext
 type NotificationContext = engine.NotificationContext
 type RecordOp = engine.RecordOp
 
@@ -23,6 +24,7 @@ type PostRuleFunc = engine.PostRuleFunc
 type ProfileRuleFunc = engine.ProfileRuleFunc
 type BlobRuleFunc = engine.BlobRuleFunc
 type NotificationRuleFunc = engine.NotificationRuleFunc
+type OzoneEventRuleFunc = engine.OzoneEventRuleFunc
 
 var (
 	ReportReasonSpam       = engine.ReportReasonSpam

--- a/automod/rules/all.go
+++ b/automod/rules/all.go
@@ -55,6 +55,9 @@ func DefaultRules() automod.RuleSet {
 		NotificationRules: []automod.NotificationRuleFunc{
 			// none
 		},
+		OzoneEventRules: []automod.OzoneEventRuleFunc{
+			HarassmentProtectionOzoneEventRule,
+		},
 	}
 	return rules
 }

--- a/automod/rules/misleading.go
+++ b/automod/rules/misleading.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"context"
 	"log/slog"
 	"net/url"
 	"strings"
@@ -106,8 +105,6 @@ func MisleadingURLPostRule(c *automod.RecordContext, post *appbsky.FeedPost) err
 var _ automod.PostRuleFunc = MisleadingMentionPostRule
 
 func MisleadingMentionPostRule(c *automod.RecordContext, post *appbsky.FeedPost) error {
-	// TODO: do we really need to route context around? probably
-	ctx := context.TODO()
 	facets, err := ExtractFacets(post)
 	if err != nil {
 		c.Logger.Warn("invalid facets", "err", err)
@@ -127,7 +124,7 @@ func MisleadingMentionPostRule(c *automod.RecordContext, post *appbsky.FeedPost)
 				continue
 			}
 
-			mentioned, err := c.Directory().LookupHandle(ctx, handle)
+			mentioned, err := c.Directory().LookupHandle(c.Ctx, handle)
 			if err != nil {
 				c.Logger.Warn("could not resolve handle", "handle", handle)
 				c.AddRecordFlag("broken-mention")

--- a/cmd/hepa/consumer.go
+++ b/cmd/hepa/consumer.go
@@ -25,7 +25,6 @@ import (
 
 func (s *Server) RunConsumer(ctx context.Context) error {
 
-	// TODO: persist cursor in a database or local disk
 	cur, err := s.ReadLastCursor(ctx)
 	if err != nil {
 		return err
@@ -89,7 +88,6 @@ func (s *Server) RunConsumer(ctx context.Context) error {
 			}
 			return nil
 		},
-		// TODO: other event callbacks as needed
 	}
 
 	var scheduler events.Scheduler
@@ -220,7 +218,7 @@ func (s *Server) HandleRepoCommit(ctx context.Context, evt *comatproto.SyncSubsc
 				continue
 			}
 		default:
-			// TODO: other event types: update, delete
+			// TODO: should this be an error?
 		}
 	}
 

--- a/cmd/hepa/consumer.go
+++ b/cmd/hepa/consumer.go
@@ -52,18 +52,6 @@ func (s *Server) RunConsumer(ctx context.Context) error {
 			atomic.StoreInt64(&s.lastSeq, evt.Seq)
 			return s.HandleRepoCommit(ctx, evt)
 		},
-		RepoHandle: func(evt *comatproto.SyncSubscribeRepos_Handle) error {
-			atomic.StoreInt64(&s.lastSeq, evt.Seq)
-			did, err := syntax.ParseDID(evt.Did)
-			if err != nil {
-				s.logger.Error("bad DID in RepoHandle event", "did", evt.Did, "handle", evt.Handle, "seq", evt.Seq, "err", err)
-				return nil
-			}
-			if err := s.engine.ProcessIdentityEvent(ctx, "handle", did); err != nil {
-				s.logger.Error("processing handle update failed", "did", evt.Did, "handle", evt.Handle, "seq", evt.Seq, "err", err)
-			}
-			return nil
-		},
 		RepoIdentity: func(evt *comatproto.SyncSubscribeRepos_Identity) error {
 			atomic.StoreInt64(&s.lastSeq, evt.Seq)
 			did, err := syntax.ParseDID(evt.Did)
@@ -76,6 +64,32 @@ func (s *Server) RunConsumer(ctx context.Context) error {
 			}
 			return nil
 		},
+		RepoAccount: func(evt *comatproto.SyncSubscribeRepos_Account) error {
+			atomic.StoreInt64(&s.lastSeq, evt.Seq)
+			did, err := syntax.ParseDID(evt.Did)
+			if err != nil {
+				s.logger.Error("bad DID in RepoAccount event", "did", evt.Did, "seq", evt.Seq, "err", err)
+				return nil
+			}
+			if err := s.engine.ProcessIdentityEvent(ctx, "account", did); err != nil {
+				s.logger.Error("processing repo account failed", "did", evt.Did, "seq", evt.Seq, "err", err)
+			}
+			return nil
+		},
+		// TODO: deprecated
+		RepoHandle: func(evt *comatproto.SyncSubscribeRepos_Handle) error {
+			atomic.StoreInt64(&s.lastSeq, evt.Seq)
+			did, err := syntax.ParseDID(evt.Did)
+			if err != nil {
+				s.logger.Error("bad DID in RepoHandle event", "did", evt.Did, "handle", evt.Handle, "seq", evt.Seq, "err", err)
+				return nil
+			}
+			if err := s.engine.ProcessIdentityEvent(ctx, "handle", did); err != nil {
+				s.logger.Error("processing handle update failed", "did", evt.Did, "handle", evt.Handle, "seq", evt.Seq, "err", err)
+			}
+			return nil
+		},
+		// TODO: deprecated
 		RepoTombstone: func(evt *comatproto.SyncSubscribeRepos_Tombstone) error {
 			atomic.StoreInt64(&s.lastSeq, evt.Seq)
 			did, err := syntax.ParseDID(evt.Did)

--- a/cmd/hepa/consumer_ozone.go
+++ b/cmd/hepa/consumer_ozone.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	toolsozone "github.com/bluesky-social/indigo/api/ozone"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+)
+
+func (s *Server) RunOzoneConsumer(ctx context.Context) error {
+
+	cur, err := s.ReadLastOzoneCursor(ctx)
+	if err != nil {
+		return err
+	}
+
+	if cur == "" {
+		cur = syntax.DatetimeNow().String()
+	}
+	since, err := time.Parse(time.RFC3339, cur)
+	if err != nil {
+		return err
+	}
+
+	s.logger.Info("subscribing to ozone event log", "upstream", s.engine.OzoneClient.Host, "cursor", cur, "since", since)
+	var limit int64 = 50
+	period := time.Second * 5
+
+	for {
+
+		//func ModerationQueryEvents(ctx context.Context, c *xrpc.Client, addedLabels []string, addedTags []string, comment string, createdAfter string, createdBefore string, createdBy string, cursor string, hasComment bool, includeAllUserRecords bool, limit int64, removedLabels []string, removedTags []string, reportTypes []string, sortDirection string, subject string, types []string) (*ModerationQueryEvents_Output, error) {
+		me, err := toolsozone.ModerationQueryEvents(
+			ctx,
+			s.engine.OzoneClient,
+			nil,            // addedLabels: If specified, only events where all of these labels were added are returned
+			nil,            // addedTags: If specified, only events where all of these tags were added are returned
+			"",             // comment: If specified, only events with comments containing the keyword are returned
+			since.String(), // createdAfter: Retrieve events created after a given timestamp
+			"",             // createdBefore: Retrieve events created before a given timestamp
+			"",             // createdBy
+			"",             // cursor
+			false,          // hasComment: If true, only events with comments are returned
+			true,           // includeAllUserRecords: If true, events on all record types (posts, lists, profile etc.) owned by the did are returned
+			limit,
+			nil,   // removedLabels: If specified, only events where all of these labels were removed are returned
+			nil,   // removedTags
+			nil,   // reportTypes
+			"asc", // sortDirection: Sort direction for the events. Defaults to descending order of created at timestamp.
+			"",    // subject
+			nil,   // types: The types of events (fully qualified string in the format of tools.ozone.moderation.defs#modEvent<name>) to filter by. If not specified, all events are returned.
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, evt := range me.Events {
+			createdAt, err := time.Parse(time.RFC3339, evt.CreatedAt)
+			if err != nil {
+				return fmt.Errorf("invalid time format for 'createdAt': %w", err)
+			}
+			// TODO: is there a race condition here?
+			if !createdAt.After(since) {
+				s.logger.Error("out of order ozone event", "event", evt)
+				continue
+			}
+			if err = s.HandleOzoneEvent(ctx, evt); err != nil {
+				s.logger.Error("failed to process ozone event", "event", evt)
+				continue
+			}
+			since = createdAt
+		}
+		if len(me.Events) == 0 {
+			s.logger.Info("... ozone poller sleeping", "period", period)
+			time.Sleep(period)
+		}
+	}
+}
+
+func (s *Server) HandleOzoneEvent(ctx context.Context, eventView *toolsozone.ModerationDefs_ModEventView) error {
+
+	s.logger.Debug("received ozone event", "eventID", eventView.Id, "createdAt", eventView.CreatedAt)
+
+	if err := s.engine.ProcessOzoneEvent(ctx, eventView); err != nil {
+		s.logger.Error("engine failed to process ozone event", "err", err)
+	}
+	return nil
+}


### PR DESCRIPTION
This has automod consume events from Ozone and feed them in to the rules engine, similar to firehose events. It uses the queryEvents endpoint, polling every 5 seconds. This is all optional; if an ozone admin client isn't configured, it doesn't happen.

- some types of ozone events on an account subject result in account metadata getting flushed. this ensures that, eg, manually-added labels or takedowns end up in automod-visible cached account metadata
- harassment protection rule is updated to look in private tag state from ozone, not just a deployed config JSON file. this was actually more complex than I would thought, and results in additional account metadata fetches, but those are all cached (with cache purging!) so should be fine
- private/admin account metadata queries go to ozone, not PDS/entryway, by default. this could increase API load on ozone a bunch; we might need to optimize that code path
- ignores events caused by mod service automation (eg, automod itself)
- does not currently have any tests :disappointed: but I tested a fair bit in staging. would go slow and careful with any prod deploy

Some follow-ups for future work (recording these from my local dev notes):

- automod "flags" and ozone "tags" are kind of duplicate. I originally thought these would have automod "flags" show up as "tags" in Ozone. but should think that through again (maybe flags are useful outside ozone?) and how to refactor things if they should be the same concept
- entirely rip out PDS/entryway private metadata queries, once we are confident ozone is sufficient
- get publicly-available account creation timestamp working consistently. this could include tweaks to appview+ozone endpoints, and possibly even going to PLC directory for more authoritative timestamps
- should probably refactor account metadata struct in to more clearly distinct "bsky-specific" (from appview), "ozone-specific" (private metadata), and public account/identity info
- should probably handle account metadata more consistently across ozone, automod, and other systems. related to the `#identity` and `#account` refactors, we now have a concept of account status at various pieces of infrastructure (active, takendown, deactivated, suspended, deleted), and should represent that cleanly
- `OzoneEventContext` currently extends `AccountContext`, with the subject account as "the account". currently all ozone events have an associated subject account, while record is optional. we might end up with events that don't have a meaningful subject account? or want to have better ergonomics with a record-variant of ozone event context? those are more complex, feels like things are fine for now
- would like to refactor the "consumption" code (firehose and ozone events) out of the `cmd/hepa/` folder and in to `automod/`

Update: created a separate issue to track these refactors: https://github.com/bluesky-social/indigo/issues/700