### PR TITLE
lexgen: handle 'ref' as procedure input type

### DIFF
--- a/lex/gen.go
+++ b/lex/gen.go
@@ -232,9 +232,16 @@ func writeMethods(typename string, ts *TypeSchema, w io.Writer) error {
 	case "record":
 		return nil
 	case "query":
-		return ts.WriteRPC(w, typename)
+		return ts.WriteRPC(w, typename, fmt.Sprintf("%s_Input", typename))
 	case "procedure":
-		return ts.WriteRPC(w, typename)
+		if ts.Input == nil || ts.Input.Schema == nil || ts.Input.Schema.Type == "object" {
+			return ts.WriteRPC(w, typename, fmt.Sprintf("%s_Input", typename))
+		} else if ts.Input.Schema.Type == "ref" {
+			inputname, _ := ts.namesFromRef(ts.Input.Schema.Ref)
+			return ts.WriteRPC(w, typename, inputname)
+		} else {
+			return fmt.Errorf("unhandled input type: %s", ts.Input.Schema.Type)
+		}
 	case "object", "string":
 		return nil
 	case "subscription":

--- a/lex/type_schema.go
+++ b/lex/type_schema.go
@@ -50,7 +50,7 @@ type TypeSchema struct {
 	Maximum any `json:"maximum"`
 }
 
-func (s *TypeSchema) WriteRPC(w io.Writer, typename string) error {
+func (s *TypeSchema) WriteRPC(w io.Writer, typename, inputname string) error {
 	pf := printerf(w)
 	fname := typename
 
@@ -65,7 +65,7 @@ func (s *TypeSchema) WriteRPC(w io.Writer, typename string) error {
 		case EncodingCBOR, EncodingCAR, EncodingANY, EncodingMP4:
 			params = fmt.Sprintf("%s, input io.Reader", params)
 		case EncodingJSON:
-			params = fmt.Sprintf("%s, input *%s_Input", params, fname)
+			params = fmt.Sprintf("%s, input *%s", params, inputname)
 
 		default:
 			return fmt.Errorf("unsupported input encoding (RPC input): %q", s.Input.Encoding)


### PR DESCRIPTION
This tries to resolve the situation discovered in https://github.com/bluesky-social/indigo/pull/785, with the ozone "upsertSet" procedure.

That lexicon specifies the input schema via reference, instead of an "object" schema in-place.

This code could use real review, I just banged on it until it worked for the current lexicon.