### PR TITLE
feat(cmd/goat): XRPC subcommand

### DIFF
--- a/cmd/goat/main.go
+++ b/cmd/goat/main.go
@@ -38,6 +38,7 @@ func run(args []string) error {
 		cmdSyntax,
 		cmdCrypto,
 		cmdPds,
+		cmdXRPC,
 	}
 	return app.Run(args)
 }

--- a/cmd/goat/xrpc.go
+++ b/cmd/goat/xrpc.go
@@ -18,6 +18,7 @@ import (
 var cmdXRPC = &cli.Command{
 	Name: "xrpc",
 	Usage: "use an XRPC endpoint",
+	Description: "Execute an XRPC query or procedure via your PDS. Procedure inputs should be provided via standard input (i.e. a pipe, or redirection with <).",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name: "proxy",

--- a/cmd/goat/xrpc.go
+++ b/cmd/goat/xrpc.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/urfave/cli/v2"
+)
+
+var cmdXRPC = &cli.Command{
+	Name: "xrpc",
+	Usage: "use an XRPC endpoint",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name: "proxy",
+			Usage: "the service to proxy to, referred to by its DID and service ID",
+		},
+		&cli.StringFlag{
+			Name: "type",
+			Usage: "the MIME type of the request body for a procedure",
+			Value: "application/json",
+		},
+		// --post and --get are flags instead of subcommands so that,
+		// when and if lexicon resolution is added, that can be used
+		// to infer the request type
+		&cli.BoolFlag{
+			Name: "procedure",
+			Aliases: []string{"post", "p"},
+			Usage: "execute an XRPC procedure (POST request)",
+		},
+		&cli.BoolFlag{
+			Name: "query",
+			Aliases: []string{"q", "get", "g"},
+			Usage: "execute an XRPC query (GET request)",
+		},
+	},
+	ArgsUsage: "<nsid> [paramKey=paramValue...]",
+	Action: runXRPC,
+}
+
+func runXRPC(cctx *cli.Context) error {
+	ctx := context.Background()
+	nsid := cctx.Args().First()
+	if nsid == "" {
+		return fmt.Errorf("need to provide NSID as argument")
+	}
+	
+	paramList := cctx.Args().Tail()
+	paramMap := make(map[string]interface{})
+	for _, param := range paramList {
+		split := strings.SplitN(param, "=", 2)
+		if len(split) != 2 {
+			return fmt.Errorf("parameters must be split with an equals sign")
+		}
+		if strings.Index(split[1], "\"") == 0 {
+			value := strings.Trim(split[1], "\"'")
+			paramMap[split[0]] = value
+		} else {
+			paramMap[split[0]] = split[1]
+		}
+	}
+
+	procedureFlag := cctx.Bool("procedure")
+	queryFlag := cctx.Bool("query")
+	if !procedureFlag && !queryFlag {
+		// TODO: resolve the lexicon for the provided NSID
+		return fmt.Errorf("need to provide exactly one of --procedure or --query")
+	} else if procedureFlag && queryFlag {
+		return fmt.Errorf("need to provide exactly one of --procedure or --query")
+	}
+
+	inpenc := cctx.String("type")
+	if inpenc == "" {
+		inpenc = "application/json"
+	}
+
+	proxy := cctx.String("proxy")
+
+	xrpcc, err := loadAuthClient(ctx)
+	if err == ErrNoAuthSession {
+		return fmt.Errorf("auth required, but not logged in")
+	} else if err != nil {
+		return err
+	}
+	if proxy != "" {
+		if xrpcc.Headers == nil {
+			xrpcc.Headers = make(map[string]string)
+		}
+		xrpcc.Headers["atproto-proxy"] = proxy
+	}
+	
+	var input []byte
+	if procedureFlag {
+		input, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("could not read input: %w", err)
+		}
+	}
+
+	var rpcType xrpc.XRPCRequestType
+	if procedureFlag {
+		rpcType = xrpc.Procedure
+	} else if queryFlag {
+		rpcType = xrpc.Query
+	}
+
+	var output any
+	err = xrpcc.Do(ctx, rpcType, inpenc, nsid, paramMap, input, &output)
+	if err != nil {
+		return err
+	}
+	
+	if reflect.TypeOf(output).Kind().String() == "map" || reflect.TypeOf(output).Kind().String() == "slice" {
+		data, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data[:]))
+	} else {
+		fmt.Println(output)
+	}
+	return nil
+}

--- a/cmd/goat/xrpc.go
+++ b/cmd/goat/xrpc.go
@@ -120,7 +120,7 @@ func runXRPC(cctx *cli.Context) error {
 	}
 	
 	if reflect.TypeOf(output).Kind().String() == "map" || reflect.TypeOf(output).Kind().String() == "slice" {
-		data, err := json.MarshalIndent(output, "", "  ")
+		data, err := json.Marshal(output)
 		if err != nil {
 			return err
 		}

--- a/cmd/goat/xrpc.go
+++ b/cmd/goat/xrpc.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
 )
 
@@ -96,12 +98,13 @@ func runXRPC(cctx *cli.Context) error {
 	}
 	
 	var input []byte
-	if procedureFlag {
+	if !isatty.IsTerminal(os.Stdin.Fd()) {
 		input, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("could not read input: %w", err)
 		}
 	}
+	inputReader := bytes.NewBuffer(input)
 
 	var rpcType xrpc.XRPCRequestType
 	if procedureFlag {
@@ -111,7 +114,7 @@ func runXRPC(cctx *cli.Context) error {
 	}
 
 	var output any
-	err = xrpcc.Do(ctx, rpcType, inpenc, nsid, paramMap, input, &output)
+	err = xrpcc.Do(ctx, rpcType, inpenc, nsid, paramMap, inputReader, &output)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR introduces a generic XRPC subcommand, which allows executing XRPC queries and procedures on your PDS, or via the `atproto-proxy` header (which is set with the `--proxy` flag). This should aid in the development of XRPC endpoints, and it may be helpful for power users.

![A screenshot of the command being run in a terminal, with the proxy DID redacted.](https://github.com/user-attachments/assets/7c20d211-eea7-445a-b182-60b759465865)

```
NAME:
   goat xrpc - use an XRPC endpoint

USAGE:
   goat xrpc [command options] <nsid> [paramKey=paramValue...]

DESCRIPTION:
   Execute an XRPC query or procedure via your PDS. Procedure inputs should be provided via standard input (i.e. a pipe, or redirection with <).

OPTIONS:
   --proxy value            the service to proxy to, referred to by its DID and service ID
   --type value             the MIME type of the request body for a procedure (default: "application/json")
   --procedure, --post, -p  execute an XRPC procedure (POST request) (default: false)
   --query, -q, --get, -g   execute an XRPC query (GET request) (default: false)
   --help, -h               show help
```

I set procedure and query to be options instead of subcommands so that lexicon resolution can be added later. If a lexicon resolves for a given NSID, the lexicon will tell it which one (procedure or query) it needs to be.