### PR TITLE
Use keyed field in DbCID initialization.

### DIFF
--- a/carstore/nonarchive.go
+++ b/carstore/nonarchive.go
@@ -100,7 +100,7 @@ func (cs *NonArchivalCarstore) updateLastCommit(ctx context.Context, uid models.
 	cri := &commitRefInfo{
 		Uid:  uid,
 		Rev:  rev,
-		Root: models.DbCID{cid},
+		Root: models.DbCID{CID: cid},
 	}
 
 	if err := cs.db.Clauses(clause.OnConflict{


### PR DESCRIPTION
fixes "struct literal uses unkeyed fields" in lint.