### PR TITLE
Rewind cursor a bit before reconnection for some relay hosts to smooth over reconnection

### DIFF
--- a/bgs/fedmgr.go
+++ b/bgs/fedmgr.go
@@ -468,6 +468,11 @@ func (s *Slurper) subscribeWithRedialer(ctx context.Context, host *models.PDS, s
 		protocol = "wss"
 	}
 
+	// Special case `.host.bsky.network` PDSs to rewind cursor by 200 events to smooth over unclean shutdowns
+	if strings.HasSuffix(host.Host, ".host.bsky.network") && host.Cursor > 200 {
+		host.Cursor -= 200
+	}
+
 	cursor := host.Cursor
 
 	var backoff int


### PR DESCRIPTION
We see some jerk when the Relay restarts caused by high concurrency of event processing for some high traffic hosts, where some in-progress event handlers die while the cursor is advanced ahead of them and the next event for that repo triggers a catch-up/resync of the repo. This change rewinds the cursor a bit on reconnect to smooth out that process.