### PR TITLE
rainbow service setup tweaks

### DIFF
--- a/cmd/rainbow/Dockerfile
+++ b/cmd/rainbow/Dockerfile
@@ -39,5 +39,5 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/usr/bin/rainbow"]
 
 LABEL org.opencontainers.image.source=https://github.com/bluesky-social/indigo
-LABEL org.opencontainers.image.description="bsky.app rainbow"
+LABEL org.opencontainers.image.description="rainbow atproto firehose fanout service"
 LABEL org.opencontainers.image.licenses=MIT

--- a/cmd/rainbow/main.go
+++ b/cmd/rainbow/main.go
@@ -3,19 +3,18 @@ package main
 import (
 	"context"
 	"github.com/bluesky-social/indigo/events"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
 	"github.com/bluesky-social/indigo/splitter"
-	"github.com/carlmjohnson/versioninfo"
-	_ "go.uber.org/automaxprocs"
-
-	_ "net/http/pprof"
 
 	_ "github.com/joho/godotenv/autoload"
+	_ "go.uber.org/automaxprocs"
 
+	"github.com/carlmjohnson/versioninfo"
 	logging "github.com/ipfs/go-log"
 	"github.com/urfave/cli/v2"
 	"go.opentelemetry.io/otel"

--- a/cmd/rainbow/main.go
+++ b/cmd/rainbow/main.go
@@ -78,8 +78,8 @@ func run(args []string) {
 		},
 		&cli.Float64Flag{
 			Name:    "persist-hours",
-			Value:   24 * 7,
-			EnvVars: []string{"SPLITTER_PERSIST_HOURS"},
+			Value:   24 * 3,
+			EnvVars: []string{"RAINBOW_PERSIST_HOURS", "SPLITTER_PERSIST_HOURS"},
 			Usage:   "hours to buffer (float, may be fractional)",
 		},
 		&cli.Int64Flag{

--- a/cmd/rainbow/main.go
+++ b/cmd/rainbow/main.go
@@ -45,12 +45,14 @@ func run(args []string) {
 
 	app.Flags = []cli.Flag{
 		&cli.BoolFlag{
-			Name:  "crawl-insecure-ws",
-			Usage: "when connecting to PDS instances, use ws:// instead of wss://",
+			Name:    "crawl-insecure-ws",
+			Usage:   "when connecting to PDS instances, use ws:// instead of wss://",
+			EnvVars: []string{"RAINBOW_INSECURE_CRAWL"},
 		},
 		&cli.StringFlag{
-			Name:  "splitter-host",
-			Value: "bsky.network",
+			Name:    "splitter-host",
+			Value:   "bsky.network",
+			EnvVars: []string{"ATP_RELAY_HOST", "RAINBOW_RELAY_HOST"},
 		},
 		&cli.StringFlag{
 			Name:  "persist-db",
@@ -63,13 +65,14 @@ func run(args []string) {
 			Usage: "write upstream cursor number to this file",
 		},
 		&cli.StringFlag{
-			Name:  "api-listen",
-			Value: ":2480",
+			Name:    "api-listen",
+			Value:   ":2480",
+			EnvVars: []string{"RAINBOW_API_LISTEN"},
 		},
 		&cli.StringFlag{
 			Name:    "metrics-listen",
 			Value:   ":2481",
-			EnvVars: []string{"SPLITTER_METRICS_LISTEN"},
+			EnvVars: []string{"RAINBOW_METRICS_LISTEN", "SPLITTER_METRICS_LISTEN"},
 		},
 		&cli.Float64Flag{
 			Name:    "persist-hours",
@@ -81,7 +84,7 @@ func run(args []string) {
 			Name:    "persist-bytes",
 			Value:   0,
 			Usage:   "max bytes target for event cache, 0 to disable size target trimming",
-			EnvVars: []string{"SPLITTER_PERSIST_BYTES"},
+			EnvVars: []string{"RAINBOW_PERSIST_BYTES", "SPLITTER_PERSIST_BYTES"},
 		},
 	}
 

--- a/cmd/rainbow/main.go
+++ b/cmd/rainbow/main.go
@@ -25,7 +25,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 )
 
-var log = logging.Logger("splitter")
+var log = logging.Logger("rainbow")
 
 func init() {
 	// control log level using, eg, GOLOG_LOG_LEVEL=debug
@@ -38,8 +38,8 @@ func main() {
 
 func run(args []string) {
 	app := cli.App{
-		Name:    "splitter",
-		Usage:   "firehose proxy",
+		Name:    "rainbow",
+		Usage:   "atproto firehose fan-out daemon",
 		Version: versioninfo.Short(),
 	}
 

--- a/cmd/rainbow/main.go
+++ b/cmd/rainbow/main.go
@@ -55,14 +55,16 @@ func run(args []string) {
 			EnvVars: []string{"ATP_RELAY_HOST", "RAINBOW_RELAY_HOST"},
 		},
 		&cli.StringFlag{
-			Name:  "persist-db",
-			Value: "",
-			Usage: "path to persistence db",
+			Name:    "persist-db",
+			Value:   "./rainbow.db",
+			Usage:   "path to persistence db",
+			EnvVars: []string{"RAINBOW_DB_PATH"},
 		},
 		&cli.StringFlag{
-			Name:  "cursor-file",
-			Value: "",
-			Usage: "write upstream cursor number to this file",
+			Name:    "cursor-file",
+			Value:   "./rainbow-cursor",
+			Usage:   "write upstream cursor number to this file",
+			EnvVars: []string{"RAINBOW_CURSOR_PATH"},
 		},
 		&cli.StringFlag{
 			Name:    "api-listen",

--- a/splitter/splitter.go
+++ b/splitter/splitter.go
@@ -196,10 +196,11 @@ func (s *Splitter) StartWithListener(listen net.Listener) error {
 		}
 	}
 
-	// TODO: this API is temporary until we formalize what we want here
-
 	e.GET("/xrpc/com.atproto.sync.subscribeRepos", s.EventsHandler)
+
 	e.GET("/xrpc/_health", s.HandleHealthCheck)
+	e.GET("/_health", s.HandleHealthCheck)
+	e.GET("/", s.HandleHomeMessage)
 
 	// In order to support booting on random ports in tests, we need to tell the
 	// Echo instance it's already got a port, and then use its StartServer
@@ -216,6 +217,21 @@ type HealthStatus struct {
 
 func (s *Splitter) HandleHealthCheck(c echo.Context) error {
 	return c.JSON(200, HealthStatus{Status: "ok"})
+}
+
+var homeMessage string = `
+          _      _
+ _ _ __ _(_)_ _ | |__  _____ __ __
+| '_/ _' | | ' \| '_ \/ _ \ V  V /
+|_| \__,_|_|_||_|_.__/\___/\_/\_/
+
+This is an atproto [https://atproto.com] firehose fanout service, running the 'rainbow' codebase [https://github.com/bluesky-social/indigo]
+
+The firehose WebSocket path is at:  /xrpc/com.atproto.sync.subscribeRepos
+`
+
+func (s *Splitter) HandleHomeMessage(c echo.Context) error {
+	return c.String(http.StatusOK, homeMessage)
 }
 
 func (s *Splitter) EventsHandler(c echo.Context) error {


### PR DESCRIPTION
- moving service config towards "rainbow" away from "splitter"
- adds env vars for more config options
- defaults and tweaks for some config options
- add a root path HTTP handler, which is helpful for debugging