### PR TITLE
Use RefreshJwt when calling ServerRefreshSession.

### DIFF
--- a/api/atproto/serverrefreshSession.go
+++ b/api/atproto/serverrefreshSession.go
@@ -24,6 +24,12 @@ type ServerRefreshSession_Output struct {
 
 // ServerRefreshSession calls the XRPC method "com.atproto.server.refreshSession".
 func ServerRefreshSession(ctx context.Context, c *xrpc.Client) (*ServerRefreshSession_Output, error) {
+	// For refreshing the session, we need to use the RefreshJwt.
+	// Do only looks at AccessJwt so we need to copy the RefreshJwt token to it.
+	if c.Auth != nil && c.Auth.RefreshJwt != "" {
+		c.Auth.AccessJwt = c.Auth.RefreshJwt
+	}
+
 	var out ServerRefreshSession_Output
 	if err := c.Do(ctx, xrpc.Procedure, "", "com.atproto.server.refreshSession", nil, nil, &out); err != nil {
 		return nil, err


### PR DESCRIPTION
*xrpc.Client.Do only looks at Auth.AccessJwt when adding the jwt token, so I changed ServerRefreshSession to copy the RefreshJwt token to it before calling Do.

Alternatively, we can change Do to use RefreshJwt if the method is "com.atproto.server.refreshSession". I'm fine either way, though adding more custom logic to Do makes it less and less a generic Do.