### PR TITLE
automod: ozone account history refactors

### DIFF
--- a/automod/capture/testing.go
+++ b/automod/capture/testing.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/bluesky-social/indigo/automod"
@@ -38,12 +39,19 @@ func ProcessCaptureRules(eng *automod.Engine, capture AccountCapture) error {
 	ctx := context.Background()
 
 	did := capture.AccountMeta.Identity.DID
+	handle := capture.AccountMeta.Identity.Handle.String()
 	dir := identity.NewMockDirectory()
 	dir.Insert(*capture.AccountMeta.Identity)
 	eng.Directory = &dir
 
 	// initial identity rules
-	eng.ProcessIdentityEvent(ctx, "new", did)
+	identEvent := comatproto.SyncSubscribeRepos_Identity{
+		Did:    did.String(),
+		Handle: &handle,
+		Seq:    12345,
+		Time:   syntax.DatetimeNow().String(),
+	}
+	eng.ProcessIdentityEvent(ctx, identEvent)
 
 	// all the post rules
 	for _, pr := range capture.PostRecords {

--- a/automod/engine/context.go
+++ b/automod/engine/context.go
@@ -292,6 +292,10 @@ func (c *RecordContext) TakedownBlob(cid string) {
 	c.effects.TakedownBlob(cid)
 }
 
+func (c *RecordContext) PersistRecordOzoneEvent() {
+	c.effects.PersistRecordOzoneEvent()
+}
+
 func (c *NotificationContext) Reject() {
 	c.effects.Reject()
 }

--- a/automod/engine/effects.go
+++ b/automod/engine/effects.go
@@ -58,6 +58,8 @@ type Effects struct {
 	RejectEvent bool
 	// Services, if any, which should blast out a notification about this even (eg, Slack)
 	NotifyServices []string
+	// If "true", and Ozone event history is configured/enable, then sent a mod event to ozone backend for this event
+	PersistOzoneRecordEvent bool
 }
 
 // Enqueues the named counter to be incremented at the end of all rule processing. Will automatically increment for all time periods.
@@ -198,4 +200,9 @@ func (e *Effects) Notify(srv string) {
 
 func (e *Effects) Reject() {
 	e.RejectEvent = true
+}
+
+// Marks that this subject should be recorded in ozone history
+func (e *Effects) PersistRecordOzoneEvent() {
+	e.PersistOzoneRecordEvent = true
 }

--- a/automod/engine/ruleset.go
+++ b/automod/engine/ruleset.go
@@ -16,6 +16,7 @@ type RuleSet struct {
 	RecordRules       []RecordRuleFunc
 	RecordDeleteRules []RecordRuleFunc
 	IdentityRules     []IdentityRuleFunc
+	AccountRules      []AccountRuleFunc
 	BlobRules         []BlobRuleFunc
 	NotificationRules []NotificationRuleFunc
 	OzoneEventRules   []OzoneEventRuleFunc
@@ -84,6 +85,17 @@ func (r *RuleSet) CallIdentityRules(c *AccountContext) error {
 		err := f(c)
 		if err != nil {
 			c.Logger.Error("identity rule execution failed", "err", err)
+		}
+	}
+	return nil
+}
+
+// Executes rules for account update events.
+func (r *RuleSet) CallAccountRules(c *AccountContext) error {
+	for _, f := range r.AccountRules {
+		err := f(c)
+		if err != nil {
+			c.Logger.Error("account rule execution failed", "err", err)
 		}
 	}
 	return nil

--- a/automod/engine/ruletypes.go
+++ b/automod/engine/ruletypes.go
@@ -6,6 +6,7 @@ import (
 )
 
 type IdentityRuleFunc = func(c *AccountContext) error
+type AccountRuleFunc = func(c *AccountContext) error
 type RecordRuleFunc = func(c *RecordContext) error
 type PostRuleFunc = func(c *RecordContext, post *appbsky.FeedPost) error
 type ProfileRuleFunc = func(c *RecordContext, profile *appbsky.ActorProfile) error

--- a/automod/pkg.go
+++ b/automod/pkg.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Engine = engine.Engine
+type EngineConfig = engine.EngineConfig
 type AccountMeta = engine.AccountMeta
 type RuleSet = engine.RuleSet
 
@@ -19,6 +20,7 @@ type NotificationContext = engine.NotificationContext
 type RecordOp = engine.RecordOp
 
 type IdentityRuleFunc = engine.IdentityRuleFunc
+type AccountRuleFunc = engine.AccountRuleFunc
 type RecordRuleFunc = engine.RecordRuleFunc
 type PostRuleFunc = engine.PostRuleFunc
 type ProfileRuleFunc = engine.ProfileRuleFunc

--- a/automod/rules/all.go
+++ b/automod/rules/all.go
@@ -39,6 +39,7 @@ func DefaultRules() automod.RuleSet {
 			BadWordRecordKeyRule,
 			BadWordOtherRecordRule,
 			TooManyRepostRule,
+			OzoneRecordHistoryPersistRule,
 		},
 		RecordDeleteRules: []automod.RecordRuleFunc{
 			DeleteInteractionRule,

--- a/automod/rules/ozone_persist.go
+++ b/automod/rules/ozone_persist.go
@@ -1,0 +1,25 @@
+package rules
+
+import (
+	"github.com/bluesky-social/indigo/automod"
+)
+
+var _ automod.RecordRuleFunc = OzoneRecordHistoryPersistRule
+
+func OzoneRecordHistoryPersistRule(c *automod.RecordContext) error {
+	// TODO: flesh out this logic
+	// based on record type
+	switch c.RecordOp.Collection {
+	case "app.bsky.labeler.service":
+		c.PersistRecordOzoneEvent()
+	case "app.bsky.feed.post":
+		if c.RecordOp.Action == "update" {
+		}
+	case "app.bsky.actor.profile":
+		// TODO: fix this logic
+		if len(c.Account.AccountLabels) > 2 {
+			c.PersistRecordOzoneEvent()
+		}
+	}
+	return nil
+}

--- a/cmd/hepa/server.go
+++ b/cmd/hepa/server.go
@@ -41,9 +41,6 @@ type Server struct {
 
 	// same as lastSeq, but for Ozone timestamp cursor. the value is a string.
 	lastOzoneCursor atomic.Value
-
-	// dictates if firehose events should be rerouted to configured destinations
-	rerouteEvents bool
 }
 
 type Config struct {
@@ -224,6 +221,9 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 		OzoneClient: ozoneClient,
 		AdminClient: adminClient,
 		BlobClient:  blobClient,
+		Config: automod.EngineConfig{
+			PersistSubjectHistoryOzone: config.RerouteEvents,
+		},
 	}
 
 	s := &Server{
@@ -232,7 +232,6 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 		logger:              logger,
 		engine:              &engine,
 		rdb:                 rdb,
-		rerouteEvents:       config.RerouteEvents,
 	}
 
 	return s, nil


### PR DESCRIPTION
These are refactors to the `ozone-account-events` branch that we went through together in a pair-programming session.

I haven't re-reviewed these yet, and there are a couple TODOs, but it at least compiles.