### PR TITLE
configuring initial perDayLimit via cmdline/env-var, to reduce ops

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -112,6 +112,7 @@ type BGSConfig struct {
 	DefaultRepoLimit  int64
 	ConcurrencyPerPDS int64
 	MaxQueuePerPDS    int64
+	InitialNewPDSPerDayLimit int64
 }
 
 func DefaultBGSConfig() *BGSConfig {
@@ -121,6 +122,7 @@ func DefaultBGSConfig() *BGSConfig {
 		DefaultRepoLimit:  100,
 		ConcurrencyPerPDS: 100,
 		MaxQueuePerPDS:    1_000,
+	        InitialNewPDSPerDayLimit: 10,
 	}
 }
 
@@ -157,6 +159,7 @@ func NewBGS(db *gorm.DB, ix *indexer.Indexer, repoman *repomgr.RepoManager, evtm
 	slOpts.DefaultRepoLimit = config.DefaultRepoLimit
 	slOpts.ConcurrencyPerPDS = config.ConcurrencyPerPDS
 	slOpts.MaxQueuePerPDS = config.MaxQueuePerPDS
+	slOpts.DefaultNewPDSPerDayLimit = config.InitialNewPDSPerDayLimit
 	s, err := NewSlurper(db, bgs.handleFedEvent, slOpts)
 	if err != nil {
 		return nil, err

--- a/bgs/fedmgr.go
+++ b/bgs/fedmgr.go
@@ -45,6 +45,7 @@ type Slurper struct {
 	MaxQueuePerPDS    int64
 
 	NewPDSPerDayLimiter *slidingwindow.Limiter
+	initialNewPDSPerDayLimit   int64
 
 	newSubsDisabled bool
 	trustedDomains  []string
@@ -70,6 +71,7 @@ type SlurperOptions struct {
 	DefaultRepoLimit      int64
 	ConcurrencyPerPDS     int64
 	MaxQueuePerPDS        int64
+	DefaultNewPDSPerDayLimit int64
 }
 
 func DefaultSlurperOptions() *SlurperOptions {
@@ -82,6 +84,7 @@ func DefaultSlurperOptions() *SlurperOptions {
 		DefaultRepoLimit:      100,
 		ConcurrencyPerPDS:     100,
 		MaxQueuePerPDS:        1_000,
+		DefaultNewPDSPerDayLimit: 10,
 	}
 }
 
@@ -112,6 +115,7 @@ func NewSlurper(db *gorm.DB, cb IndexCallback, opts *SlurperOptions) (*Slurper, 
 		ssl:                   opts.SSL,
 		shutdownChan:          make(chan bool),
 		shutdownResult:        make(chan []error),
+		initialNewPDSPerDayLimit:     opts.DefaultNewPDSPerDayLimit,
 	}
 	if err := s.loadConfig(); err != nil {
 		return nil, err
@@ -224,13 +228,15 @@ func (s *Slurper) loadConfig() error {
 	}
 
 	if sc.ID == 0 {
-		if err := s.db.Create(&SlurpConfig{}).Error; err != nil {
+		sc.NewPDSPerDayLimit = s.initialNewPDSPerDayLimit
+		if err := s.db.Create(&SlurpConfig{ NewPDSPerDayLimit: s.initialNewPDSPerDayLimit, }).Error; err != nil {
 			return err
 		}
 	}
 
 	s.newSubsDisabled = sc.NewSubsDisabled
 	s.trustedDomains = sc.TrustedDomains
+	s.initialNewPDSPerDayLimit = sc.NewPDSPerDayLimit
 
 	s.NewPDSPerDayLimiter, _ = slidingwindow.NewLimiter(time.Hour*24, sc.NewPDSPerDayLimit, windowFunc)
 

--- a/cmd/bigsky/main.go
+++ b/cmd/bigsky/main.go
@@ -183,6 +183,12 @@ func run(args []string) error {
 			EnvVars: []string{"RELAY_MAX_QUEUE_PER_PDS"},
 			Value:   1_000,
 		},
+		&cli.Int64Flag{
+			Name:    "newpds-perday-limit",
+			EnvVars: []string{"RELAY_NEWPDS_PERDAY_LIMIT"},
+			Value:   10,
+			Usage:   "initial value for NewPDSPerDayLimit",
+		},
 	}
 
 	app.Action = runBigsky
@@ -398,6 +404,7 @@ func runBigsky(cctx *cli.Context) error {
 	bgsConfig.ConcurrencyPerPDS = cctx.Int64("concurrency-per-pds")
 	bgsConfig.MaxQueuePerPDS = cctx.Int64("max-queue-per-pds")
 	bgsConfig.DefaultRepoLimit = cctx.Int64("default-repo-limit")
+	bgsConfig.InitialNewPDSPerDayLimit = cctx.Int64("newpds-perday-limit")
 	bgs, err := libbgs.NewBGS(db, ix, repoman, evtman, cachedidr, rf, hr, bgsConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
fix #684

This PR supports you to configure **initial value** of perDayLimit via commandline or environment variable, to reduce ops.

```
cmdline option:  --newpds-perday-limit N
env var:  RELAY_NEWPDS_PERDAY_LIMIT=N
```

the above ops takes efforts only when the the value is not configured before.
so there is no bad side-effect on your existing parameters, nor your runtime ops.

if both of cmdline option and env var are not specified at first deployment, default value 10 is passed by cli.Context