### PR TITLE
add `IdenticalReplyPostSameParentRule` to automod

### DIFF
--- a/automod/rules/all.go
+++ b/automod/rules/all.go
@@ -20,6 +20,7 @@ func DefaultRules() automod.RuleSet {
 			ReplySingleBadWordPostRule,
 			AggressivePromotionRule,
 			IdenticalReplyPostRule,
+			IdenticalReplyPostSameParentRule,
 			DistinctMentionsRule,
 			YoungAccountDistinctMentionsRule,
 			MisleadingLinkUnicodeReversalPostRule,

--- a/automod/rules/replies.go
+++ b/automod/rules/replies.go
@@ -93,10 +93,8 @@ func IdenticalReplyPostSameParentRule(c *automod.RecordContext, post *appbsky.Fe
 		return nil
 	}
 
-	createdAt := c.Account.CreatedAt
 	postCount := c.Account.PostsCount
-
-	if time.Since(*createdAt) >= identicalReplySameParentMaxAge || postCount >= identicalReplySameParentMaxPosts {
+	if AccountIsOlderThan(&c.AccountContext, identicalReplySameParentMaxAge) || postCount >= identicalReplySameParentMaxPosts {
 		return nil
 	}
 

--- a/automod/rules/replies.go
+++ b/automod/rules/replies.go
@@ -98,7 +98,7 @@ func IdenticalReplyPostSameParentRule(c *automod.RecordContext, post *appbsky.Fe
 		return nil
 	}
 
-	period := countstore.PeriodDay
+	period := countstore.PeriodHour
 	bucket := c.Account.Identity.DID.String() + "/" + post.Reply.Parent.Uri + "/" + HashOfString(post.Text)
 	c.IncrementPeriod("reply-text-same-post", bucket, period)
 

--- a/automod/rules/replies.go
+++ b/automod/rules/replies.go
@@ -78,6 +78,39 @@ func IdenticalReplyPostRule(c *automod.RecordContext, post *appbsky.FeedPost) er
 	return nil
 }
 
+// Similar to above rule but only counts replies to the same post. More aggressively applies a spam label to new accounts that are less than a day old.
+var identicalReplySameParentLimit = 3
+var identicalReplySameParentSpamLabel = 24 * time.Hour
+var _ automod.PostRuleFunc = IdenticalReplyPostSameParentRule
+
+func IdenticalReplyPostSameParentRule(c *automod.RecordContext, post *appbsky.FeedPost) error {
+	if post.Reply == nil || IsSelfThread(c, post) {
+		return nil
+	}
+
+	if ParentOrRootIsFollower(c, post) {
+		return nil
+	}
+
+	period := countstore.PeriodDay
+	bucket := c.Account.Identity.DID.String() + "/" + post.Reply.Parent.Uri + "/" + HashOfString(post.Text)
+	c.IncrementPeriod("reply-text-same-post", bucket, period)
+
+	count := c.GetCount("reply-text-same-post", bucket, period)
+	if count >= identicalReplySameParentLimit {
+		// if account is young, add spam label. otherwise just report.
+		createdAt := c.Account.CreatedAt
+		c.AddAccountFlag("multi-identical-reply-same-post")
+		c.ReportAccount(automod.ReportReasonSpam, fmt.Sprintf("possible spam (%d identical reply-posts to same post today)", count))
+		if time.Since(*createdAt) < identicalReplySameParentSpamLabel {
+			c.AddAccountLabel("spam")
+		}
+		c.Notify("slack")
+	}
+
+	return nil
+}
+
 // TODO: bumping temporarily
 // var youngReplyAccountLimit = 12
 var youngReplyAccountLimit = 30


### PR DESCRIPTION
adds a spam label to accounts that are under 24 hours doing this, otherwise just reports. maybe too hasty on the label, can adjust. (note our client really doesn't make it easy to make an identical post multiple times in a row like this, where even failures will usually close the composer anyway, so its likely to be intentional). same could probably be applied for same author but with a maybe higher limit