### PR TITLE
goat: longer timeout for CAR export

### DIFF
--- a/cmd/goat/repo.go
+++ b/cmd/goat/repo.go
@@ -120,7 +120,7 @@ func runRepoExport(cctx *cli.Context) error {
 
 	// set longer timeout, for large CAR files
 	xrpcc.Client = util.RobustHTTPClient()
-	xrpcc.Client.Timeout = 180 * time.Second
+	xrpcc.Client.Timeout = 600 * time.Second
 
 	carPath := cctx.String("output")
 	if carPath == "" {

--- a/cmd/goat/repo.go
+++ b/cmd/goat/repo.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bluesky-social/indigo/repo"
 	"github.com/bluesky-social/indigo/util"
 	"github.com/bluesky-social/indigo/xrpc"
+
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	ipld "github.com/ipfs/go-ipld-format"
@@ -116,6 +117,10 @@ func runRepoExport(cctx *cli.Context) error {
 	if xrpcc.Host == "" {
 		return fmt.Errorf("no PDS endpoint for identity")
 	}
+
+	// set longer timeout, for large CAR files
+	xrpcc.Client = util.RobustHTTPClient()
+	xrpcc.Client.Timeout = 180 * time.Second
 
 	carPath := cctx.String("output")
 	if carPath == "" {


### PR DESCRIPTION
Closes: https://github.com/bluesky-social/indigo/issues/896

Suspect repo exports to crop up in other places, but can start with this here.