### PR TITLE
syntax: clearer error for trivial empty string case

### DIFF
--- a/atproto/syntax/atidentifier.go
+++ b/atproto/syntax/atidentifier.go
@@ -10,6 +10,9 @@ type AtIdentifier struct {
 }
 
 func ParseAtIdentifier(raw string) (*AtIdentifier, error) {
+	if raw == "" {
+		return nil, fmt.Errorf("expected AT account identifier, got empty string")
+	}
 	if strings.HasPrefix(raw, "did:") {
 		did, err := ParseDID(raw)
 		if err != nil {

--- a/atproto/syntax/atidentifier.go
+++ b/atproto/syntax/atidentifier.go
@@ -1,7 +1,7 @@
 package syntax
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 )
 
@@ -11,7 +11,7 @@ type AtIdentifier struct {
 
 func ParseAtIdentifier(raw string) (*AtIdentifier, error) {
 	if raw == "" {
-		return nil, fmt.Errorf("expected AT account identifier, got empty string")
+		return nil, errors.New("expected AT account identifier, got empty string")
 	}
 	if strings.HasPrefix(raw, "did:") {
 		did, err := ParseDID(raw)
@@ -37,7 +37,7 @@ func (n AtIdentifier) AsHandle() (Handle, error) {
 	if ok {
 		return handle, nil
 	}
-	return "", fmt.Errorf("AT Identifier is not a Handle")
+	return "", errors.New("AT Identifier is not a Handle")
 }
 
 func (n AtIdentifier) IsDID() bool {
@@ -50,7 +50,7 @@ func (n AtIdentifier) AsDID() (DID, error) {
 	if ok {
 		return did, nil
 	}
-	return "", fmt.Errorf("AT Identifier is not a DID")
+	return "", errors.New("AT Identifier is not a DID")
 }
 
 func (n AtIdentifier) Normalize() AtIdentifier {

--- a/atproto/syntax/aturi.go
+++ b/atproto/syntax/aturi.go
@@ -1,6 +1,7 @@
 package syntax
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -17,11 +18,11 @@ type ATURI string
 
 func ParseATURI(raw string) (ATURI, error) {
 	if len(raw) > 8192 {
-		return "", fmt.Errorf("ATURI is too long (8192 chars max)")
+		return "", errors.New("ATURI is too long (8192 chars max)")
 	}
 	parts := aturiRegex.FindStringSubmatch(raw)
 	if parts == nil || len(parts) < 2 || parts[0] == "" {
-		return "", fmt.Errorf("AT-URI syntax didn't validate via regex")
+		return "", errors.New("AT-URI syntax didn't validate via regex")
 	}
 	// verify authority as either a DID or NSID
 	_, err := ParseAtIdentifier(parts[1])

--- a/atproto/syntax/cid.go
+++ b/atproto/syntax/cid.go
@@ -16,6 +16,9 @@ type CID string
 var cidRegex = regexp.MustCompile(`^[a-zA-Z0-9+=]{8,256}$`)
 
 func ParseCID(raw string) (CID, error) {
+	if raw == "" {
+		return "", fmt.Errorf("expected CID, got empty string")
+	}
 	if len(raw) > 256 {
 		return "", fmt.Errorf("CID is too long (256 chars max)")
 	}

--- a/atproto/syntax/cid.go
+++ b/atproto/syntax/cid.go
@@ -1,7 +1,7 @@
 package syntax
 
 import (
-	"fmt"
+	"errors"
 	"regexp"
 	"strings"
 )
@@ -17,20 +17,20 @@ var cidRegex = regexp.MustCompile(`^[a-zA-Z0-9+=]{8,256}$`)
 
 func ParseCID(raw string) (CID, error) {
 	if raw == "" {
-		return "", fmt.Errorf("expected CID, got empty string")
+		return "", errors.New("expected CID, got empty string")
 	}
 	if len(raw) > 256 {
-		return "", fmt.Errorf("CID is too long (256 chars max)")
+		return "", errors.New("CID is too long (256 chars max)")
 	}
 	if len(raw) < 8 {
-		return "", fmt.Errorf("CID is too short (8 chars min)")
+		return "", errors.New("CID is too short (8 chars min)")
 	}
 
 	if !cidRegex.MatchString(raw) {
-		return "", fmt.Errorf("CID syntax didn't validate via regex")
+		return "", errors.New("CID syntax didn't validate via regex")
 	}
 	if strings.HasPrefix(raw, "Qmb") {
-		return "", fmt.Errorf("CIDv0 not allowed in this version of atproto")
+		return "", errors.New("CIDv0 not allowed in this version of atproto")
 	}
 	return CID(raw), nil
 }

--- a/atproto/syntax/datetime.go
+++ b/atproto/syntax/datetime.go
@@ -1,6 +1,7 @@
 package syntax
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -25,17 +26,17 @@ var datetimeRegex = regexp.MustCompile(`^[0-9]{4}-[01][0-9]-[0-3][0-9]T[0-2][0-9
 
 func ParseDatetime(raw string) (Datetime, error) {
 	if raw == "" {
-		return "", fmt.Errorf("expected datetime, got empty string")
+		return "", errors.New("expected datetime, got empty string")
 	}
 	if len(raw) > 64 {
-		return "", fmt.Errorf("Datetime too long (max 64 chars)")
+		return "", errors.New("Datetime too long (max 64 chars)")
 	}
 
 	if !datetimeRegex.MatchString(raw) {
-		return "", fmt.Errorf("Datetime syntax didn't validate via regex")
+		return "", errors.New("Datetime syntax didn't validate via regex")
 	}
 	if strings.HasSuffix(raw, "-00:00") {
-		return "", fmt.Errorf("Datetime can't use '-00:00' for UTC timezone, must use '+00:00', per ISO-8601")
+		return "", errors.New("Datetime can't use '-00:00' for UTC timezone, must use '+00:00', per ISO-8601")
 	}
 	// ensure that the datetime actually parses using golang time lib
 	_, err := time.Parse(time.RFC3339Nano, raw)

--- a/atproto/syntax/datetime.go
+++ b/atproto/syntax/datetime.go
@@ -24,6 +24,9 @@ type Datetime string
 var datetimeRegex = regexp.MustCompile(`^[0-9]{4}-[01][0-9]-[0-3][0-9]T[0-2][0-9]:[0-6][0-9]:[0-6][0-9](.[0-9]{1,20})?(Z|([+-][0-2][0-9]:[0-5][0-9]))$`)
 
 func ParseDatetime(raw string) (Datetime, error) {
+	if raw == "" {
+		return "", fmt.Errorf("expected datetime, got empty string")
+	}
 	if len(raw) > 64 {
 		return "", fmt.Errorf("Datetime too long (max 64 chars)")
 	}

--- a/atproto/syntax/did.go
+++ b/atproto/syntax/did.go
@@ -16,6 +16,9 @@ type DID string
 var didRegex = regexp.MustCompile(`^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$`)
 
 func ParseDID(raw string) (DID, error) {
+	if raw == "" {
+		return "", fmt.Errorf("expected DID, got empty string")
+	}
 	if len(raw) > 2*1024 {
 		return "", fmt.Errorf("DID is too long (2048 chars max)")
 	}

--- a/atproto/syntax/did.go
+++ b/atproto/syntax/did.go
@@ -1,7 +1,7 @@
 package syntax
 
 import (
-	"fmt"
+	"errors"
 	"regexp"
 	"strings"
 )
@@ -17,13 +17,13 @@ var didRegex = regexp.MustCompile(`^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$`
 
 func ParseDID(raw string) (DID, error) {
 	if raw == "" {
-		return "", fmt.Errorf("expected DID, got empty string")
+		return "", errors.New("expected DID, got empty string")
 	}
 	if len(raw) > 2*1024 {
-		return "", fmt.Errorf("DID is too long (2048 chars max)")
+		return "", errors.New("DID is too long (2048 chars max)")
 	}
 	if !didRegex.MatchString(raw) {
-		return "", fmt.Errorf("DID syntax didn't validate via regex")
+		return "", errors.New("DID syntax didn't validate via regex")
 	}
 	return DID(raw), nil
 }

--- a/atproto/syntax/handle.go
+++ b/atproto/syntax/handle.go
@@ -1,6 +1,7 @@
 package syntax
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -22,10 +23,10 @@ type Handle string
 
 func ParseHandle(raw string) (Handle, error) {
 	if raw == "" {
-		return "", fmt.Errorf("expected handle, got empty string")
+		return "", errors.New("expected handle, got empty string")
 	}
 	if len(raw) > 253 {
-		return "", fmt.Errorf("handle is too long (253 chars max)")
+		return "", errors.New("handle is too long (253 chars max)")
 	}
 	if !handleRegex.MatchString(raw) {
 		return "", fmt.Errorf("handle syntax didn't validate via regex: %s", raw)

--- a/atproto/syntax/handle.go
+++ b/atproto/syntax/handle.go
@@ -21,6 +21,9 @@ var (
 type Handle string
 
 func ParseHandle(raw string) (Handle, error) {
+	if raw == "" {
+		return "", fmt.Errorf("expected handle, got empty string")
+	}
 	if len(raw) > 253 {
 		return "", fmt.Errorf("handle is too long (253 chars max)")
 	}

--- a/atproto/syntax/language.go
+++ b/atproto/syntax/language.go
@@ -1,7 +1,7 @@
 package syntax
 
 import (
-	"fmt"
+	"errors"
 	"regexp"
 )
 
@@ -16,13 +16,13 @@ var langRegex = regexp.MustCompile(`^(i|[a-z]{2,3})(-[a-zA-Z0-9]+)*$`)
 
 func ParseLanguage(raw string) (Language, error) {
 	if raw == "" {
-		return "", fmt.Errorf("expected language code, got empty string")
+		return "", errors.New("expected language code, got empty string")
 	}
 	if len(raw) > 128 {
-		return "", fmt.Errorf("Language is too long (128 chars max)")
+		return "", errors.New("Language is too long (128 chars max)")
 	}
 	if !langRegex.MatchString(raw) {
-		return "", fmt.Errorf("Language syntax didn't validate via regex")
+		return "", errors.New("Language syntax didn't validate via regex")
 	}
 	return Language(raw), nil
 }

--- a/atproto/syntax/language.go
+++ b/atproto/syntax/language.go
@@ -15,6 +15,9 @@ type Language string
 var langRegex = regexp.MustCompile(`^(i|[a-z]{2,3})(-[a-zA-Z0-9]+)*$`)
 
 func ParseLanguage(raw string) (Language, error) {
+	if raw == "" {
+		return "", fmt.Errorf("expected language code, got empty string")
+	}
 	if len(raw) > 128 {
 		return "", fmt.Errorf("Language is too long (128 chars max)")
 	}

--- a/atproto/syntax/nsid.go
+++ b/atproto/syntax/nsid.go
@@ -16,6 +16,9 @@ var nsidRegex = regexp.MustCompile(`^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.
 type NSID string
 
 func ParseNSID(raw string) (NSID, error) {
+	if raw == "" {
+		return "", fmt.Errorf("expected NSID, got empty string")
+	}
 	if len(raw) > 317 {
 		return "", fmt.Errorf("NSID is too long (317 chars max)")
 	}

--- a/atproto/syntax/nsid.go
+++ b/atproto/syntax/nsid.go
@@ -1,7 +1,7 @@
 package syntax
 
 import (
-	"fmt"
+	"errors"
 	"regexp"
 	"strings"
 )
@@ -17,13 +17,13 @@ type NSID string
 
 func ParseNSID(raw string) (NSID, error) {
 	if raw == "" {
-		return "", fmt.Errorf("expected NSID, got empty string")
+		return "", errors.New("expected NSID, got empty string")
 	}
 	if len(raw) > 317 {
-		return "", fmt.Errorf("NSID is too long (317 chars max)")
+		return "", errors.New("NSID is too long (317 chars max)")
 	}
 	if !nsidRegex.MatchString(raw) {
-		return "", fmt.Errorf("NSID syntax didn't validate via regex")
+		return "", errors.New("NSID syntax didn't validate via regex")
 	}
 	return NSID(raw), nil
 }

--- a/atproto/syntax/recordkey.go
+++ b/atproto/syntax/recordkey.go
@@ -1,7 +1,7 @@
 package syntax
 
 import (
-	"fmt"
+	"errors"
 	"regexp"
 )
 
@@ -16,16 +16,16 @@ type RecordKey string
 
 func ParseRecordKey(raw string) (RecordKey, error) {
 	if raw == "" {
-		return "", fmt.Errorf("expected record key, got empty string")
+		return "", errors.New("expected record key, got empty string")
 	}
 	if len(raw) > 512 {
-		return "", fmt.Errorf("recordkey is too long (512 chars max)")
+		return "", errors.New("recordkey is too long (512 chars max)")
 	}
 	if raw == "" || raw == "." || raw == ".." {
-		return "", fmt.Errorf("recordkey can not be empty, '.', or '..'")
+		return "", errors.New("recordkey can not be empty, '.', or '..'")
 	}
 	if !recordKeyRegex.MatchString(raw) {
-		return "", fmt.Errorf("recordkey syntax didn't validate via regex")
+		return "", errors.New("recordkey syntax didn't validate via regex")
 	}
 	return RecordKey(raw), nil
 }

--- a/atproto/syntax/recordkey.go
+++ b/atproto/syntax/recordkey.go
@@ -15,6 +15,9 @@ var recordKeyRegex = regexp.MustCompile(`^[a-zA-Z0-9_~.:-]{1,512}$`)
 type RecordKey string
 
 func ParseRecordKey(raw string) (RecordKey, error) {
+	if raw == "" {
+		return "", fmt.Errorf("expected record key, got empty string")
+	}
 	if len(raw) > 512 {
 		return "", fmt.Errorf("recordkey is too long (512 chars max)")
 	}

--- a/atproto/syntax/tid.go
+++ b/atproto/syntax/tid.go
@@ -27,6 +27,9 @@ type TID string
 var tidRegex = regexp.MustCompile(`^[234567abcdefghij][234567abcdefghijklmnopqrstuvwxyz]{12}$`)
 
 func ParseTID(raw string) (TID, error) {
+	if raw == "" {
+		return "", fmt.Errorf("expected TID, got empty string")
+	}
 	if len(raw) != 13 {
 		return "", fmt.Errorf("TID is wrong length (expected 13 chars)")
 	}

--- a/atproto/syntax/tid.go
+++ b/atproto/syntax/tid.go
@@ -2,7 +2,7 @@ package syntax
 
 import (
 	"encoding/base32"
-	"fmt"
+	"errors"
 	"regexp"
 	"strings"
 	"sync"
@@ -28,13 +28,13 @@ var tidRegex = regexp.MustCompile(`^[234567abcdefghij][234567abcdefghijklmnopqrs
 
 func ParseTID(raw string) (TID, error) {
 	if raw == "" {
-		return "", fmt.Errorf("expected TID, got empty string")
+		return "", errors.New("expected TID, got empty string")
 	}
 	if len(raw) != 13 {
-		return "", fmt.Errorf("TID is wrong length (expected 13 chars)")
+		return "", errors.New("TID is wrong length (expected 13 chars)")
 	}
 	if !tidRegex.MatchString(raw) {
-		return "", fmt.Errorf("TID syntax didn't validate via regex")
+		return "", errors.New("TID syntax didn't validate via regex")
 	}
 	return TID(raw), nil
 }

--- a/atproto/syntax/uri.go
+++ b/atproto/syntax/uri.go
@@ -1,7 +1,7 @@
 package syntax
 
 import (
-	"fmt"
+	"errors"
 	"regexp"
 )
 
@@ -14,14 +14,14 @@ type URI string
 
 func ParseURI(raw string) (URI, error) {
 	if raw == "" {
-		return "", fmt.Errorf("expected URI, got empty string")
+		return "", errors.New("expected URI, got empty string")
 	}
 	if len(raw) > 8192 {
-		return "", fmt.Errorf("URI is too long (8192 chars max)")
+		return "", errors.New("URI is too long (8192 chars max)")
 	}
 	var uriRegex = regexp.MustCompile(`^[a-z][a-z.-]{0,80}:[[:graph:]]+$`)
 	if !uriRegex.MatchString(raw) {
-		return "", fmt.Errorf("URI syntax didn't validate via regex")
+		return "", errors.New("URI syntax didn't validate via regex")
 	}
 	return URI(raw), nil
 }

--- a/atproto/syntax/uri.go
+++ b/atproto/syntax/uri.go
@@ -13,6 +13,9 @@ import (
 type URI string
 
 func ParseURI(raw string) (URI, error) {
+	if raw == "" {
+		return "", fmt.Errorf("expected URI, got empty string")
+	}
 	if len(raw) > 8192 {
 		return "", fmt.Errorf("URI is too long (8192 chars max)")
 	}


### PR DESCRIPTION
Was getting "doesn't match regex" for trivial empty-string situations. having shorter more descriptive errors helps debugging.