### PR TITLE
identity package default tweaks

### DIFF
--- a/atproto/identity/identity.go
+++ b/atproto/identity/identity.go
@@ -74,7 +74,7 @@ func DefaultDirectory() Directory {
 		},
 		Resolver: net.Resolver{
 			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-				d := net.Dialer{Timeout: time.Second * 5}
+				d := net.Dialer{Timeout: time.Second * 3}
 				return d.DialContext(ctx, network, address)
 			},
 		},

--- a/atproto/identity/identity.go
+++ b/atproto/identity/identity.go
@@ -65,7 +65,7 @@ func DefaultDirectory() Directory {
 	base := BaseDirectory{
 		PLCURL: DefaultPLCURL,
 		HTTPClient: http.Client{
-			Timeout: time.Second * 15,
+			Timeout: time.Second * 10,
 			Transport: &http.Transport{
 				// would want this around 100ms for services doing lots of handle resolution. Impacts PLC connections as well, but not too bad.
 				IdleConnTimeout: time.Millisecond * 1000,

--- a/atproto/identity/identity.go
+++ b/atproto/identity/identity.go
@@ -66,6 +66,11 @@ func DefaultDirectory() Directory {
 		PLCURL: DefaultPLCURL,
 		HTTPClient: http.Client{
 			Timeout: time.Second * 15,
+			Transport: &http.Transport{
+				// would want this around 100ms for services doing lots of handle resolution. Impacts PLC connections as well, but not too bad.
+				IdleConnTimeout: time.Millisecond * 1000,
+				MaxIdleConns:    100,
+			},
 		},
 		Resolver: net.Resolver{
 			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {


### PR DESCRIPTION
- limits on HTTP idle connections. mostly impacts did:web and HTTPS handle resolution, which can otherwise result in huge numbers of sockets hanging around (one per custom domain) when operating at scale. values chosen should not have too bad an impact on PLC usage, though we might want to split out separate PLC and non-PLC HTTP clients at some point
- drop some timeouts