### PR TITLE
Add PDS host argument to blob export

### DIFF
--- a/cmd/goat/blob.go
+++ b/cmd/goat/blob.go
@@ -78,14 +78,14 @@ func runBlobExport(cctx *cli.Context) error {
 		return err
 	}
 
-	pds_host := cctx.String("pds-host")
-	if pds_host == "" {
-		pds_host = ident.PDSEndpoint()
+	pdsHost := cctx.String("pds-host")
+	if pdsHost == "" {
+		pdsHost = ident.PDSEndpoint()
 	}
 
 	// create a new API client to connect to the account's PDS
 	xrpcc := xrpc.Client{
-		Host: pds_host,,
+		Host: pdsHost,
 	}
 	if xrpcc.Host == "" {
 		return fmt.Errorf("no PDS endpoint for identity")

--- a/cmd/goat/blob.go
+++ b/cmd/goat/blob.go
@@ -31,7 +31,6 @@ var cmdBlob = &cli.Command{
 				&cli.StringFlag{
 					Name:    "pds-host",
 					Usage:   "URL of the PDS to export blobs from (overrides DID doc)",
-					EnvVars: []string{"ATP_PDS_HOST"},
 				},
 			},
 			Action: runBlobExport,

--- a/cmd/goat/blob.go
+++ b/cmd/goat/blob.go
@@ -28,6 +28,11 @@ var cmdBlob = &cli.Command{
 					Aliases: []string{"o"},
 					Usage:   "directory to store blobs in",
 				},
+				&cli.StringFlag{
+					Name:    "pds-host",
+					Usage:   "URL of the PDS to export blobs from (overrides DID doc)",
+					EnvVars: []string{"ATP_PDS_HOST"},
+				},
 			},
 			Action: runBlobExport,
 		},
@@ -73,9 +78,14 @@ func runBlobExport(cctx *cli.Context) error {
 		return err
 	}
 
+	pds_host := cctx.String("pds-host")
+	if pds_host == "" {
+		pds_host = ident.PDSEndpoint()
+	}
+
 	// create a new API client to connect to the account's PDS
 	xrpcc := xrpc.Client{
-		Host: ident.PDSEndpoint(),
+		Host: pds_host,,
 	}
 	if xrpcc.Host == "" {
 		return fmt.Errorf("no PDS endpoint for identity")


### PR DESCRIPTION
This PR introduces the `--pds-host` argument to the `blob export` command chain.

This was needed in order to export the blobs from an old PDS when by DID document was pointing to the new one already.