### PR TITLE
don't use 'host' as structured logging field

### DIFF
--- a/automod/rules/identity.go
+++ b/automod/rules/identity.go
@@ -32,7 +32,7 @@ func NewAccountRule(c *automod.AccountContext) error {
 
 		// new PDS host
 		if existingAccounts == 0 {
-			c.Logger.Info("new PDS instance", "host", pdsHost)
+			c.Logger.Info("new PDS instance", "pdsHost", pdsHost)
 			c.Increment("host", "new")
 			c.AddAccountFlag("host-first-account")
 			c.Notify("slack")

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -800,7 +800,7 @@ func (bgs *BGS) handleFedEvent(ctx context.Context, host *models.PDS, env *event
 	case env.RepoCommit != nil:
 		repoCommitsReceivedCounter.WithLabelValues(host.Host).Add(1)
 		evt := env.RepoCommit
-		log.Debugw("bgs got repo append event", "seq", evt.Seq, "host", host.Host, "repo", evt.Repo)
+		log.Debugw("bgs got repo append event", "seq", evt.Seq, "pdsHost", host.Host, "repo", evt.Repo)
 		u, err := bgs.lookupUserByDid(ctx, evt.Repo)
 		if err != nil {
 			if !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -822,17 +822,17 @@ func (bgs *BGS) handleFedEvent(ctx context.Context, host *models.PDS, env *event
 
 		if u.TakenDown || u.UpstreamStatus == events.AccountStatusTakendown {
 			span.SetAttributes(attribute.Bool("taken_down_by_relay_admin", u.TakenDown))
-			log.Debugw("dropping commit event from taken down user", "did", evt.Repo, "seq", evt.Seq, "host", host.Host)
+			log.Debugw("dropping commit event from taken down user", "did", evt.Repo, "seq", evt.Seq, "pdsHost", host.Host)
 			return nil
 		}
 
 		if u.UpstreamStatus == events.AccountStatusSuspended {
-			log.Debugw("dropping commit event from suspended user", "did", evt.Repo, "seq", evt.Seq, "host", host.Host)
+			log.Debugw("dropping commit event from suspended user", "did", evt.Repo, "seq", evt.Seq, "pdsHost", host.Host)
 			return nil
 		}
 
 		if u.UpstreamStatus == events.AccountStatusDeactivated {
-			log.Debugw("dropping commit event from deactivated user", "did", evt.Repo, "seq", evt.Seq, "host", host.Host)
+			log.Debugw("dropping commit event from deactivated user", "did", evt.Repo, "seq", evt.Seq, "pdsHost", host.Host)
 			return nil
 		}
 
@@ -891,7 +891,7 @@ func (bgs *BGS) handleFedEvent(ctx context.Context, host *models.PDS, env *event
 		}
 
 		if err := bgs.repoman.HandleExternalUserEvent(ctx, host.ID, u.ID, u.Did, evt.Since, evt.Rev, evt.Blocks, evt.Ops); err != nil {
-			log.Warnw("failed handling event", "err", err, "host", host.Host, "seq", evt.Seq, "repo", u.Did, "prev", stringLink(evt.Prev), "commit", evt.Commit.String())
+			log.Warnw("failed handling event", "err", err, "pdsHost", host.Host, "seq", evt.Seq, "repo", u.Did, "prev", stringLink(evt.Prev), "commit", evt.Commit.String())
 
 			if errors.Is(err, carstore.ErrRepoBaseMismatch) || ipld.IsNotFound(err) {
 				ai, lerr := bgs.Index.LookupUser(ctx, u.ID)

--- a/cmd/athome/handlers.go
+++ b/cmd/athome/handlers.go
@@ -17,7 +17,7 @@ func (srv *Server) reqHandle(c echo.Context) syntax.Handle {
 	host = strings.SplitN(host, ":", 2)[0]
 	handle, err := syntax.ParseHandle(host)
 	if err != nil {
-		slog.Warn("host is not a valid handle, fallback to default", "host", host)
+		slog.Warn("host is not a valid handle, fallback to default", "hostname", host)
 		handle = srv.defaultHandle
 	}
 	return handle

--- a/cmd/hepa/server.go
+++ b/cmd/hepa/server.go
@@ -95,7 +95,7 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 			return nil, fmt.Errorf("ozone account DID supplied was not valid: %v", err)
 		}
 		ozoneClient.Auth.Did = od.String()
-		logger.Info("configured ozone admin client", "did", od.String(), "host", config.OzoneHost)
+		logger.Info("configured ozone admin client", "did", od.String(), "ozoneHost", config.OzoneHost)
 	} else {
 		logger.Info("did not configure ozone client")
 	}
@@ -112,7 +112,7 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 			adminClient.Headers = make(map[string]string)
 			adminClient.Headers["x-ratelimit-bypass"] = config.RatelimitBypass
 		}
-		logger.Info("configured PDS admin client", "host", config.PDSHost)
+		logger.Info("configured PDS admin client", "pdsHost", config.PDSHost)
 	} else {
 		logger.Info("did not configure PDS admin client")
 	}


### PR DESCRIPTION
at least in datadog, the structured logging 'host' field clobbers host metadata for the log line.

this might not impact loko, but seems reasonable to just avoid the naming collision generally.