### PR TITLE
support tokenize while keeping common censor chars

### DIFF
--- a/automod/keyword/tokenize.go
+++ b/automod/keyword/tokenize.go
@@ -20,7 +20,7 @@ var (
 // Splits free-form text in to tokens, including lower-case, unicode normalization, and some unicode folding.
 //
 // The intent is for this to work similarly to an NLP tokenizer, as might be used in a fulltext search engine, and enable fast matching to a list of known tokens. It might eventually even do stemming, removing pluralization (trailing "s" for English), etc.
-func tokenizeText(text string, nonTokenCharsRegex *regexp.Regexp) []string {
+func TokenizeTextWithRegex(text string, nonTokenCharsRegex *regexp.Regexp) []string {
 	// this function needs to be re-defined in every function call to prevent a race condition
 	normFunc := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
 	split := strings.ToLower(nonTokenCharsRegex.ReplaceAllString(text, " "))
@@ -34,15 +34,11 @@ func tokenizeText(text string, nonTokenCharsRegex *regexp.Regexp) []string {
 }
 
 func TokenizeText(text string) []string {
-	return tokenizeText(text, nonTokenChars)
+	return TokenizeTextWithRegex(text, nonTokenChars)
 }
 
 func TokenizeTextSkippingCensorChars(text string) []string {
-	return tokenizeText(text, nonTokenCharsSkipCensorChars)
-}
-
-func TokenizeTextWithRegex(text string, nonTokenCharsRegex *regexp.Regexp) []string {
-	return tokenizeText(text, nonTokenCharsRegex)
+	return TokenizeTextWithRegex(text, nonTokenCharsSkipCensorChars)
 }
 
 func splitIdentRune(c rune) bool {

--- a/automod/keyword/tokenize.go
+++ b/automod/keyword/tokenize.go
@@ -41,8 +41,8 @@ func TokenizeTextSkippingCensorChars(text string) []string {
 	return tokenizeText(text, nonTokenCharsSkipCensorChars)
 }
 
-func TokenizeTextWithCustomNonTokenRegex(text string, regex *regexp.Regexp) []string {
-	return tokenizeText(text, regex)
+func TokenizeTextWithRegex(text string, nonTokenCharsRegex *regexp.Regexp) []string {
+	return tokenizeText(text, nonTokenCharsRegex)
 }
 
 func splitIdentRune(c rune) bool {

--- a/automod/keyword/tokenize_test.go
+++ b/automod/keyword/tokenize_test.go
@@ -1,6 +1,7 @@
 package keyword
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,10 +18,56 @@ func TestTokenizeText(t *testing.T) {
 		{text: "Hello, โลก!", out: []string{"hello", "โลก"}},
 		{text: "Gdańsk", out: []string{"gdansk"}},
 		{text: " foo1;bar2,baz3...", out: []string{"foo1", "bar2", "baz3"}},
+		{text: "foo*bar", out: []string{"foo", "bar"}},
+		{text: "foo-bar", out: []string{"foo", "bar"}},
+		{text: "foo_bar", out: []string{"foo", "bar"}},
 	}
 
 	for _, fix := range fixtures {
 		assert.Equal(fix.out, TokenizeText(fix.text))
+	}
+}
+
+func TestTokenizeTextWithCensorChars(t *testing.T) {
+	assert := assert.New(t)
+
+	fixtures := []struct {
+		text string
+		out  []string
+	}{
+		{text: "", out: []string{}},
+		{text: "Hello, โลก!", out: []string{"hello", "โลก"}},
+		{text: "Gdańsk", out: []string{"gdansk"}},
+		{text: " foo1;bar2,baz3...", out: []string{"foo1", "bar2", "baz3"}},
+		{text: "foo*bar,foo&bar", out: []string{"foo*bar", "foo", "bar"}},
+		{text: "foo-bar,foo&bar", out: []string{"foo-bar", "foo", "bar"}},
+		{text: "foo_bar,foo&bar", out: []string{"foo_bar", "foo", "bar"}},
+		{text: "foo#bar,foo&bar", out: []string{"foo#bar", "foo", "bar"}},
+	}
+
+	for _, fix := range fixtures {
+		assert.Equal(fix.out, TokenizeTextSkippingCensorChars(fix.text))
+	}
+}
+
+func TestTokenizeTextWithCustomRegex(t *testing.T) {
+	assert := assert.New(t)
+
+	fixtures := []struct {
+		text string
+		out  []string
+	}{
+		{text: "", out: []string{}},
+		{text: "Hello, โลก!", out: []string{"hello", "โลก"}},
+		{text: "Gdańsk", out: []string{"gdansk"}},
+		{text: " foo1;bar2,baz3...", out: []string{"foo1", "bar2", "baz3"}},
+		{text: "foo*bar", out: []string{"foo", "bar"}},
+		{text: "foo&bar,foo*bar", out: []string{"foo&bar", "foo", "bar"}},
+	}
+
+	regex := regexp.MustCompile(`[^\pL\pN\s&]`)
+	for _, fix := range fixtures {
+		assert.Equal(fix.out, TokenizeTextWithCustomNonTokenRegex(fix.text, regex))
 	}
 }
 

--- a/automod/keyword/tokenize_test.go
+++ b/automod/keyword/tokenize_test.go
@@ -67,7 +67,7 @@ func TestTokenizeTextWithCustomRegex(t *testing.T) {
 
 	regex := regexp.MustCompile(`[^\pL\pN\s&]`)
 	for _, fix := range fixtures {
-		assert.Equal(fix.out, TokenizeTextWithCustomNonTokenRegex(fix.text, regex))
+		assert.Equal(fix.out, TokenizeTextWithRegex(fix.text, regex))
 	}
 }
 


### PR DESCRIPTION
There are some cases where it's useful to tokenize a string while _not_ splitting on some non-letter chars like `#`, `*`, `-`, or `_`. Unfortunately right now `Tokenize` will split on all of these, making some matching difficult.

This just adds a second `TokenizeTextSkippingCensorChars` for those particular use cases. Also adding `TokenizeTextWithRegex`, so that other cases can be easily covered in the future if they arise.