### PR TITLE
sync get record shouldnt unmarshal

### DIFF
--- a/repomgr/repomgr.go
+++ b/repomgr/repomgr.go
@@ -467,7 +467,7 @@ func (rm *RepoManager) GetRecordProof(ctx context.Context, user models.Uid, coll
 		return cid.Undef, nil, err
 	}
 
-	_, _, err = r.GetRecord(ctx, collection+"/"+rkey)
+	_, _, err = r.GetRecordBytes(ctx, collection+"/"+rkey)
 	if err != nil {
 		return cid.Undef, nil, err
 	}


### PR DESCRIPTION
allows this to work on non bsky.app records