### PR TITLE
bump golang version to 1.23; fix slog syntax issues

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go tooling
         uses: actions/setup-go@v4
         with:
-          go-version: "1.22"
+          go-version: "1.23"
       - name: Build
         run: make build
       - name: Test
@@ -32,6 +32,6 @@ jobs:
       - name: Set up Go tooling
         uses: actions/setup-go@v4
         with:
-          go-version: "1.22"
+          go-version: "1.23"
       - name: Lint
         run: make lint

--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -662,7 +662,7 @@ func (bgs *BGS) EventsHandler(c echo.Context) error {
 				}
 
 				if err := conn.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(5*time.Second)); err != nil {
-					bgs.log.Warn("failed to ping client: %s", err)
+					bgs.log.Warn("failed to ping client", "err", err)
 					cancel()
 					return
 				}
@@ -687,7 +687,7 @@ func (bgs *BGS) EventsHandler(c echo.Context) error {
 		for {
 			_, _, err := conn.ReadMessage()
 			if err != nil {
-				bgs.log.Warn("failed to read message from client: %s", err)
+				bgs.log.Warn("failed to read message from client", "err", err)
 				cancel()
 				return
 			}

--- a/carstore/nonarchive.go
+++ b/carstore/nonarchive.go
@@ -131,7 +131,7 @@ func (cs *NonArchivalCarstore) NewDeltaSession(ctx context.Context, user models.
 	}
 
 	if since != nil && *since != lastShard.Rev {
-		cs.log.Warn("revision mismatch: %s != %s: %s", *since, lastShard.Rev, ErrRepoBaseMismatch)
+		cs.log.Warn("revision mismatch", "commitSince", since, "lastRev", lastShard.Rev, "err", ErrRepoBaseMismatch)
 	}
 
 	return &DeltaSession{

--- a/cmd/beemo/Dockerfile
+++ b/cmd/beemo/Dockerfile
@@ -3,7 +3,7 @@
 #   podman build -f ./cmd/beemo/Dockerfile -t beemo .
 
 ### Compile stage
-FROM golang:1.22-alpine3.19 AS build-env
+FROM golang:1.23-alpine3.20 AS build-env
 RUN apk add --no-cache build-base make git
 
 ADD . /dockerbuild
@@ -15,7 +15,7 @@ RUN GIT_VERSION=$(git describe --tags --long --always) && \
     go build -tags timetzdata -o /beemo ./cmd/beemo
 
 ### Run stage
-FROM alpine:3.19
+FROM alpine:3.20
 
 RUN apk add --no-cache --update dumb-init ca-certificates
 ENTRYPOINT ["dumb-init", "--"]

--- a/cmd/bigsky/Dockerfile
+++ b/cmd/bigsky/Dockerfile
@@ -3,7 +3,7 @@
 #   podman build -f ./cmd/bigsky/Dockerfile -t bigsky .
 
 ### Compile stage
-FROM golang:1.22-alpine3.19 AS build-env
+FROM golang:1.23-alpine3.20 AS build-env
 RUN apk add --no-cache build-base make git
 
 ADD . /dockerbuild
@@ -26,7 +26,7 @@ RUN yarn install --frozen-lockfile
 RUN yarn build
 
 ### Run stage
-FROM alpine:3.19
+FROM alpine:3.20
 
 RUN apk add --no-cache --update dumb-init ca-certificates runit
 ENTRYPOINT ["dumb-init", "--"]

--- a/cmd/hepa/Dockerfile
+++ b/cmd/hepa/Dockerfile
@@ -3,7 +3,7 @@
 #   podman build -f ./cmd/hepa/Dockerfile -t hepa .
 
 ### Compile stage
-FROM golang:1.22-alpine3.19 AS build-env
+FROM golang:1.23-alpine3.20 AS build-env
 RUN apk add --no-cache build-base make git
 
 ADD . /dockerbuild
@@ -15,7 +15,7 @@ RUN GIT_VERSION=$(git describe --tags --long --always) && \
     go build -tags timetzdata -o /hepa ./cmd/hepa
 
 ### Run stage
-FROM alpine:3.19
+FROM alpine:3.20
 
 RUN apk add --no-cache --update dumb-init ca-certificates
 ENTRYPOINT ["dumb-init", "--"]

--- a/cmd/palomar/Dockerfile
+++ b/cmd/palomar/Dockerfile
@@ -3,7 +3,7 @@
 #   podman build -f ./cmd/palomar/Dockerfile -t palomar .
 
 ### Compile stage
-FROM golang:1.22-alpine3.19 AS build-env
+FROM golang:1.23-alpine3.20 AS build-env
 RUN apk add --no-cache build-base make git
 
 ADD . /dockerbuild
@@ -15,7 +15,7 @@ RUN GIT_VERSION=$(git describe --tags --long --always) && \
     go build -tags timetzdata -o /palomar ./cmd/palomar
 
 ### Run stage
-FROM alpine:3.19
+FROM alpine:3.20
 
 RUN apk add --no-cache --update dumb-init ca-certificates
 ENTRYPOINT ["dumb-init", "--"]

--- a/cmd/rainbow/Dockerfile
+++ b/cmd/rainbow/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-bullseye AS build-env
+FROM golang:1.23-bullseye AS build-env
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC

--- a/cmd/sonar/Dockerfile
+++ b/cmd/sonar/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go binary
-FROM golang:1.22-alpine3.19 AS builder
+FROM golang:1.23-alpine3.20 AS builder
 
 # Install SSL ca certificates.
 RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates

--- a/cmd/supercollider/Dockerfile
+++ b/cmd/supercollider/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go binary
-FROM golang:1.22-alpine3.18 AS builder
+FROM golang:1.23-alpine3.20 AS builder
 
 # Create a directory for the application
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bluesky-social/indigo
 
-go 1.22
+go 1.23
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2


### PR DESCRIPTION
This is just periodic maintenance, there isn't anything specific in 1.23 we want/need.

go v1.24 is expected in February 2025; we usually wait a month or two before upgrading (though we didn't get around to 1.23 until now).

The newer `go vet` turned up some slog syntax issues.