### PR TITLE
automod: fix automod account age

### DIFF
--- a/automod/engine/account_meta.go
+++ b/automod/engine/account_meta.go
@@ -32,6 +32,6 @@ type ProfileSummary struct {
 type AccountPrivate struct {
 	Email          string
 	EmailConfirmed bool
-	IndexedAt      time.Time
+	IndexedAt      *time.Time
 	AccountTags    []string
 }

--- a/automod/engine/engine_ozone.go
+++ b/automod/engine/engine_ozone.go
@@ -110,7 +110,7 @@ func NewOzoneEventContext(ctx context.Context, eng *Engine, eventView *toolsozon
 		return nil, err
 	}
 	if creatorIdent == nil {
-		return nil, fmt.Errorf("identity not found for DID: %s", evt.CreatedBy)
+		return nil, fmt.Errorf("identity not found for creator DID: %s", evt.CreatedBy)
 	}
 	creatorMeta, err := eng.GetAccountMeta(ctx, creatorIdent)
 	if err != nil {
@@ -122,7 +122,7 @@ func NewOzoneEventContext(ctx context.Context, eng *Engine, eventView *toolsozon
 		return nil, err
 	}
 	if subjectIdent == nil {
-		return nil, fmt.Errorf("identity not found for DID: %s", evt.SubjectDID)
+		return nil, fmt.Errorf("identity not found for subject DID: %s", evt.SubjectDID)
 	}
 	accountMeta, err := eng.GetAccountMeta(ctx, subjectIdent)
 	if err != nil {

--- a/automod/engine/fetch_account_meta.go
+++ b/automod/engine/fetch_account_meta.go
@@ -64,7 +64,7 @@ func (e *Engine) GetAccountMeta(ctx context.Context, ident *identity.Identity) (
 	// most common cause of this is a race between automod and ozone/appview for new accounts. just sleep a couple seconds and retry!
 	var xrpcError *xrpc.Error
 	if err != nil && errors.As(err, &xrpcError) && (xrpcError.StatusCode == 400 || xrpcError.StatusCode == 404) {
-		logger.Info("account profile lookup initially failed (from bsky appview), will retry", "err", err, "sleepDuration", NewAccountRetryDuration)
+		logger.Info("account profile lookup initially failed (from bsky appview), will retry", "err", err, "sleepDuration", newAccountRetryDuration)
 		time.Sleep(newAccountRetryDuration)
 		pv, err = appbsky.ActorGetProfile(ctx, e.BskyClient, ident.DID.String())
 	}

--- a/automod/engine/fetch_account_meta.go
+++ b/automod/engine/fetch_account_meta.go
@@ -69,7 +69,7 @@ func (e *Engine) GetAccountMeta(ctx context.Context, ident *identity.Identity) (
 		pv, err = appbsky.ActorGetProfile(ctx, e.BskyClient, ident.DID.String())
 	}
 	if err != nil {
-		logger.Warn("account profile lookup failed (from bsky appviewk)", "err", err)
+		logger.Warn("account profile lookup failed (from bsky appview)", "err", err)
 		return &am, nil
 	}
 

--- a/automod/engine/persist.go
+++ b/automod/engine/persist.go
@@ -170,7 +170,7 @@ func (eng *Engine) persistRecordModActions(c *RecordContext) error {
 		rv, err := toolsozone.ModerationGetRecord(ctx, eng.OzoneClient, c.RecordOp.CID.String(), c.RecordOp.ATURI().String())
 		if err != nil {
 			// NOTE: there is a frequent 4xx error here from Ozone because this record has not been indexed yet
-			c.Logger.Warn("failed to fetch private record metadata", "err", err)
+			c.Logger.Warn("failed to fetch private record metadata from Ozone", "err", err)
 		} else {
 			var existingLabels []string
 			var negLabels []string

--- a/automod/pkg.go
+++ b/automod/pkg.go
@@ -7,6 +7,8 @@ import (
 
 type Engine = engine.Engine
 type AccountMeta = engine.AccountMeta
+type ProfileSummary = engine.ProfileSummary
+type AccountPrivate = engine.AccountPrivate
 type RuleSet = engine.RuleSet
 
 type Notifier = engine.Notifier

--- a/automod/rules/harassment.go
+++ b/automod/rules/harassment.go
@@ -14,7 +14,7 @@ var _ automod.PostRuleFunc = HarassmentTargetInteractionPostRule
 
 // looks for new accounts, which interact with frequently-harassed accounts, and report them for review
 func HarassmentTargetInteractionPostRule(c *automod.RecordContext, post *appbsky.FeedPost) error {
-	if c.Account.Identity == nil || !AccountIsYoungerThan(&c.AccountContext, 7*24*time.Hour) {
+	if c.Account.Identity == nil || !AccountIsYoungerThan(&c.AccountContext, 24*time.Hour) {
 		return nil
 	}
 
@@ -35,8 +35,25 @@ func HarassmentTargetInteractionPostRule(c *automod.RecordContext, post *appbsky
 		}
 		interactionDIDs = append(interactionDIDs, parentURI.Authority().String())
 	}
-	// TODO: quote-posts; any other interactions?
+	// quote posts
+	if post.Embed != nil && post.Embed.EmbedRecord != nil && post.Embed.EmbedRecord.Record != nil {
+		uri, err := syntax.ParseATURI(post.Embed.EmbedRecord.Record.Uri)
+		if err != nil {
+			c.Logger.Warn("invalid AT-URI in post embed record (quote-post)", "uri", post.Embed.EmbedRecord.Record.Uri)
+		} else {
+			interactionDIDs = append(interactionDIDs, uri.Authority().String())
+		}
+	}
 	if len(interactionDIDs) == 0 {
+		return nil
+	}
+
+	// more than a handful of followers or posts from author account? skip
+	if c.Account.FollowersCount > 10 || c.Account.PostsCount > 10 {
+		return nil
+	}
+	postCount := c.GetCount("post", c.Account.Identity.DID.String(), countstore.PeriodTotal)
+	if postCount > 20 {
 		return nil
 	}
 

--- a/automod/rules/harassment.go
+++ b/automod/rules/harassment.go
@@ -101,8 +101,7 @@ func HarassmentTargetInteractionPostRule(c *automod.RecordContext, post *appbsky
 		}
 		c.Logger.Warn("possible harassment", "targetDID", did, "author", c.Account.Identity.DID, "accountCreated", c.Account.CreatedAt, "privateAccountCreated", privCreatedAt)
 		c.ReportAccount(automod.ReportReasonOther, fmt.Sprintf("possible harassment of known target account: %s (also labeled; remove label if this isn't harassment)", did))
-		// XXX: disable while debugging
-		//c.AddAccountLabel("!hide")
+		c.AddAccountLabel("!hide")
 		c.Notify("slack")
 		return nil
 	}

--- a/automod/rules/harassment.go
+++ b/automod/rules/harassment.go
@@ -78,8 +78,14 @@ func HarassmentTargetInteractionPostRule(c *automod.RecordContext, post *appbsky
 		}
 
 		//c.AddRecordFlag("interaction-harassed-target")
+		var privCreatedAt *time.Time
+		if c.Account.Private != nil {
+			privCreatedAt = &c.Account.Private.IndexedAt
+		}
+		c.Logger.Warn("possible harassment", "targetDID", did, "author", c.Account.Identity.DID, "accountCreated", c.Account.CreatedAt, "privateAccountCreated", privCreatedAt)
 		c.ReportAccount(automod.ReportReasonOther, fmt.Sprintf("possible harassment of known target account: %s (also labeled; remove label if this isn't harassment)", did))
-		c.AddAccountLabel("!hide")
+		// XXX: disable while debugging
+		//c.AddAccountLabel("!hide")
 		c.Notify("slack")
 		return nil
 	}

--- a/automod/rules/harassment.go
+++ b/automod/rules/harassment.go
@@ -14,12 +14,7 @@ var _ automod.PostRuleFunc = HarassmentTargetInteractionPostRule
 
 // looks for new accounts, which interact with frequently-harassed accounts, and report them for review
 func HarassmentTargetInteractionPostRule(c *automod.RecordContext, post *appbsky.FeedPost) error {
-	if c.Account.Private == nil || c.Account.Identity == nil {
-		return nil
-	}
-	// TODO: helper for account age; and use public info for this (not private)
-	age := time.Since(c.Account.Private.IndexedAt)
-	if age > 7*24*time.Hour {
+	if c.Account.Identity == nil || !AccountIsYoungerThan(&c.AccountContext, 7*24*time.Hour) {
 		return nil
 	}
 
@@ -95,12 +90,7 @@ var _ automod.PostRuleFunc = HarassmentTrivialPostRule
 
 // looks for new accounts, which frequently post the same type of content
 func HarassmentTrivialPostRule(c *automod.RecordContext, post *appbsky.FeedPost) error {
-	if c.Account.Private == nil || c.Account.Identity == nil {
-		return nil
-	}
-	// TODO: helper for account age; and use public info for this (not private)
-	age := time.Since(c.Account.Private.IndexedAt)
-	if age > 7*24*time.Hour {
+	if c.Account.Identity == nil || !AccountIsYoungerThan(&c.AccountContext, 7*24*time.Hour) {
 		return nil
 	}
 

--- a/automod/rules/harassment.go
+++ b/automod/rules/harassment.go
@@ -79,8 +79,8 @@ func HarassmentTargetInteractionPostRule(c *automod.RecordContext, post *appbsky
 
 		//c.AddRecordFlag("interaction-harassed-target")
 		var privCreatedAt *time.Time
-		if c.Account.Private != nil {
-			privCreatedAt = &c.Account.Private.IndexedAt
+		if c.Account.Private != nil && c.Account.Private.IndexedAt != nil {
+			privCreatedAt = c.Account.Private.IndexedAt
 		}
 		c.Logger.Warn("possible harassment", "targetDID", did, "author", c.Account.Identity.DID, "accountCreated", c.Account.CreatedAt, "privateAccountCreated", privCreatedAt)
 		c.ReportAccount(automod.ReportReasonOther, fmt.Sprintf("possible harassment of known target account: %s (also labeled; remove label if this isn't harassment)", did))

--- a/automod/rules/helpers.go
+++ b/automod/rules/helpers.go
@@ -272,3 +272,15 @@ func AccountIsYoungerThan(c *automod.AccountContext, age time.Duration) bool {
 	}
 	return false
 }
+
+// checks if account was *not* created recently, based on either public or private account metadata. if metadata isn't available at all, or seems bogus, returns 'false'
+func AccountIsOlderThan(c *automod.AccountContext, age time.Duration) bool {
+	// trust private account metadata more
+	if c.Account.Private != nil && plausibleAccountCreation(&c.Account.Private.IndexedAt) {
+		return time.Since(c.Account.Private.IndexedAt) >= age
+	}
+	if c.Account.CreatedAt != nil && plausibleAccountCreation(c.Account.CreatedAt) {
+		return time.Since(*c.Account.CreatedAt) >= age
+	}
+	return false
+}

--- a/automod/rules/helpers.go
+++ b/automod/rules/helpers.go
@@ -263,24 +263,23 @@ func plausibleAccountCreation(when *time.Time) bool {
 
 // checks if account was created recently, based on either public or private account metadata. if metadata isn't available at all, or seems bogus, returns 'false'
 func AccountIsYoungerThan(c *automod.AccountContext, age time.Duration) bool {
-	// trust private account metadata more
-	if c.Account.Private != nil && plausibleAccountCreation(&c.Account.Private.IndexedAt) {
-		return time.Since(c.Account.Private.IndexedAt) < age
-	}
+	// TODO: consider swapping priority order here (and below)
 	if c.Account.CreatedAt != nil && plausibleAccountCreation(c.Account.CreatedAt) {
 		return time.Since(*c.Account.CreatedAt) < age
+	}
+	if c.Account.Private != nil && plausibleAccountCreation(c.Account.Private.IndexedAt) {
+		return time.Since(*c.Account.Private.IndexedAt) < age
 	}
 	return false
 }
 
 // checks if account was *not* created recently, based on either public or private account metadata. if metadata isn't available at all, or seems bogus, returns 'false'
 func AccountIsOlderThan(c *automod.AccountContext, age time.Duration) bool {
-	// trust private account metadata more
-	if c.Account.Private != nil && plausibleAccountCreation(&c.Account.Private.IndexedAt) {
-		return time.Since(c.Account.Private.IndexedAt) >= age
-	}
 	if c.Account.CreatedAt != nil && plausibleAccountCreation(c.Account.CreatedAt) {
 		return time.Since(*c.Account.CreatedAt) >= age
+	}
+	if c.Account.Private != nil && plausibleAccountCreation(c.Account.Private.IndexedAt) {
+		return time.Since(*c.Account.Private.IndexedAt) >= age
 	}
 	return false
 }

--- a/automod/rules/helpers.go
+++ b/automod/rules/helpers.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"fmt"
 	"regexp"
+	"time"
 
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/atproto/syntax"
@@ -237,6 +238,37 @@ func ParentOrRootIsFollower(c *automod.RecordContext, post *appbsky.FeedPost) bo
 	rel = c.GetAccountRelationship(rootDID)
 	if rel.FollowedBy {
 		return true
+	}
+	return false
+}
+
+// no accounts exist before this time
+var atprotoAccountEpoch = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// returns true if account creation timestamp is plausible: not-nil, not in distant past, not in the future
+func plausibleAccountCreation(when *time.Time) bool {
+	if when == nil {
+		return false
+	}
+	// this is mostly to check for misconfigurations or null values (eg, UNIX epoch zero means "unknown" not actually 1970)
+	if !when.After(atprotoAccountEpoch) {
+		return false
+	}
+	// a timestamp in the future would also indicate some misconfiguration
+	if when.After(time.Now().Add(time.Hour)) {
+		return false
+	}
+	return true
+}
+
+// checks if account was created recently, based on either public or private account metadata. if metadata isn't available at all, or seems bogus, returns 'false'
+func AccountIsYoungerThan(c *automod.AccountContext, age time.Duration) bool {
+	// trust private account metadata more
+	if c.Account.Private != nil && plausibleAccountCreation(&c.Account.Private.IndexedAt) {
+		return time.Since(c.Account.Private.IndexedAt) < age
+	}
+	if c.Account.CreatedAt != nil && plausibleAccountCreation(c.Account.CreatedAt) {
+		return time.Since(*c.Account.CreatedAt) < age
 	}
 	return false
 }

--- a/automod/rules/helpers_test.go
+++ b/automod/rules/helpers_test.go
@@ -82,27 +82,36 @@ func TestAccountIsYoungerThan(t *testing.T) {
 		Account: am,
 	}
 	assert.False(AccountIsYoungerThan(&ac, time.Hour))
+	assert.False(AccountIsOlderThan(&ac, time.Hour))
 
 	ac.Account.CreatedAt = &now
 	assert.True(AccountIsYoungerThan(&ac, time.Hour))
+	assert.False(AccountIsOlderThan(&ac, time.Hour))
 
 	yesterday := time.Now().Add(-1 * time.Hour * 24)
 	ac.Account.CreatedAt = &yesterday
 	assert.False(AccountIsYoungerThan(&ac, time.Hour))
+	assert.True(AccountIsOlderThan(&ac, time.Hour))
 
 	old := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
 	ac.Account.CreatedAt = &old
 	assert.False(AccountIsYoungerThan(&ac, time.Hour))
 	assert.False(AccountIsYoungerThan(&ac, time.Hour*24*365*100))
+	assert.False(AccountIsOlderThan(&ac, time.Hour))
+	assert.False(AccountIsOlderThan(&ac, time.Hour*24*365*100))
 
 	future := time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC)
 	ac.Account.CreatedAt = &future
 	assert.False(AccountIsYoungerThan(&ac, time.Hour))
+	assert.False(AccountIsOlderThan(&ac, time.Hour))
 
 	ac.Account.CreatedAt = nil
 	ac.Account.Private = &automod.AccountPrivate{
 		Email:     "account@example.com",
-		IndexedAt: time.Now(),
+		IndexedAt: yesterday,
 	}
-	assert.True(AccountIsYoungerThan(&ac, time.Hour))
+	assert.True(AccountIsYoungerThan(&ac, 48*time.Hour))
+	assert.False(AccountIsYoungerThan(&ac, time.Hour))
+	assert.True(AccountIsOlderThan(&ac, time.Hour))
+	assert.False(AccountIsOlderThan(&ac, 48*time.Hour))
 }

--- a/automod/rules/helpers_test.go
+++ b/automod/rules/helpers_test.go
@@ -2,7 +2,11 @@ package rules
 
 import (
 	"testing"
+	"time"
 
+	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/bluesky-social/indigo/automod"
 	"github.com/bluesky-social/indigo/automod/keyword"
 	"github.com/stretchr/testify/assert"
 )
@@ -60,4 +64,45 @@ func TestHashOfString(t *testing.T) {
 
 	// hashing function should be consistent over time
 	assert.Equal("4e6f69c0e3d10992", HashOfString("dummy-value"))
+}
+
+func TestAccountIsYoungerThan(t *testing.T) {
+	assert := assert.New(t)
+
+	am := automod.AccountMeta{
+		Identity: &identity.Identity{
+			DID:    syntax.DID("did:plc:abc111"),
+			Handle: syntax.Handle("handle.example.com"),
+		},
+		Profile: automod.ProfileSummary{},
+		Private: nil,
+	}
+	now := time.Now()
+	ac := automod.AccountContext{
+		Account: am,
+	}
+	assert.False(AccountIsYoungerThan(&ac, time.Hour))
+
+	ac.Account.CreatedAt = &now
+	assert.True(AccountIsYoungerThan(&ac, time.Hour))
+
+	yesterday := time.Now().Add(-1 * time.Hour * 24)
+	ac.Account.CreatedAt = &yesterday
+	assert.False(AccountIsYoungerThan(&ac, time.Hour))
+
+	old := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+	ac.Account.CreatedAt = &old
+	assert.False(AccountIsYoungerThan(&ac, time.Hour))
+	assert.False(AccountIsYoungerThan(&ac, time.Hour*24*365*100))
+
+	future := time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC)
+	ac.Account.CreatedAt = &future
+	assert.False(AccountIsYoungerThan(&ac, time.Hour))
+
+	ac.Account.CreatedAt = nil
+	ac.Account.Private = &automod.AccountPrivate{
+		Email:     "account@example.com",
+		IndexedAt: time.Now(),
+	}
+	assert.True(AccountIsYoungerThan(&ac, time.Hour))
 }

--- a/automod/rules/helpers_test.go
+++ b/automod/rules/helpers_test.go
@@ -108,7 +108,7 @@ func TestAccountIsYoungerThan(t *testing.T) {
 	ac.Account.CreatedAt = nil
 	ac.Account.Private = &automod.AccountPrivate{
 		Email:     "account@example.com",
-		IndexedAt: yesterday,
+		IndexedAt: &yesterday,
 	}
 	assert.True(AccountIsYoungerThan(&ac, 48*time.Hour))
 	assert.False(AccountIsYoungerThan(&ac, time.Hour))

--- a/automod/rules/identity.go
+++ b/automod/rules/identity.go
@@ -11,16 +11,11 @@ import (
 
 // triggers on first identity event for an account (DID)
 func NewAccountRule(c *automod.AccountContext) error {
-	// need access to IndexedAt for this rule
-	if c.Account.Private == nil || c.Account.Identity == nil {
+	if c.Account.Identity == nil || !AccountIsYoungerThan(c, 4*time.Hour) {
 		return nil
 	}
 
 	did := c.Account.Identity.DID.String()
-	age := time.Since(c.Account.Private.IndexedAt)
-	if age > 4*time.Hour {
-		return nil
-	}
 	exists := c.GetCount("acct/exists", did, countstore.PeriodTotal)
 	if exists == 0 {
 		c.Logger.Info("new account")

--- a/automod/rules/mentions.go
+++ b/automod/rules/mentions.go
@@ -47,13 +47,8 @@ var youngMentionAccountLimit = 12
 var _ automod.PostRuleFunc = YoungAccountDistinctMentionsRule
 
 func YoungAccountDistinctMentionsRule(c *automod.RecordContext, post *appbsky.FeedPost) error {
-
-	// only young posting accounts
-	if c.Account.Private != nil {
-		age := time.Since(c.Account.Private.IndexedAt)
-		if age > 2*7*24*time.Hour {
-			return nil
-		}
+	if c.Account.Identity == nil || !AccountIsYoungerThan(&c.AccountContext, 14*24*time.Hour) {
+		return nil
 	}
 
 	// parse out all the mentions

--- a/automod/rules/nostr.go
+++ b/automod/rules/nostr.go
@@ -13,17 +13,8 @@ var _ automod.PostRuleFunc = NostrSpamPostRule
 
 // looks for new accounts, which frequently post the same type of content
 func NostrSpamPostRule(c *automod.RecordContext, post *appbsky.FeedPost) error {
-	if c.Account.Identity == nil {
+	if c.Account.Identity == nil || !AccountIsYoungerThan(&c.AccountContext, 2*24*time.Hour) {
 		return nil
-	}
-
-	// often don't have private metadata for these accounts right after creation
-	if c.Account.Private != nil {
-		// TODO: helper for account age; and use public info for this (not private)
-		age := time.Since(c.Account.Private.IndexedAt)
-		if age > 2*24*time.Hour {
-			return nil
-		}
 	}
 
 	// is this a bridged nostr account? if not, bail out

--- a/automod/rules/promo.go
+++ b/automod/rules/promo.go
@@ -17,12 +17,7 @@ var _ automod.PostRuleFunc = AggressivePromotionRule
 //
 // this rule depends on ReplyCountPostRule() to set counts
 func AggressivePromotionRule(c *automod.RecordContext, post *appbsky.FeedPost) error {
-	if c.Account.Private == nil || c.Account.Identity == nil {
-		return nil
-	}
-	// TODO: helper for account age
-	age := time.Since(c.Account.Private.IndexedAt)
-	if age > 7*24*time.Hour {
+	if c.Account.Identity == nil || !AccountIsYoungerThan(&c.AccountContext, 7*24*time.Hour) {
 		return nil
 	}
 	if post.Reply == nil || IsSelfThread(c, post) {

--- a/automod/rules/quick.go
+++ b/automod/rules/quick.go
@@ -46,13 +46,7 @@ func SimpleBotPostRule(c *automod.RecordContext, post *appbsky.FeedPost) error {
 var _ automod.IdentityRuleFunc = NewAccountBotEmailRule
 
 func NewAccountBotEmailRule(c *automod.AccountContext) error {
-	// need access to IndexedAt for this rule
-	if c.Account.Private == nil || c.Account.Identity == nil {
-		return nil
-	}
-
-	age := time.Since(c.Account.Private.IndexedAt)
-	if age > 1*time.Hour {
+	if c.Account.Identity == nil || !AccountIsYoungerThan(c, 1*time.Hour) {
 		return nil
 	}
 

--- a/automod/rules/replies.go
+++ b/automod/rules/replies.go
@@ -52,11 +52,8 @@ func IdenticalReplyPostRule(c *automod.RecordContext, post *appbsky.FeedPost) er
 	if utf8.RuneCountInString(post.Text) <= 10 {
 		return nil
 	}
-	if c.Account.Private != nil {
-		age := time.Since(c.Account.Private.IndexedAt)
-		if age > 2*7*24*time.Hour {
-			return nil
-		}
+	if AccountIsOlderThan(&c.AccountContext, 14*24*time.Hour) {
+		return nil
 	}
 
 	// don't count if there is a follow-back relationship
@@ -92,11 +89,8 @@ func YoungAccountDistinctRepliesRule(c *automod.RecordContext, post *appbsky.Fee
 	if utf8.RuneCountInString(post.Text) <= 10 {
 		return nil
 	}
-	if c.Account.Private != nil {
-		age := time.Since(c.Account.Private.IndexedAt)
-		if age > 2*7*24*time.Hour {
-			return nil
-		}
+	if AccountIsOlderThan(&c.AccountContext, 14*24*time.Hour) {
+		return nil
 	}
 
 	// don't count if there is a follow-back relationship

--- a/automod/rules/reposts.go
+++ b/automod/rules/reposts.go
@@ -17,15 +17,12 @@ var _ automod.RecordRuleFunc = TooManyRepostRule
 
 // looks for accounts which do frequent reposts
 func TooManyRepostRule(c *automod.RecordContext) error {
+	// Don't bother checking reposts from accounts older than 30 days
+	if c.Account.Identity == nil || !AccountIsYoungerThan(&c.AccountContext, 30*24*time.Hour) {
+		return nil
+	}
 
 	did := c.Account.Identity.DID.String()
-	// Don't bother checking reposts from accounts older than 30 days
-	if c.Account.Private != nil {
-		age := time.Since(c.Account.Private.IndexedAt)
-		if age > 30*24*time.Hour {
-			return nil
-		}
-	}
 
 	// Special case for newsmast bridge feeds
 	handle := c.Account.Identity.Handle.String()

--- a/cmd/hepa/server.go
+++ b/cmd/hepa/server.go
@@ -147,7 +147,7 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 		}
 		counters = cnt
 
-		csh, err := cachestore.NewRedisCacheStore(config.RedisURL, 30*time.Minute)
+		csh, err := cachestore.NewRedisCacheStore(config.RedisURL, 6*time.Hour)
 		if err != nil {
 			return nil, fmt.Errorf("initializing redis cachestore: %v", err)
 		}
@@ -160,7 +160,7 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 		flags = flg
 	} else {
 		counters = countstore.NewMemCountStore()
-		cache = cachestore.NewMemCacheStore(5_000, 30*time.Minute)
+		cache = cachestore.NewMemCacheStore(5_000, 1*time.Hour)
 		flags = flagstore.NewMemFlagStore()
 	}
 


### PR DESCRIPTION
these are cleanups related to an earlier bug when rolling out account creation timestamp handling in automod