### PR TITLE
schema-agnostic API helpers

### DIFF
--- a/api/agnostic/actorgetPreferences.go
+++ b/api/agnostic/actorgetPreferences.go
@@ -1,0 +1,28 @@
+// Copied from indigo:api/atproto/actorgetPreferences.go
+
+package agnostic
+
+// schema: app.bsky.actor.getPreferences
+
+import (
+	"context"
+
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+// ActorGetPreferences_Output is the output of a app.bsky.actor.getPreferences call.
+type ActorGetPreferences_Output struct {
+	Preferences []map[string]any `json:"preferences" cborgen:"preferences"`
+}
+
+// ActorGetPreferences calls the XRPC method "app.bsky.actor.getPreferences".
+func ActorGetPreferences(ctx context.Context, c *xrpc.Client) (*ActorGetPreferences_Output, error) {
+	var out ActorGetPreferences_Output
+
+	params := map[string]interface{}{}
+	if err := c.Do(ctx, xrpc.Query, "", "app.bsky.actor.getPreferences", params, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}

--- a/api/agnostic/actorgetPreferences.go
+++ b/api/agnostic/actorgetPreferences.go
@@ -1,4 +1,4 @@
-// Copied from indigo:api/atproto/actorgetPreferences.go
+// Copied from indigo:api/bsky/actorgetPreferences.go
 
 package agnostic
 

--- a/api/agnostic/actorputPreferences.go
+++ b/api/agnostic/actorputPreferences.go
@@ -1,4 +1,4 @@
-// Copied from indigo:api/atproto/actorputPreferences.go
+// Copied from indigo:api/bsky/actorputPreferences.go
 
 package agnostic
 

--- a/api/agnostic/actorputPreferences.go
+++ b/api/agnostic/actorputPreferences.go
@@ -1,0 +1,25 @@
+// Copied from indigo:api/atproto/actorputPreferences.go
+
+package agnostic
+
+// schema: app.bsky.actor.putPreferences
+
+import (
+	"context"
+
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+// ActorPutPreferences_Input is the input argument to a app.bsky.actor.putPreferences call.
+type ActorPutPreferences_Input struct {
+	Preferences []map[string]any `json:"preferences" cborgen:"preferences"`
+}
+
+// ActorPutPreferences calls the XRPC method "app.bsky.actor.putPreferences".
+func ActorPutPreferences(ctx context.Context, c *xrpc.Client, input *ActorPutPreferences_Input) error {
+	if err := c.Do(ctx, xrpc.Procedure, "application/json", "app.bsky.actor.putPreferences", nil, input, nil); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/agnostic/doc.go
+++ b/api/agnostic/doc.go
@@ -1,0 +1,4 @@
+// Package indigo/api/agnositc provides schema-agnostic helpers for fetching records from the network.
+//
+// These are variants of endpoints in indigo/api/atproto.
+package agnostic

--- a/api/agnostic/identitygetRecommendedDidCredentials.go
+++ b/api/agnostic/identitygetRecommendedDidCredentials.go
@@ -1,0 +1,23 @@
+// Copied from indigo:api/atproto/identitygetRecommendedDidCredentials.go
+
+package agnostic
+
+// schema: com.atproto.identity.getRecommendedDidCredentials
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+// IdentityGetRecommendedDidCredentials calls the XRPC method "com.atproto.identity.getRecommendedDidCredentials".
+func IdentityGetRecommendedDidCredentials(ctx context.Context, c *xrpc.Client) (*json.RawMessage, error) {
+	var out json.RawMessage
+
+	if err := c.Do(ctx, xrpc.Query, "", "com.atproto.identity.getRecommendedDidCredentials", nil, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}

--- a/api/agnostic/identitysignPlcOperation.go
+++ b/api/agnostic/identitysignPlcOperation.go
@@ -1,0 +1,38 @@
+// Copied from indigo:api/atproto/identitysignPlcOperation.go
+
+package agnostic
+
+// schema: com.atproto.identity.signPlcOperation
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+// IdentitySignPlcOperation_Input is the input argument to a com.atproto.identity.signPlcOperation call.
+type IdentitySignPlcOperation_Input struct {
+	AlsoKnownAs  []string         `json:"alsoKnownAs,omitempty" cborgen:"alsoKnownAs,omitempty"`
+	RotationKeys []string         `json:"rotationKeys,omitempty" cborgen:"rotationKeys,omitempty"`
+	Services     *json.RawMessage `json:"services,omitempty" cborgen:"services,omitempty"`
+	// token: A token received through com.atproto.identity.requestPlcOperationSignature
+	Token               *string          `json:"token,omitempty" cborgen:"token,omitempty"`
+	VerificationMethods *json.RawMessage `json:"verificationMethods,omitempty" cborgen:"verificationMethods,omitempty"`
+}
+
+// IdentitySignPlcOperation_Output is the output of a com.atproto.identity.signPlcOperation call.
+type IdentitySignPlcOperation_Output struct {
+	// operation: A signed DID PLC operation.
+	Operation *json.RawMessage `json:"operation" cborgen:"operation"`
+}
+
+// IdentitySignPlcOperation calls the XRPC method "com.atproto.identity.signPlcOperation".
+func IdentitySignPlcOperation(ctx context.Context, c *xrpc.Client, input *IdentitySignPlcOperation_Input) (*IdentitySignPlcOperation_Output, error) {
+	var out IdentitySignPlcOperation_Output
+	if err := c.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.identity.signPlcOperation", nil, input, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}

--- a/api/agnostic/identitysubmitPlcOperation.go
+++ b/api/agnostic/identitysubmitPlcOperation.go
@@ -1,0 +1,26 @@
+// Copied from indigo:api/atproto/identitysubmitPlcOperation.go
+
+package agnostic
+
+// schema: com.atproto.identity.submitPlcOperation
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+// IdentitySubmitPlcOperation_Input is the input argument to a com.atproto.identity.submitPlcOperation call.
+type IdentitySubmitPlcOperation_Input struct {
+	Operation *json.RawMessage `json:"operation" cborgen:"operation"`
+}
+
+// IdentitySubmitPlcOperation calls the XRPC method "com.atproto.identity.submitPlcOperation".
+func IdentitySubmitPlcOperation(ctx context.Context, c *xrpc.Client, input *IdentitySubmitPlcOperation_Input) error {
+	if err := c.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.identity.submitPlcOperation", nil, input, nil); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/agnostic/repoapplyWrites.go
+++ b/api/agnostic/repoapplyWrites.go
@@ -1,0 +1,189 @@
+// Copied from indigo:api/atproto/repoapplyWrites.go
+
+package agnostic
+
+// schema: com.atproto.repo.applyWrites
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/bluesky-social/indigo/lex/util"
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+// RepoApplyWrites_Create is a "create" in the com.atproto.repo.applyWrites schema.
+//
+// Operation which creates a new record.
+//
+// RECORDTYPE: RepoApplyWrites_Create
+type RepoApplyWrites_Create struct {
+	LexiconTypeID string           `json:"$type,const=com.atproto.repo.applyWrites#create" cborgen:"$type,const=com.atproto.repo.applyWrites#create"`
+	Collection    string           `json:"collection" cborgen:"collection"`
+	Rkey          *string          `json:"rkey,omitempty" cborgen:"rkey,omitempty"`
+	Value         *json.RawMessage `json:"value" cborgen:"value"`
+}
+
+// RepoApplyWrites_CreateResult is a "createResult" in the com.atproto.repo.applyWrites schema.
+//
+// RECORDTYPE: RepoApplyWrites_CreateResult
+type RepoApplyWrites_CreateResult struct {
+	LexiconTypeID    string  `json:"$type,const=com.atproto.repo.applyWrites#createResult" cborgen:"$type,const=com.atproto.repo.applyWrites#createResult"`
+	Cid              string  `json:"cid" cborgen:"cid"`
+	Uri              string  `json:"uri" cborgen:"uri"`
+	ValidationStatus *string `json:"validationStatus,omitempty" cborgen:"validationStatus,omitempty"`
+}
+
+// RepoApplyWrites_Delete is a "delete" in the com.atproto.repo.applyWrites schema.
+//
+// Operation which deletes an existing record.
+//
+// RECORDTYPE: RepoApplyWrites_Delete
+type RepoApplyWrites_Delete struct {
+	LexiconTypeID string `json:"$type,const=com.atproto.repo.applyWrites#delete" cborgen:"$type,const=com.atproto.repo.applyWrites#delete"`
+	Collection    string `json:"collection" cborgen:"collection"`
+	Rkey          string `json:"rkey" cborgen:"rkey"`
+}
+
+// RepoApplyWrites_DeleteResult is a "deleteResult" in the com.atproto.repo.applyWrites schema.
+//
+// RECORDTYPE: RepoApplyWrites_DeleteResult
+type RepoApplyWrites_DeleteResult struct {
+	LexiconTypeID string `json:"$type,const=com.atproto.repo.applyWrites#deleteResult" cborgen:"$type,const=com.atproto.repo.applyWrites#deleteResult"`
+}
+
+// RepoApplyWrites_Input is the input argument to a com.atproto.repo.applyWrites call.
+type RepoApplyWrites_Input struct {
+	// repo: The handle or DID of the repo (aka, current account).
+	Repo string `json:"repo" cborgen:"repo"`
+	// swapCommit: If provided, the entire operation will fail if the current repo commit CID does not match this value. Used to prevent conflicting repo mutations.
+	SwapCommit *string `json:"swapCommit,omitempty" cborgen:"swapCommit,omitempty"`
+	// validate: Can be set to 'false' to skip Lexicon schema validation of record data across all operations, 'true' to require it, or leave unset to validate only for known Lexicons.
+	Validate *bool                                `json:"validate,omitempty" cborgen:"validate,omitempty"`
+	Writes   []*RepoApplyWrites_Input_Writes_Elem `json:"writes" cborgen:"writes"`
+}
+
+type RepoApplyWrites_Input_Writes_Elem struct {
+	RepoApplyWrites_Create *RepoApplyWrites_Create
+	RepoApplyWrites_Update *RepoApplyWrites_Update
+	RepoApplyWrites_Delete *RepoApplyWrites_Delete
+}
+
+func (t *RepoApplyWrites_Input_Writes_Elem) MarshalJSON() ([]byte, error) {
+	if t.RepoApplyWrites_Create != nil {
+		t.RepoApplyWrites_Create.LexiconTypeID = "com.atproto.repo.applyWrites#create"
+		return json.Marshal(t.RepoApplyWrites_Create)
+	}
+	if t.RepoApplyWrites_Update != nil {
+		t.RepoApplyWrites_Update.LexiconTypeID = "com.atproto.repo.applyWrites#update"
+		return json.Marshal(t.RepoApplyWrites_Update)
+	}
+	if t.RepoApplyWrites_Delete != nil {
+		t.RepoApplyWrites_Delete.LexiconTypeID = "com.atproto.repo.applyWrites#delete"
+		return json.Marshal(t.RepoApplyWrites_Delete)
+	}
+	return nil, fmt.Errorf("cannot marshal empty enum")
+}
+func (t *RepoApplyWrites_Input_Writes_Elem) UnmarshalJSON(b []byte) error {
+	typ, err := util.TypeExtract(b)
+	if err != nil {
+		return err
+	}
+
+	switch typ {
+	case "com.atproto.repo.applyWrites#create":
+		t.RepoApplyWrites_Create = new(RepoApplyWrites_Create)
+		return json.Unmarshal(b, t.RepoApplyWrites_Create)
+	case "com.atproto.repo.applyWrites#update":
+		t.RepoApplyWrites_Update = new(RepoApplyWrites_Update)
+		return json.Unmarshal(b, t.RepoApplyWrites_Update)
+	case "com.atproto.repo.applyWrites#delete":
+		t.RepoApplyWrites_Delete = new(RepoApplyWrites_Delete)
+		return json.Unmarshal(b, t.RepoApplyWrites_Delete)
+
+	default:
+		return fmt.Errorf("closed enums must have a matching value")
+	}
+}
+
+// RepoApplyWrites_Output is the output of a com.atproto.repo.applyWrites call.
+type RepoApplyWrites_Output struct {
+	Commit  *RepoDefs_CommitMeta                   `json:"commit,omitempty" cborgen:"commit,omitempty"`
+	Results []*RepoApplyWrites_Output_Results_Elem `json:"results,omitempty" cborgen:"results,omitempty"`
+}
+
+type RepoApplyWrites_Output_Results_Elem struct {
+	RepoApplyWrites_CreateResult *RepoApplyWrites_CreateResult
+	RepoApplyWrites_UpdateResult *RepoApplyWrites_UpdateResult
+	RepoApplyWrites_DeleteResult *RepoApplyWrites_DeleteResult
+}
+
+func (t *RepoApplyWrites_Output_Results_Elem) MarshalJSON() ([]byte, error) {
+	if t.RepoApplyWrites_CreateResult != nil {
+		t.RepoApplyWrites_CreateResult.LexiconTypeID = "com.atproto.repo.applyWrites#createResult"
+		return json.Marshal(t.RepoApplyWrites_CreateResult)
+	}
+	if t.RepoApplyWrites_UpdateResult != nil {
+		t.RepoApplyWrites_UpdateResult.LexiconTypeID = "com.atproto.repo.applyWrites#updateResult"
+		return json.Marshal(t.RepoApplyWrites_UpdateResult)
+	}
+	if t.RepoApplyWrites_DeleteResult != nil {
+		t.RepoApplyWrites_DeleteResult.LexiconTypeID = "com.atproto.repo.applyWrites#deleteResult"
+		return json.Marshal(t.RepoApplyWrites_DeleteResult)
+	}
+	return nil, fmt.Errorf("cannot marshal empty enum")
+}
+func (t *RepoApplyWrites_Output_Results_Elem) UnmarshalJSON(b []byte) error {
+	typ, err := util.TypeExtract(b)
+	if err != nil {
+		return err
+	}
+
+	switch typ {
+	case "com.atproto.repo.applyWrites#createResult":
+		t.RepoApplyWrites_CreateResult = new(RepoApplyWrites_CreateResult)
+		return json.Unmarshal(b, t.RepoApplyWrites_CreateResult)
+	case "com.atproto.repo.applyWrites#updateResult":
+		t.RepoApplyWrites_UpdateResult = new(RepoApplyWrites_UpdateResult)
+		return json.Unmarshal(b, t.RepoApplyWrites_UpdateResult)
+	case "com.atproto.repo.applyWrites#deleteResult":
+		t.RepoApplyWrites_DeleteResult = new(RepoApplyWrites_DeleteResult)
+		return json.Unmarshal(b, t.RepoApplyWrites_DeleteResult)
+
+	default:
+		return fmt.Errorf("closed enums must have a matching value")
+	}
+}
+
+// RepoApplyWrites_Update is a "update" in the com.atproto.repo.applyWrites schema.
+//
+// Operation which updates an existing record.
+//
+// RECORDTYPE: RepoApplyWrites_Update
+type RepoApplyWrites_Update struct {
+	LexiconTypeID string           `json:"$type,const=com.atproto.repo.applyWrites#update" cborgen:"$type,const=com.atproto.repo.applyWrites#update"`
+	Collection    string           `json:"collection" cborgen:"collection"`
+	Rkey          string           `json:"rkey" cborgen:"rkey"`
+	Value         *json.RawMessage `json:"value" cborgen:"value"`
+}
+
+// RepoApplyWrites_UpdateResult is a "updateResult" in the com.atproto.repo.applyWrites schema.
+//
+// RECORDTYPE: RepoApplyWrites_UpdateResult
+type RepoApplyWrites_UpdateResult struct {
+	LexiconTypeID    string  `json:"$type,const=com.atproto.repo.applyWrites#updateResult" cborgen:"$type,const=com.atproto.repo.applyWrites#updateResult"`
+	Cid              string  `json:"cid" cborgen:"cid"`
+	Uri              string  `json:"uri" cborgen:"uri"`
+	ValidationStatus *string `json:"validationStatus,omitempty" cborgen:"validationStatus,omitempty"`
+}
+
+// RepoApplyWrites calls the XRPC method "com.atproto.repo.applyWrites".
+func RepoApplyWrites(ctx context.Context, c *xrpc.Client, input *RepoApplyWrites_Input) (*RepoApplyWrites_Output, error) {
+	var out RepoApplyWrites_Output
+	if err := c.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.applyWrites", nil, input, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}

--- a/api/agnostic/repocreateRecord.go
+++ b/api/agnostic/repocreateRecord.go
@@ -1,0 +1,51 @@
+// Copied from indigo:api/atproto/repocreateRecords.go
+
+package agnostic
+
+// schema: com.atproto.repo.createRecord
+
+import (
+	"context"
+
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+// RepoDefs_CommitMeta is a "commitMeta" in the com.atproto.repo.defs schema.
+type RepoDefs_CommitMeta struct {
+	Cid string `json:"cid" cborgen:"cid"`
+	Rev string `json:"rev" cborgen:"rev"`
+}
+
+// RepoCreateRecord_Input is the input argument to a com.atproto.repo.createRecord call.
+type RepoCreateRecord_Input struct {
+	// collection: The NSID of the record collection.
+	Collection string `json:"collection" cborgen:"collection"`
+	// record: The record itself. Must contain a $type field.
+	Record map[string]any `json:"record" cborgen:"record"`
+	// repo: The handle or DID of the repo (aka, current account).
+	Repo string `json:"repo" cborgen:"repo"`
+	// rkey: The Record Key.
+	Rkey *string `json:"rkey,omitempty" cborgen:"rkey,omitempty"`
+	// swapCommit: Compare and swap with the previous commit by CID.
+	SwapCommit *string `json:"swapCommit,omitempty" cborgen:"swapCommit,omitempty"`
+	// validate: Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons.
+	Validate *bool `json:"validate,omitempty" cborgen:"validate,omitempty"`
+}
+
+// RepoCreateRecord_Output is the output of a com.atproto.repo.createRecord call.
+type RepoCreateRecord_Output struct {
+	Cid              string               `json:"cid" cborgen:"cid"`
+	Commit           *RepoDefs_CommitMeta `json:"commit,omitempty" cborgen:"commit,omitempty"`
+	Uri              string               `json:"uri" cborgen:"uri"`
+	ValidationStatus *string              `json:"validationStatus,omitempty" cborgen:"validationStatus,omitempty"`
+}
+
+// RepoCreateRecord calls the XRPC method "com.atproto.repo.createRecord".
+func RepoCreateRecord(ctx context.Context, c *xrpc.Client, input *RepoCreateRecord_Input) (*RepoCreateRecord_Output, error) {
+	var out RepoCreateRecord_Output
+	if err := c.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.createRecord", nil, input, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}

--- a/api/agnostic/repogetRecord.go
+++ b/api/agnostic/repogetRecord.go
@@ -1,0 +1,42 @@
+// Copied from indigo:api/atproto/repolistRecords.go
+
+package agnostic
+
+// schema: com.atproto.repo.getRecord
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+// RepoGetRecord_Output is the output of a com.atproto.repo.getRecord call.
+type RepoGetRecord_Output struct {
+	Cid *string `json:"cid,omitempty" cborgen:"cid,omitempty"`
+	Uri string  `json:"uri" cborgen:"uri"`
+	//  NOTE: changed from lex decoder to json.RawMessage
+	Value *json.RawMessage `json:"value" cborgen:"value"`
+}
+
+// RepoGetRecord calls the XRPC method "com.atproto.repo.getRecord".
+//
+// cid: The CID of the version of the record. If not specified, then return the most recent version.
+// collection: The NSID of the record collection.
+// repo: The handle or DID of the repo.
+// rkey: The Record Key.
+func RepoGetRecord(ctx context.Context, c *xrpc.Client, cid string, collection string, repo string, rkey string) (*RepoGetRecord_Output, error) {
+	var out RepoGetRecord_Output
+
+	params := map[string]interface{}{
+		"cid":        cid,
+		"collection": collection,
+		"repo":       repo,
+		"rkey":       rkey,
+	}
+	if err := c.Do(ctx, xrpc.Query, "", "com.atproto.repo.getRecord", params, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}

--- a/api/agnostic/repolistRecords.go
+++ b/api/agnostic/repolistRecords.go
@@ -1,0 +1,53 @@
+// Copied from indigo:api/atproto/repolistRecords.go
+
+package agnostic
+
+// schema: com.atproto.repo.listRecords
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+// RepoListRecords_Output is the output of a com.atproto.repo.listRecords call.
+type RepoListRecords_Output struct {
+	Cursor  *string                   `json:"cursor,omitempty" cborgen:"cursor,omitempty"`
+	Records []*RepoListRecords_Record `json:"records" cborgen:"records"`
+}
+
+// RepoListRecords_Record is a "record" in the com.atproto.repo.listRecords schema.
+type RepoListRecords_Record struct {
+	Cid string `json:"cid" cborgen:"cid"`
+	Uri string `json:"uri" cborgen:"uri"`
+	//  NOTE: changed from lex decoder to json.RawMessage
+	Value *json.RawMessage `json:"value" cborgen:"value"`
+}
+
+// RepoListRecords calls the XRPC method "com.atproto.repo.listRecords".
+//
+// collection: The NSID of the record type.
+// limit: The number of records to return.
+// repo: The handle or DID of the repo.
+// reverse: Flag to reverse the order of the returned records.
+// rkeyEnd: DEPRECATED: The highest sort-ordered rkey to stop at (exclusive)
+// rkeyStart: DEPRECATED: The lowest sort-ordered rkey to start from (exclusive)
+func RepoListRecords(ctx context.Context, c *xrpc.Client, collection string, cursor string, limit int64, repo string, reverse bool, rkeyEnd string, rkeyStart string) (*RepoListRecords_Output, error) {
+	var out RepoListRecords_Output
+
+	params := map[string]interface{}{
+		"collection": collection,
+		"cursor":     cursor,
+		"limit":      limit,
+		"repo":       repo,
+		"reverse":    reverse,
+		"rkeyEnd":    rkeyEnd,
+		"rkeyStart":  rkeyStart,
+	}
+	if err := c.Do(ctx, xrpc.Query, "", "com.atproto.repo.listRecords", params, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}

--- a/api/agnostic/repoputRecord.go
+++ b/api/agnostic/repoputRecord.go
@@ -1,0 +1,47 @@
+// Copied from indigo:api/atproto/repoputRecords.go
+
+package agnostic
+
+// schema: com.atproto.repo.putRecord
+
+import (
+	"context"
+
+	"github.com/bluesky-social/indigo/xrpc"
+)
+
+// RepoPutRecord_Input is the input argument to a com.atproto.repo.putRecord call.
+type RepoPutRecord_Input struct {
+	// collection: The NSID of the record collection.
+	Collection string `json:"collection" cborgen:"collection"`
+	// record: The record to write.
+	Record map[string]any `json:"record" cborgen:"record"`
+	// repo: The handle or DID of the repo (aka, current account).
+	Repo string `json:"repo" cborgen:"repo"`
+	// rkey: The Record Key.
+	Rkey string `json:"rkey" cborgen:"rkey"`
+	// swapCommit: Compare and swap with the previous commit by CID.
+	SwapCommit *string `json:"swapCommit,omitempty" cborgen:"swapCommit,omitempty"`
+	// swapRecord: Compare and swap with the previous record by CID. WARNING: nullable and optional field; may cause problems with golang implementation
+	SwapRecord *string `json:"swapRecord" cborgen:"swapRecord"`
+	// validate: Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons.
+	Validate *bool `json:"validate,omitempty" cborgen:"validate,omitempty"`
+}
+
+// RepoPutRecord_Output is the output of a com.atproto.repo.putRecord call.
+type RepoPutRecord_Output struct {
+	Cid              string               `json:"cid" cborgen:"cid"`
+	Commit           *RepoDefs_CommitMeta `json:"commit,omitempty" cborgen:"commit,omitempty"`
+	Uri              string               `json:"uri" cborgen:"uri"`
+	ValidationStatus *string              `json:"validationStatus,omitempty" cborgen:"validationStatus,omitempty"`
+}
+
+// RepoPutRecord calls the XRPC method "com.atproto.repo.putRecord".
+func RepoPutRecord(ctx context.Context, c *xrpc.Client, input *RepoPutRecord_Input) (*RepoPutRecord_Output, error) {
+	var out RepoPutRecord_Output
+	if err := c.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.putRecord", nil, input, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}


### PR DESCRIPTION
These are some variants of "typed" atproto sync/repo helpers from `api/atproto` which use `json.RawMessage` instead of the lexutil `LexiconTypeDecoder` wrapper.

These are mostly used from tools like `goat` which work with arbitrary record data, when we don't have lexgen types (or they aren't imported, or whatever). They can also be used for things like preferences, where the type in an open union is rapidly changing, and we don't want to "clobber" (drop) data from new lexicons the client code isn't familiar with.

You can see these in action: https://github.com/bluesky-social/indigo/pull/870

@whyrusleeping you might want to do similar things in `gosky`.

Big picture we'll maybe want to move lexgen in this direction at some point? Relatedly, having LexiconTypeDecoder and open unions have an "unknown schema" option with raw data (possibly `map[string]any` instead of `json.RawMessage`; the later only makes sense for API endpoints, not record data).