### PR TITLE
backfill: checkout from relay, not entryway

### DIFF
--- a/backfill/backfill.go
+++ b/backfill/backfill.go
@@ -119,7 +119,7 @@ func DefaultBackfillOptions() *BackfillOptions {
 		ParallelRecordCreates: 100,
 		NSIDFilter:            "",
 		SyncRequestsPerSecond: 2,
-		CheckoutPath:          "https://bsky.social/xrpc/com.atproto.sync.getRepo",
+		CheckoutPath:          "https://bsky.network/xrpc/com.atproto.sync.getRepo",
 	}
 }
 


### PR DESCRIPTION
This is pretty drive-by, i'm basically going through our public code and removing direct requests against the entryway (`https://bsky.social/xrpc/...`). It might be more appropriate here to resolve to the user's actual PDS, not sure.