### PR TITLE
syntax: ParseDID performance

### DIFF
--- a/atproto/syntax/cmd/atp-syntax/main.go
+++ b/atproto/syntax/cmd/atp-syntax/main.go
@@ -22,6 +22,12 @@ func main() {
 			ArgsUsage: "<tid>",
 			Action:    runParseTID,
 		},
+		&cli.Command{
+			Name:      "parse-did",
+			Usage:     "parse a DID",
+			ArgsUsage: "<did>",
+			Action:    runParseDID,
+		},
 	}
 	h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})
 	slog.SetDefault(slog.New(h))
@@ -40,6 +46,21 @@ func runParseTID(cctx *cli.Context) error {
 	}
 	fmt.Printf("TID: %s\n", tid)
 	fmt.Printf("Time: %s\n", tid.Time())
+
+	return nil
+}
+
+func runParseDID(cctx *cli.Context) error {
+	s := cctx.Args().First()
+	if s == "" {
+		return fmt.Errorf("need to provide identifier as an argument")
+	}
+
+	did, err := syntax.ParseDID(s)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", did)
 
 	return nil
 }


### PR DESCRIPTION
we are apparently burning a bunch of CPU on this regex in prod, so let's bypass for the most common case (valid did:plc).

Would be nice to have a benchmark demonstrating perf gains (or not).

I did some manually testing with the CLI helper and inserted `panic()` statements to confirm that valid DID PLC stays on fast path, and other DIDs don't.

Feedback welcome if there is a more idiomatic/performant golang way to do this... this is still doing unicode stuff, I assume, and maybe casting to bytes would be faster? though probably doesn't impact the actual hot path much. `strings.ContainsAny` or `strings.ContainsFunc` could be used here I guess but :shrug: 