### PR TITLE
feat(cmd/goat): allow specifying authFactorToken

### DIFF
--- a/cmd/goat/account.go
+++ b/cmd/goat/account.go
@@ -39,9 +39,8 @@ var cmdAccount = &cli.Command{
 				},
 				&cli.StringFlag{
 					Name:    "auth-factor-token",
-					Aliases: []string{"t"},
 					Usage:   "token required if password is used and 2fa is required",
-					EnvVars: []string{"ATP_AUTH_TOKEN"},
+					EnvVars: []string{"ATP_AUTH_2FA_TOKEN"},
 				},
 				&cli.StringFlag{
 					Name:    "pds-host",
@@ -169,7 +168,7 @@ func runAccountLogin(cctx *cli.Context) error {
 		return err
 	}
 
-	_, err = refreshAuthSession(ctx, *username, cctx.String("app-password"), cctx.String("auth-factor-token"), cctx.String("pds-host"))
+	_, err = refreshAuthSession(ctx, *username, cctx.String("app-password"), cctx.String("pds-host"), cctx.String("auth-factor-token"))
 	return err
 }
 

--- a/cmd/goat/account.go
+++ b/cmd/goat/account.go
@@ -40,7 +40,7 @@ var cmdAccount = &cli.Command{
 				&cli.StringFlag{
 					Name:    "auth-factor-token",
 					Usage:   "token required if password is used and 2fa is required",
-					EnvVars: []string{"ATP_AUTH_2FA_TOKEN"},
+					EnvVars: []string{"ATP_AUTH_FACTOR_TOKEN"},
 				},
 				&cli.StringFlag{
 					Name:    "pds-host",

--- a/cmd/goat/account.go
+++ b/cmd/goat/account.go
@@ -38,6 +38,12 @@ var cmdAccount = &cli.Command{
 					EnvVars:  []string{"ATP_AUTH_PASSWORD"},
 				},
 				&cli.StringFlag{
+					Name:    "auth-factor-token",
+					Aliases: []string{"t"},
+					Usage:   "token required if password is used and 2fa is required",
+					EnvVars: []string{"ATP_AUTH_TOKEN"},
+				},
+				&cli.StringFlag{
 					Name:    "pds-host",
 					Usage:   "URL of the PDS to create account on (overrides DID doc)",
 					EnvVars: []string{"ATP_PDS_HOST"},
@@ -163,7 +169,7 @@ func runAccountLogin(cctx *cli.Context) error {
 		return err
 	}
 
-	_, err = refreshAuthSession(ctx, *username, cctx.String("app-password"), cctx.String("pds-host"))
+	_, err = refreshAuthSession(ctx, *username, cctx.String("app-password"), cctx.String("auth-factor-token"), cctx.String("pds-host"))
 	return err
 }
 

--- a/cmd/goat/auth.go
+++ b/cmd/goat/auth.go
@@ -79,7 +79,7 @@ func loadAuthClient(ctx context.Context) (*xrpc.Client, error) {
 	if err != nil {
 		// TODO: if failure, try creating a new session from password (2fa tokens are only valid once, so not reused)
 		fmt.Println("trying to refresh auth from password...")
-		as, err := refreshAuthSession(ctx, sess.DID.AtIdentifier(), sess.Password, "", sess.PDS)
+		as, err := refreshAuthSession(ctx, sess.DID.AtIdentifier(), sess.Password, sess.PDS, "")
 		if err != nil {
 			return nil, err
 		}
@@ -96,7 +96,7 @@ func loadAuthClient(ctx context.Context) (*xrpc.Client, error) {
 	return &client, nil
 }
 
-func refreshAuthSession(ctx context.Context, username syntax.AtIdentifier, password, authFactorToken, pdsURL string) (*AuthSession, error) {
+func refreshAuthSession(ctx context.Context, username syntax.AtIdentifier, password, pdsURL, authFactorToken string) (*AuthSession, error) {
 
 	var did syntax.DID
 	if pdsURL == "" {

--- a/cmd/goat/auth.go
+++ b/cmd/goat/auth.go
@@ -77,9 +77,9 @@ func loadAuthClient(ctx context.Context) (*xrpc.Client, error) {
 	}
 	resp, err := comatproto.ServerRefreshSession(ctx, &client)
 	if err != nil {
-		// TODO: if failure, try creating a new session from password
+		// TODO: if failure, try creating a new session from password (2fa tokens are only valid once, so not reused)
 		fmt.Println("trying to refresh auth from password...")
-		as, err := refreshAuthSession(ctx, sess.DID.AtIdentifier(), sess.Password, sess.PDS)
+		as, err := refreshAuthSession(ctx, sess.DID.AtIdentifier(), sess.Password, "", sess.PDS)
 		if err != nil {
 			return nil, err
 		}
@@ -96,7 +96,7 @@ func loadAuthClient(ctx context.Context) (*xrpc.Client, error) {
 	return &client, nil
 }
 
-func refreshAuthSession(ctx context.Context, username syntax.AtIdentifier, password, pdsURL string) (*AuthSession, error) {
+func refreshAuthSession(ctx context.Context, username syntax.AtIdentifier, password, authFactorToken, pdsURL string) (*AuthSession, error) {
 
 	var did syntax.DID
 	if pdsURL == "" {
@@ -120,9 +120,14 @@ func refreshAuthSession(ctx context.Context, username syntax.AtIdentifier, passw
 	client := xrpc.Client{
 		Host: pdsURL,
 	}
+	var token *string
+	if authFactorToken != "" {
+		token = &authFactorToken
+	}
 	sess, err := comatproto.ServerCreateSession(ctx, &client, &comatproto.ServerCreateSession_Input{
-		Identifier: username.String(),
-		Password:   password,
+		Identifier:      username.String(),
+		Password:        password,
+		AuthFactorToken: token,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Supports using goat account login with [email 2fa enabled](https://github.com/bluesky-social/atproto/discussions/2435) so that users do not need to first disable 2fa to then get an email token anyways to obtain plc signing tokens.