### PR TITLE
Pre-allocate ops slices that are appended in a loop where possible.

### DIFF
--- a/backfill/backfill.go
+++ b/backfill/backfill.go
@@ -468,7 +468,7 @@ func (bf *Backfiller) HandleEvent(ctx context.Context, evt *atproto.SyncSubscrib
 		return fmt.Errorf("failed to read event repo: %w", err)
 	}
 
-	var ops []*BufferedOp
+	ops := make([]*BufferedOp, 0, len(evt.Ops))
 	for _, op := range evt.Ops {
 		kind := repomgr.EventKind(op.Action)
 		switch kind {

--- a/cmd/supercollider/main.go
+++ b/cmd/supercollider/main.go
@@ -586,7 +586,7 @@ func initSpeedyRepoMan(key *godid.PrivKey) (*repomgr.RepoManager, *godid.PrivKey
 
 // HandleRepoEvent is the callback for the RepoManager
 func (s *Server) HandleRepoEvent(ctx context.Context, evt *repomgr.RepoEvent) {
-	var outops []*comatproto.SyncSubscribeRepos_RepoOp
+	outops := make([]*comatproto.SyncSubscribeRepos_RepoOp, 0, len(evt.Ops))
 	for _, op := range evt.Ops {
 		link := (*lexutil.LexLink)(op.RecCid)
 		outops = append(outops, &comatproto.SyncSubscribeRepos_RepoOp{
@@ -596,8 +596,6 @@ func (s *Server) HandleRepoEvent(ctx context.Context, evt *repomgr.RepoEvent) {
 		})
 	}
 
-	toobig := false
-
 	if err := s.Events.AddEvent(ctx, &events.XRPCStreamEvent{
 		RepoCommit: &comatproto.SyncSubscribeRepos_Commit{
 			Repo:   s.Dids[evt.User-1],
@@ -606,7 +604,7 @@ func (s *Server) HandleRepoEvent(ctx context.Context, evt *repomgr.RepoEvent) {
 			Commit: lexutil.LexLink(evt.NewRoot),
 			Time:   time.Now().Format(util.ISO8601),
 			Ops:    outops,
-			TooBig: toobig,
+			TooBig: false,
 		},
 		PrivUid: evt.User,
 	}); err != nil {

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -86,7 +86,7 @@ func (ix *Indexer) HandleRepoEvent(ctx context.Context, evt *repomgr.RepoEvent) 
 
 	log.Debugw("Handling Repo Event!", "uid", evt.User)
 
-	var outops []*comatproto.SyncSubscribeRepos_RepoOp
+	outops := make([]*comatproto.SyncSubscribeRepos_RepoOp, 0, len(evt.Ops))
 	for _, op := range evt.Ops {
 		link := (*lexutil.LexLink)(op.RecCid)
 		outops = append(outops, &comatproto.SyncSubscribeRepos_RepoOp{

--- a/repomgr/repomgr.go
+++ b/repomgr/repomgr.go
@@ -576,7 +576,7 @@ func (rm *RepoManager) HandleExternalUserEvent(ctx context.Context, pdsid uint, 
 
 	}
 
-	var evtops []RepoOp
+	evtops := make([]RepoOp, 0, len(ops))
 
 	for _, op := range ops {
 		parts := strings.SplitN(op.Path, "/", 2)
@@ -679,7 +679,7 @@ func (rm *RepoManager) BatchWrite(ctx context.Context, user models.Uid, writes [
 		return err
 	}
 
-	var ops []RepoOp
+	ops := make([]RepoOp, 0, len(writes))
 	for _, w := range writes {
 		switch {
 		case w.RepoApplyWrites_Create != nil:
@@ -826,7 +826,7 @@ func (rm *RepoManager) ImportNewRepo(ctx context.Context, user models.Uid, repoD
 			return fmt.Errorf("diff trees (curhead: %s): %w", curhead, err)
 		}
 
-		var ops []RepoOp
+		ops := make([]RepoOp, 0, len(diffops))
 		for _, op := range diffops {
 			repoOpsImported.Inc()
 			out, err := processOp(ctx, bs, op, rm.hydrateRecords)


### PR DESCRIPTION
This ensures that only one larger allocation is done instead of multiple small ones, reducing pressure on the garbage collector.