### PR TITLE
backfill: add failback to fetch CAR file from PDS (if relay errors)

### DIFF
--- a/backfill/backfill.go
+++ b/backfill/backfill.go
@@ -386,6 +386,7 @@ func (b *Backfiller) BackfillRepo(ctx context.Context, job Job) (string, error) 
 			slog.Warn("repo CAR fetch from PDS failed", "did", repoDID, "since", job.Rev(), "pdsHost", pdsHost, "err", err)
 			return "repo CAR fetch from PDS failed", err
 		}
+		slog.Info("repo CAR fetch from PDS successful", "did", repoDID, "since", job.Rev(), "pdsHost", pdsHost, "err", err)
 	}
 
 	numRecords := 0

--- a/search/indexing.go
+++ b/search/indexing.go
@@ -130,7 +130,7 @@ func NewIndexer(db *gorm.DB, escli *es.Client, dir identity.Directory, config In
 		opts.SyncRequestsPerSecond = 8
 	}
 
-	opts.CheckoutPath = fmt.Sprintf("%s/xrpc/com.atproto.sync.getRepo", relayHTTP)
+	opts.RelayHost = relayHTTP
 	if config.IndexMaxConcurrency > 0 {
 		opts.ParallelRecordCreates = config.IndexMaxConcurrency
 	} else {
@@ -145,6 +145,8 @@ func NewIndexer(db *gorm.DB, escli *es.Client, dir identity.Directory, config In
 		idx.handleDelete,
 		opts,
 	)
+	// reuse identity directory (for efficient caching)
+	bf.Directory = dir
 
 	idx.bfs = bfstore
 	idx.bf = bf


### PR DESCRIPTION
The main motivation here is that non-archival relay is returning a 4xx error for fetching repos, and we want to try fetching those from the actual PDS when that happens. This code adds a new code branch when a relay CAR fetch fails to do an identity lookup to find the account's PDS instance, and fetches the CAR from there.

For the search code specifically, it re-uses an existing identity directory, to reduce double-resolution.

This also refactors how fetch URLs are constructed to use just hostnames.

UPDATE: should probably *not* merge this to `main` until Jaz can review