### PR TITLE
goat account migration

### DIFF
--- a/cmd/goat/account.go
+++ b/cmd/goat/account.go
@@ -68,6 +68,12 @@ var cmdAccount = &cli.Command{
 			Action:    runAccountLookup,
 		},
 		&cli.Command{
+			Name:      "update-handle",
+			Usage:     "change handle for current account",
+			ArgsUsage: `<handle>`,
+			Action:    runAccountUpdateHandle,
+		},
+		&cli.Command{
 			Name:   "status",
 			Usage:  "show current account status at PDS",
 			Action: runAccountStatus,
@@ -76,6 +82,74 @@ var cmdAccount = &cli.Command{
 			Name:   "missing-blobs",
 			Usage:  "list any missing blobs for current account",
 			Action: runAccountMissingBlobs,
+		},
+		&cli.Command{
+			Name:  "service-auth",
+			Usage: "create service auth token",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:    "endpoint",
+					Aliases: []string{"lxm"},
+					Usage:   "restrict token to API endpoint (NSID, optional)",
+				},
+				&cli.StringFlag{
+					Name:     "audience",
+					Aliases:  []string{"aud"},
+					Required: true,
+					Usage:    "DID of service that will receive and validate token",
+				},
+				&cli.IntFlag{
+					Name:  "duration-sec",
+					Value: 60,
+					Usage: "validity time window of token (seconds)",
+				},
+			},
+			Action: runAccountServiceAuth,
+		},
+		&cli.Command{
+			Name:  "create",
+			Usage: "create a new account on the indicated PDS host",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:     "pds-host",
+					Usage:    "URL of the PDS to create account on",
+					Required: true,
+					EnvVars:  []string{"ATP_PDS_HOST"},
+				},
+				&cli.StringFlag{
+					Name:     "handle",
+					Usage:    "handle for new account",
+					Required: true,
+					EnvVars:  []string{"ATP_AUTH_HANDLE"},
+				},
+				&cli.StringFlag{
+					Name:     "password",
+					Usage:    "initial account password",
+					Required: true,
+					EnvVars:  []string{"ATP_AUTH_PASSWORD"},
+				},
+				&cli.StringFlag{
+					Name:  "invite-code",
+					Usage: "invite code for account signup",
+				},
+				&cli.StringFlag{
+					Name:  "email",
+					Usage: "email address for new account",
+				},
+				&cli.StringFlag{
+					Name:  "existing-did",
+					Usage: "an existing DID to use (eg, non-PLC DID, or migration)",
+				},
+				&cli.StringFlag{
+					Name:  "recovery-key",
+					Usage: "public cryptographic key (did:key) to add as PLC recovery",
+				},
+				&cli.StringFlag{
+					Name:  "service-auth",
+					Usage: "service auth token (for account migration)",
+				},
+			},
+			Action: runAccountCreate,
 		},
 		cmdAccountMigrate,
 	},
@@ -151,6 +225,8 @@ func runAccountStatus(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	fmt.Printf("DID: %s\n", client.Auth.Did)
+	fmt.Printf("Host: %s\n", client.Host)
 	fmt.Println(string(b))
 
 	return nil
@@ -217,5 +293,139 @@ func runAccountDeactivate(cctx *cli.Context) error {
 		return fmt.Errorf("failed deactivating account: %w", err)
 	}
 
+	return nil
+}
+
+func runAccountUpdateHandle(cctx *cli.Context) error {
+	ctx := context.Background()
+
+	raw := cctx.Args().First()
+	if raw == "" {
+		return fmt.Errorf("need to provide new handle as argument")
+	}
+	handle, err := syntax.ParseHandle(raw)
+	if err != nil {
+		return err
+	}
+
+	client, err := loadAuthClient(ctx)
+	if err == ErrNoAuthSession {
+		return fmt.Errorf("auth required, but not logged in")
+	} else if err != nil {
+		return err
+	}
+
+	err = comatproto.IdentityUpdateHandle(ctx, client, &comatproto.IdentityUpdateHandle_Input{
+		Handle: handle.String(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed updating handle: %w", err)
+	}
+
+	return nil
+}
+
+func runAccountServiceAuth(cctx *cli.Context) error {
+	ctx := context.Background()
+
+	client, err := loadAuthClient(ctx)
+	if err == ErrNoAuthSession {
+		return fmt.Errorf("auth required, but not logged in")
+	} else if err != nil {
+		return err
+	}
+
+	lxm := cctx.String("endpoint")
+	if lxm != "" {
+		_, err := syntax.ParseNSID(lxm)
+		if err != nil {
+			return fmt.Errorf("lxm argument must be a valid NSID: %w", err)
+		}
+	}
+
+	aud := cctx.String("audience")
+	// TODO: can aud DID have a fragment?
+	_, err = syntax.ParseDID(aud)
+	if err != nil {
+		return fmt.Errorf("aud argument must be a valid DID: %w", err)
+	}
+
+	durSec := cctx.Int("duration-sec")
+	expTimestamp := time.Now().Unix() + int64(durSec)
+
+	resp, err := comatproto.ServerGetServiceAuth(ctx, client, aud, expTimestamp, lxm)
+	if err != nil {
+		return fmt.Errorf("failed updating handle: %w", err)
+	}
+
+	fmt.Println(resp.Token)
+
+	return nil
+}
+
+func runAccountCreate(cctx *cli.Context) error {
+	ctx := context.Background()
+
+	// validate args
+	pdsHost := cctx.String("pds-host")
+	if !strings.Contains(pdsHost, "://") {
+		return fmt.Errorf("PDS host is not a url: %s", pdsHost)
+	}
+	handle := cctx.String("handle")
+	_, err := syntax.ParseHandle(handle)
+	if err != nil {
+		return err
+	}
+	password := cctx.String("password")
+	params := &comatproto.ServerCreateAccount_Input{
+		Handle:   handle,
+		Password: &password,
+	}
+	raw := cctx.String("existing-did")
+	if raw != "" {
+		_, err := syntax.ParseDID(raw)
+		if err != nil {
+			return err
+		}
+		s := raw
+		params.Did = &s
+	}
+	raw = cctx.String("email")
+	if raw != "" {
+		s := raw
+		params.Email = &s
+	}
+	raw = cctx.String("invite-code")
+	if raw != "" {
+		s := raw
+		params.InviteCode = &s
+	}
+	raw = cctx.String("recovery-key")
+	if raw != "" {
+		s := raw
+		params.RecoveryKey = &s
+	}
+
+	// create a new API client to connect to the account's PDS
+	xrpcc := xrpc.Client{
+		Host: pdsHost,
+	}
+
+	raw = cctx.String("service-auth")
+	if raw != "" && params.Did != nil {
+		xrpcc.Auth = &xrpc.AuthInfo{
+			Did: *params.Did,
+			AccessJwt: raw,
+		}
+	}
+
+	resp, err := comatproto.ServerCreateAccount(ctx, &xrpcc, params)
+	if err != nil {
+		return fmt.Errorf("failed to create account: %w", err)
+	}
+
+	fmt.Println("Success!")
+	fmt.Printf("DID: %s\n", resp.Did)
+	fmt.Printf("Handle: %s\n", resp.Handle)
 	return nil
 }

--- a/cmd/goat/account.go
+++ b/cmd/goat/account.go
@@ -53,6 +53,7 @@ var cmdAccount = &cli.Command{
 			ArgsUsage: `<at-identifier>`,
 			Action:    runAccountStatus,
 		},
+		cmdAccountMigrate,
 	},
 }
 

--- a/cmd/goat/account.go
+++ b/cmd/goat/account.go
@@ -18,11 +18,6 @@ var cmdAccount = &cli.Command{
 	Flags: []cli.Flag{},
 	Subcommands: []*cli.Command{
 		&cli.Command{
-			Name:   "check",
-			Usage:  "verifies current auth session is functional",
-			Action: runAccountCheck,
-		},
-		&cli.Command{
 			Name:  "login",
 			Usage: "create session with PDS instance",
 			Flags: []cli.Flag{
@@ -61,22 +56,6 @@ var cmdAccount = &cli.Command{
 		},
 		cmdAccountMigrate,
 	},
-}
-
-func runAccountCheck(cctx *cli.Context) error {
-	ctx := context.Background()
-
-	client, err := loadAuthClient(ctx)
-	if err == ErrNoAuthSession {
-		return fmt.Errorf("auth required, but not logged in")
-	} else if err != nil {
-		return err
-	}
-	// TODO: more explicit check?
-	fmt.Printf("DID: %s\n", client.Auth.Did)
-	fmt.Printf("PDS: %s\n", client.Host)
-
-	return nil
 }
 
 func runAccountLogin(cctx *cli.Context) error {

--- a/cmd/goat/account.go
+++ b/cmd/goat/account.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/atproto/syntax"
@@ -34,6 +36,12 @@ var cmdAccount = &cli.Command{
 					Required: true,
 					Usage:    "password (app password recommended)",
 					EnvVars:  []string{"ATP_AUTH_PASSWORD"},
+				},
+				&cli.StringFlag{
+					Name:     "pds-host",
+					Usage:    "URL of the PDS to create account on (overrides DID doc)",
+					Required: true,
+					EnvVars:  []string{"ATP_PDS_HOST"},
 				},
 			},
 			Action: runAccountLogin,
@@ -81,7 +89,7 @@ func runAccountLogin(cctx *cli.Context) error {
 		return err
 	}
 
-	_, err = refreshAuthSession(ctx, *username, cctx.String("app-password"))
+	_, err = refreshAuthSession(ctx, *username, cctx.String("app-password"), cctx.String("pds-host"))
 	return err
 }
 

--- a/cmd/goat/account.go
+++ b/cmd/goat/account.go
@@ -38,10 +38,9 @@ var cmdAccount = &cli.Command{
 					EnvVars:  []string{"ATP_AUTH_PASSWORD"},
 				},
 				&cli.StringFlag{
-					Name:     "pds-host",
-					Usage:    "URL of the PDS to create account on (overrides DID doc)",
-					Required: true,
-					EnvVars:  []string{"ATP_PDS_HOST"},
+					Name:    "pds-host",
+					Usage:   "URL of the PDS to create account on (overrides DID doc)",
+					EnvVars: []string{"ATP_PDS_HOST"},
 				},
 			},
 			Action: runAccountLogin,
@@ -152,6 +151,7 @@ var cmdAccount = &cli.Command{
 			Action: runAccountCreate,
 		},
 		cmdAccountMigrate,
+		cmdAccountPlc,
 	},
 }
 
@@ -414,7 +414,7 @@ func runAccountCreate(cctx *cli.Context) error {
 	raw = cctx.String("service-auth")
 	if raw != "" && params.Did != nil {
 		xrpcc.Auth = &xrpc.AuthInfo{
-			Did: *params.Did,
+			Did:       *params.Did,
 			AccessJwt: raw,
 		}
 	}

--- a/cmd/goat/account_migrate.go
+++ b/cmd/goat/account_migrate.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
+	appbsky "github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/bluesky-social/indigo/xrpc"
+
+	"github.com/urfave/cli/v2"
+)
+
+var cmdAccountMigrate = &cli.Command{
+	Name:  "migrate",
+	Usage: "move account to a new PDS. requires full auth.",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:     "new-handle",
+			Required: true,
+			Usage:    "handle on new PDS",
+			EnvVars:  []string{"NEW_ACCOUNT_HANDLE"},
+		},
+		&cli.StringFlag{
+			Name:     "new-password",
+			Required: true,
+			Usage:    "password on new PDS",
+			EnvVars:  []string{"NEW_ACCOUNT_PASSWORD"},
+		},
+	},
+	Action: runAccountMigrate,
+}
+
+func runAccountMigrate(cctx *cli.Context) error {
+	// TODO: this could check rev / commit before and after
+	ctx := context.Background()
+
+	oldClient, err := loadAuthClient(ctx)
+	if err == ErrNoAuthSession {
+		return fmt.Errorf("auth required, but not logged in")
+	} else if err != nil {
+		return err
+	}
+	did := oldClient.Auth.Did
+
+	// connect to new host to discover service DID
+	newHostURL := "XXX"
+	newHandle := "XXX"
+	newPassword := "XXX"
+	newEmail := "XXX"
+	inviteCode := "XXX"
+	newClient := xrpc.Client{
+		Host: newHostURL,
+	}
+	newHostDesc, err := comatproto.ServerDescribeServer(ctx, &newClient)
+	if err != nil {
+		return fmt.Errorf("failed connecting to new host: %w", err)
+	}
+	newHostDID, err := syntax.ParseDID(newHostDesc.Did)
+	if err != nil {
+		return err
+	}
+	slog.Info("new host", "did", newHostDID, "url", newHostURL)
+
+	// 1. Create New Account
+	slog.Info("creating account on new host", "handle", newHandle)
+
+	// get service auth token from old host
+	// args: (ctx, client, aud string, exp int64, lxm string)
+	expTimestamp := time.Now().Unix() + 60
+	createAuthResp, err := comatproto.ServerGetServiceAuth(ctx, oldClient, newHostDID.String(), expTimestamp, "com.atproto.server.createAccount")
+	if err != nil {
+		return fmt.Errorf("failed getting service auth token from old host: %w", err)
+	}
+
+	// then create the new account
+	// XXX: "Authorization  Bearer <createAuthResp.Token>"
+	_ = createAuthResp
+	createAccountResp, err := comatproto.ServerCreateAccount(ctx, &newClient, &comatproto.ServerCreateAccount_Input{
+		Did:        &did,
+		Email:      &newEmail,
+		Handle:     newHandle,
+		InviteCode: &inviteCode,
+		Password:   &newPassword,
+	})
+	if err != nil {
+		return fmt.Errorf("failed getting service auth token from old host: %w", err)
+	}
+	// TODO: validate response?
+	_ = createAccountResp
+
+	// login client on the new host
+	sess, err := comatproto.ServerCreateSession(ctx, &newClient, &comatproto.ServerCreateSession_Input{
+		Identifier: did,
+		Password:   newPassword,
+	})
+	if err != nil {
+		return fmt.Errorf("failed login to newly created account on new host: %w", err)
+	}
+	newClient.Auth = &xrpc.AuthInfo{
+		Did:        did,
+		AccessJwt:  sess.AccessJwt,
+		RefreshJwt: sess.RefreshJwt,
+	}
+
+	// 2. Migrate Data
+
+	slog.Info("migrating repo")
+	repoBytes, err := comatproto.SyncGetRepo(ctx, oldClient, did, "")
+	if err != nil {
+		return fmt.Errorf("failed exporting repo: %w", err)
+	}
+	err = comatproto.RepoImportRepo(ctx, &newClient, bytes.NewReader(repoBytes))
+	if err != nil {
+		return fmt.Errorf("failed importing repo: %w", err)
+	}
+
+	slog.Info("migrating preferences")
+	// TODO: service proxy header
+	prefResp, err := appbsky.ActorGetPreferences(ctx, oldClient)
+	if err != nil {
+		return fmt.Errorf("failed fetching old preferences: %w", err)
+	}
+	err = appbsky.ActorPutPreferences(ctx, &newClient, &appbsky.ActorPutPreferences_Input{
+		Preferences: prefResp.Preferences,
+	})
+
+	slog.Info("migrating blobs")
+	blobCursor := ""
+	for {
+		listResp, err := comatproto.SyncListBlobs(ctx, oldClient, blobCursor, did, 100, "")
+		if err != nil {
+			return fmt.Errorf("failed listing blobs: %w", err)
+		}
+		for _, blobCID := range listResp.Cids {
+			blobBytes, err := comatproto.SyncGetBlob(ctx, oldClient, blobCID, did)
+			if err != nil {
+				slog.Warn("failed downloading blob", "cid", blobCID, "err", err)
+				continue
+			}
+			_, err = comatproto.RepoUploadBlob(ctx, &newClient, bytes.NewReader(blobBytes))
+			if err != nil {
+				slog.Warn("failed uploading blob", "cid", blobCID, "err", err, "size", len(blobBytes))
+			}
+			slog.Info("transfered blob", "cid", blobCID, "size", len(blobBytes))
+		}
+		if listResp.Cursor == nil || *listResp.Cursor == "" {
+			break
+		}
+		blobCursor = *listResp.Cursor
+	}
+
+	// display migration status
+	// TODO: should this loop? with a delay?
+	statusResp, err := comatproto.ServerCheckAccountStatus(ctx, &newClient)
+	if err != nil {
+		return fmt.Errorf("failed checking account status: %w", err)
+	}
+	slog.Info("account migration status", "status", statusResp)
+
+	// 3. Migrate Identity
+	// TODO: support did:web etc
+	slog.Info("updating identity to new host")
+
+	credsResp, err := comatproto.IdentityGetRecommendedDidCredentials(ctx, &newClient)
+	if err != nil {
+		return fmt.Errorf("failed fetching new credentials: %w", err)
+	}
+
+	// TODO: add some safety checks here around rotation key set intersection?
+
+	err = comatproto.IdentityRequestPlcOperationSignature(ctx, oldClient)
+	if err != nil {
+		return fmt.Errorf("failed requesting PLC operation token: %w", err)
+	}
+
+	plcAuthToken := "XXX"
+	signedPlcOpResp, err := comatproto.IdentitySignPlcOperation(ctx, oldClient, &comatproto.IdentitySignPlcOperation_Input{
+		// XXX: not just pass-through
+		AlsoKnownAs:         credsResp.AlsoKnownAs,
+		RotationKeys:        credsResp.RotationKeys,
+		Services:            credsResp.Services,
+		Token:               &plcAuthToken,
+		VerificationMethods: credsResp.VerificationMethods,
+	})
+	if err != nil {
+		return fmt.Errorf("failed requesting PLC operation signature: %w", err)
+	}
+
+	err = comatproto.IdentitySubmitPlcOperation(ctx, &newClient, &comatproto.IdentitySubmitPlcOperation_Input{
+		Operation: signedPlcOpResp.Operation,
+	})
+	if err != nil {
+		return fmt.Errorf("failed submitting PLC operation: %w", err)
+	}
+
+	// 4. Finalize Migration
+	slog.Info("activating new account")
+
+	err = comatproto.ServerActivateAccount(ctx, &newClient)
+	if err != nil {
+		return fmt.Errorf("failed activating new host: %w", err)
+	}
+	err = comatproto.ServerDeactivateAccount(ctx, oldClient, nil)
+	if err != nil {
+		return fmt.Errorf("failed deactivating old host: %w", err)
+	}
+
+	slog.Info("account migration completed")
+	return nil
+}

--- a/cmd/goat/account_migrate.go
+++ b/cmd/goat/account_migrate.go
@@ -128,6 +128,9 @@ func runAccountMigrate(cctx *cli.Context) error {
 	err = appbsky.ActorPutPreferences(ctx, &newClient, &appbsky.ActorPutPreferences_Input{
 		Preferences: prefResp.Preferences,
 	})
+	if err != nil {
+		return fmt.Errorf("failed importing preferences: %w", err)
+	}
 
 	slog.Info("migrating blobs")
 	blobCursor := ""

--- a/cmd/goat/account_plc.go
+++ b/cmd/goat/account_plc.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
+
+	"github.com/urfave/cli/v2"
+)
+
+var cmdAccountPlc = &cli.Command{
+	Name:  "plc",
+	Usage: "sub-commands for managing PLC DID via PDS host",
+	Subcommands: []*cli.Command{
+		&cli.Command{
+			Name:   "recommended",
+			Usage:  "list recommended DID fields for current account",
+			Action: runAccountPlcRecommended,
+		},
+		&cli.Command{
+			Name:   "request-token",
+			Usage:  "request a 2FA token (by email) for signing op",
+			Action: runAccountPlcRequestToken,
+		},
+		&cli.Command{
+			Name:      "sign",
+			Usage:     "sign a PLC operation",
+			ArgsUsage: `<json-file>`,
+			Action:    runAccountPlcSign,
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:  "token",
+					Usage: "2FA token for signing request",
+				},
+			},
+		},
+		&cli.Command{
+			Name:      "submit",
+			Usage:     "submit a PLC operation (via PDS)",
+			ArgsUsage: `<json-file>`,
+			Action:    runAccountPlcSubmit,
+		},
+	},
+}
+
+func runAccountPlcRecommended(cctx *cli.Context) error {
+	ctx := context.Background()
+
+	xrpcc, err := loadAuthClient(ctx)
+	if err == ErrNoAuthSession {
+		return fmt.Errorf("auth required, but not logged in")
+	} else if err != nil {
+		return err
+	}
+
+	resp, err := IdentityGetRecommendedDidCredentials(ctx, xrpcc)
+	if err != nil {
+		return err
+	}
+
+	b, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(b))
+	return nil
+}
+
+func runAccountPlcRequestToken(cctx *cli.Context) error {
+	ctx := context.Background()
+
+	xrpcc, err := loadAuthClient(ctx)
+	if err == ErrNoAuthSession {
+		return fmt.Errorf("auth required, but not logged in")
+	} else if err != nil {
+		return err
+	}
+
+	err = comatproto.IdentityRequestPlcOperationSignature(ctx, xrpcc)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Success; check email for token.")
+	return nil
+}
+
+func runAccountPlcSign(cctx *cli.Context) error {
+	ctx := context.Background()
+
+	opPath := cctx.Args().First()
+	if opPath == "" {
+		return fmt.Errorf("need to provide JSON file path as an argument")
+	}
+
+	xrpcc, err := loadAuthClient(ctx)
+	if err == ErrNoAuthSession {
+		return fmt.Errorf("auth required, but not logged in")
+	} else if err != nil {
+		return err
+	}
+
+	fileBytes, err := os.ReadFile(opPath)
+	if err != nil {
+		return err
+	}
+
+	var body IdentitySignPlcOperation_Input
+	if err = json.Unmarshal(fileBytes, &body); err != nil {
+		return fmt.Errorf("failed decoding PLC op JSON: %w", err)
+	}
+
+	token := cctx.String("token")
+	if token != "" {
+		body.Token = &token
+	}
+
+	resp, err := IdentitySignPlcOperation(ctx, xrpcc, &body)
+	if err != nil {
+		return err
+	}
+
+	b, err := json.MarshalIndent(resp.Operation, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(b))
+	return nil
+}
+
+func runAccountPlcSubmit(cctx *cli.Context) error {
+	ctx := context.Background()
+
+	opPath := cctx.Args().First()
+	if opPath == "" {
+		return fmt.Errorf("need to provide JSON file path as an argument")
+	}
+
+	xrpcc, err := loadAuthClient(ctx)
+	if err == ErrNoAuthSession {
+		return fmt.Errorf("auth required, but not logged in")
+	} else if err != nil {
+		return err
+	}
+
+	fileBytes, err := os.ReadFile(opPath)
+	if err != nil {
+		return err
+	}
+
+	var op json.RawMessage
+	if err = json.Unmarshal(fileBytes, &op); err != nil {
+		return fmt.Errorf("failed decoding PLC op JSON: %w", err)
+	}
+
+	err = IdentitySubmitPlcOperation(ctx, xrpcc, &IdentitySubmitPlcOperation_Input{
+		Operation: &op,
+	})
+	if err != nil {
+		return fmt.Errorf("failed submitting PLC op via PDS: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/goat/auth.go
+++ b/cmd/goat/auth.go
@@ -106,7 +106,7 @@ func refreshAuthSession(ctx context.Context, username syntax.AtIdentifier, passw
 			return nil, err
 		}
 
-		pdsURL := ident.PDSEndpoint()
+		pdsURL = ident.PDSEndpoint()
 		if pdsURL == "" {
 			return nil, fmt.Errorf("empty PDS URL")
 		}

--- a/cmd/goat/bsky.go
+++ b/cmd/goat/bsky.go
@@ -23,6 +23,7 @@ var cmdBsky = &cli.Command{
 			ArgsUsage: `<text>`,
 			Action:    runBskyPost,
 		},
+		cmdBskyPrefs,
 	},
 }
 

--- a/cmd/goat/bsky_prefs.go
+++ b/cmd/goat/bsky_prefs.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	appbsky "github.com/bluesky-social/indigo/api/bsky"
+
+	"github.com/urfave/cli/v2"
+)
+
+var cmdBskyPrefs = &cli.Command{
+	Name:  "prefs",
+	Usage: "sub-commands for preferences",
+	Flags: []cli.Flag{},
+	Subcommands: []*cli.Command{
+		&cli.Command{
+			Name:   "export",
+			Usage:  "dump preferences out as JSON",
+			Action: runBskyPrefsExport,
+		},
+		&cli.Command{
+			Name:      "import",
+			Usage:     "upload preferences from JSON file",
+			ArgsUsage: `<file>`,
+			Action:    runBskyPrefsImport,
+		},
+	},
+}
+
+func runBskyPrefsExport(cctx *cli.Context) error {
+	ctx := context.Background()
+
+	xrpcc, err := loadAuthClient(ctx)
+	if err == ErrNoAuthSession {
+		return fmt.Errorf("auth required, but not logged in")
+	} else if err != nil {
+		return err
+	}
+
+	// TODO: does this crash with unsupported preference types?
+	resp, err := appbsky.ActorGetPreferences(ctx, xrpcc)
+	if err != nil {
+		return fmt.Errorf("failed fetching old preferences: %w", err)
+	}
+
+	b, err := json.MarshalIndent(resp.Preferences, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(b))
+
+	return nil
+}
+
+func runBskyPrefsImport(cctx *cli.Context) error {
+	ctx := context.Background()
+	prefsPath := cctx.Args().First()
+	if prefsPath == "" {
+		return fmt.Errorf("need to provide file path as an argument")
+	}
+
+	xrpcc, err := loadAuthClient(ctx)
+	if err == ErrNoAuthSession {
+		return fmt.Errorf("auth required, but not logged in")
+	} else if err != nil {
+		return err
+	}
+
+	prefsBytes, err := os.ReadFile(prefsPath)
+	if err != nil {
+		return err
+	}
+
+	var prefsArray []appbsky.ActorDefs_Preferences_Elem
+	err = json.Unmarshal(prefsBytes, &prefsArray)
+	if err != nil {
+		return err
+	}
+
+	// TODO: does this clobber unsupported preference types?
+	err = appbsky.ActorPutPreferences(ctx, xrpcc, &appbsky.ActorPutPreferences_Input{
+		Preferences: prefsArray,
+	})
+	if err != nil {
+		return fmt.Errorf("failed fetching old preferences: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/goat/bsky_prefs.go
+++ b/cmd/goat/bsky_prefs.go
@@ -40,7 +40,7 @@ func runBskyPrefsExport(cctx *cli.Context) error {
 		return err
 	}
 
-	// TODO: does this crash with unsupported preference types?
+	// TODO: does indigo API code crash with unsupported preference '$type'? Eg "Lexicon decoder" with unsupported type.
 	resp, err := appbsky.ActorGetPreferences(ctx, xrpcc)
 	if err != nil {
 		return fmt.Errorf("failed fetching old preferences: %w", err)
@@ -80,7 +80,7 @@ func runBskyPrefsImport(cctx *cli.Context) error {
 		return err
 	}
 
-	// TODO: does this clobber unsupported preference types?
+	// WARNING: might clobber off-Lexicon or new-Lexicon data fields (which don't round-trip deserialization)
 	err = appbsky.ActorPutPreferences(ctx, xrpcc, &appbsky.ActorPutPreferences_Input{
 		Preferences: prefsArray,
 	})

--- a/cmd/goat/identitygetRecommendedDidCredentials.go
+++ b/cmd/goat/identitygetRecommendedDidCredentials.go
@@ -1,0 +1,23 @@
+// Copied from indigo:api/atproto/identitygetRecommendedDidCredentials.go
+
+package main
+
+// schema: com.atproto.identity.getRecommendedDidCredentials
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+// IdentityGetRecommendedDidCredentials calls the XRPC method "com.atproto.identity.getRecommendedDidCredentials".
+func IdentityGetRecommendedDidCredentials(ctx context.Context, c *xrpc.Client) (*json.RawMessage, error) {
+	var out json.RawMessage
+
+	if err := c.Do(ctx, xrpc.Query, "", "com.atproto.identity.getRecommendedDidCredentials", nil, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}

--- a/cmd/goat/identitysignPlcOperation.go
+++ b/cmd/goat/identitysignPlcOperation.go
@@ -1,0 +1,38 @@
+// Copied from indigo:api/atproto/identitysignPlcOperation.go
+
+package main
+
+// schema: com.atproto.identity.signPlcOperation
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+// IdentitySignPlcOperation_Input is the input argument to a com.atproto.identity.signPlcOperation call.
+type IdentitySignPlcOperation_Input struct {
+	AlsoKnownAs  []string         `json:"alsoKnownAs,omitempty" cborgen:"alsoKnownAs,omitempty"`
+	RotationKeys []string         `json:"rotationKeys,omitempty" cborgen:"rotationKeys,omitempty"`
+	Services     *json.RawMessage `json:"services,omitempty" cborgen:"services,omitempty"`
+	// token: A token received through com.atproto.identity.requestPlcOperationSignature
+	Token               *string          `json:"token,omitempty" cborgen:"token,omitempty"`
+	VerificationMethods *json.RawMessage `json:"verificationMethods,omitempty" cborgen:"verificationMethods,omitempty"`
+}
+
+// IdentitySignPlcOperation_Output is the output of a com.atproto.identity.signPlcOperation call.
+type IdentitySignPlcOperation_Output struct {
+	// operation: A signed DID PLC operation.
+	Operation *json.RawMessage `json:"operation" cborgen:"operation"`
+}
+
+// IdentitySignPlcOperation calls the XRPC method "com.atproto.identity.signPlcOperation".
+func IdentitySignPlcOperation(ctx context.Context, c *xrpc.Client, input *IdentitySignPlcOperation_Input) (*IdentitySignPlcOperation_Output, error) {
+	var out IdentitySignPlcOperation_Output
+	if err := c.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.identity.signPlcOperation", nil, input, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}

--- a/cmd/goat/identitysubmitPlcOperation.go
+++ b/cmd/goat/identitysubmitPlcOperation.go
@@ -1,0 +1,26 @@
+// Copied from indigo:api/atproto/identitysubmitPlcOperation.go
+
+package main
+
+// schema: com.atproto.identity.submitPlcOperation
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+// IdentitySubmitPlcOperation_Input is the input argument to a com.atproto.identity.submitPlcOperation call.
+type IdentitySubmitPlcOperation_Input struct {
+	Operation *json.RawMessage `json:"operation" cborgen:"operation"`
+}
+
+// IdentitySubmitPlcOperation calls the XRPC method "com.atproto.identity.submitPlcOperation".
+func IdentitySubmitPlcOperation(ctx context.Context, c *xrpc.Client, input *IdentitySubmitPlcOperation_Input) error {
+	if err := c.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.identity.submitPlcOperation", nil, input, nil); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/goat/main.go
+++ b/cmd/goat/main.go
@@ -37,6 +37,7 @@ func run(args []string) error {
 		cmdRecord,
 		cmdSyntax,
 		cmdCrypto,
+		cmdPds,
 	}
 	return app.Run(args)
 }

--- a/cmd/goat/pds.go
+++ b/cmd/goat/pds.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	comatproto "github.com/bluesky-social/indigo/api/atproto"
+	"github.com/bluesky-social/indigo/xrpc"
+
+	"github.com/urfave/cli/v2"
+)
+
+var cmdPds = &cli.Command{
+	Name:  "pds",
+	Usage: "sub-commands for pds hosts",
+	Flags: []cli.Flag{},
+	Subcommands: []*cli.Command{
+		&cli.Command{
+			Name:      "describe",
+			Usage:     "shows info about a PDS info",
+			ArgsUsage: `<url>`,
+			Action: runPdsDescribe,
+		},
+	},
+}
+
+func runPdsDescribe(cctx *cli.Context) error {
+	ctx := context.Background()
+
+	pdsHost := cctx.Args().First()
+	if pdsHost== "" {
+		return fmt.Errorf("need to provide new handle as argument")
+	}
+	if !strings.Contains(pdsHost, "://") {
+		return fmt.Errorf("PDS host is not a url: %s", pdsHost)
+	}
+	client := xrpc.Client{
+		Host: pdsHost,
+	}
+
+	resp, err := comatproto.ServerDescribeServer(ctx, &client)
+	if err != nil {
+		return err
+	}
+
+	b, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(b))
+
+	return nil
+}

--- a/cmd/goat/pds.go
+++ b/cmd/goat/pds.go
@@ -21,7 +21,7 @@ var cmdPds = &cli.Command{
 			Name:      "describe",
 			Usage:     "shows info about a PDS info",
 			ArgsUsage: `<url>`,
-			Action: runPdsDescribe,
+			Action:    runPdsDescribe,
 		},
 	},
 }
@@ -30,7 +30,7 @@ func runPdsDescribe(cctx *cli.Context) error {
 	ctx := context.Background()
 
 	pdsHost := cctx.Args().First()
-	if pdsHost== "" {
+	if pdsHost == "" {
 		return fmt.Errorf("need to provide new handle as argument")
 	}
 	if !strings.Contains(pdsHost, "://") {

--- a/cmd/goat/repo.go
+++ b/cmd/goat/repo.go
@@ -41,7 +41,7 @@ var cmdRepo = &cli.Command{
 			Name:      "import",
 			Usage:     "upload CAR file for current account",
 			ArgsUsage: `<path>`,
-			Action: runRepoImport,
+			Action:    runRepoImport,
 		},
 		&cli.Command{
 			Name:      "ls",


### PR DESCRIPTION
This PR adds support for account migration using the goat CLI tool two different ways:

- a bunch of account helper commands which individually enable doing an account migration: creating a new account using service auth and old DID; migrating all the data; swapping identity around
- a helper command that automates all this (starting with a PLC op auth token)

The hope is that the migrate command should work in common cases, but the individual commands allow cleaning up in the case of partial success, and doing more complex stuff.

Missing pieces as future work:

- `did:web` functionality
- detection of current progress and only continue work that needs continuing (eg, don't try to re-create new account if it already exists and can auth with provided credentials)
- proper support for inserting a recovery key when signing PLC op
- more safety validation and guardrails