### PR TITLE
allow admin to add PDS that are ssl or not

### DIFF
--- a/bgs/fedmgr.go
+++ b/bgs/fedmgr.go
@@ -55,7 +55,7 @@ type Slurper struct {
 	shutdownChan   chan bool
 	shutdownResult chan []error
 
-	ssl bool
+	ssl SlurperSSLStance
 }
 
 type Limiters struct {
@@ -64,8 +64,71 @@ type Limiters struct {
 	PerDay    *slidingwindow.Limiter
 }
 
+type SlurperSSLStance int
+
+const (
+	// ALL upstreams must be wss:// and https://
+	SlurperRequireSSL SlurperSSLStance = 1
+
+	// NO upstreams may be wss:// and https://
+	SlurperDisableSSL SlurperSSLStance = 2
+
+	// Anything is allowed!
+	SlurperMixedSSL SlurperSSLStance = 3
+
+	// upstreams set by /admin/* may be anything, other things must be wss:// https://
+	SlurperRequireExternalSSL SlurperSSLStance = 4
+)
+
+// return true if an external requestCrawl meets SSL policy
+func (sssl SlurperSSLStance) ExternalOk(ssl bool) bool {
+	switch sssl {
+	case SlurperRequireSSL:
+		return ssl
+	case SlurperDisableSSL:
+		return !ssl
+	case SlurperRequireExternalSSL:
+		return ssl
+	case SlurperMixedSSL:
+		return true
+	default:
+		slog.Error("unknown ssl policy", "ssl", sssl)
+		return true
+	}
+}
+
+// return true if admin action meets SSL policy
+func (sssl SlurperSSLStance) AdminOk(ssl bool) bool {
+	switch sssl {
+	case SlurperRequireSSL:
+		return ssl
+	case SlurperDisableSSL:
+		return !ssl
+	case SlurperRequireExternalSSL, SlurperMixedSSL:
+		return true
+	default:
+		slog.Error("unknown ssl policy", "ssl", sssl)
+		return true
+	}
+}
+
+func (sssl SlurperSSLStance) String() string {
+	switch sssl {
+	case SlurperRequireSSL:
+		return "required"
+	case SlurperRequireExternalSSL:
+		return "external required"
+	case SlurperDisableSSL:
+		return "disabled"
+	case SlurperMixedSSL:
+		return "mixed"
+	default:
+		return fmt.Sprintf("slurper_ssl_%d", int(sssl))
+	}
+}
+
 type SlurperOptions struct {
-	SSL                   bool
+	SSL                   SlurperSSLStance
 	DefaultPerSecondLimit int64
 	DefaultPerHourLimit   int64
 	DefaultPerDayLimit    int64
@@ -77,7 +140,7 @@ type SlurperOptions struct {
 
 func DefaultSlurperOptions() *SlurperOptions {
 	return &SlurperOptions{
-		SSL:                   false,
+		SSL:                   SlurperDisableSSL,
 		DefaultPerSecondLimit: 50,
 		DefaultPerHourLimit:   2500,
 		DefaultPerDayLimit:    20_000,
@@ -363,7 +426,7 @@ func (s *Slurper) canSlurpHost(host string) bool {
 	return !s.newSubsDisabled
 }
 
-func (s *Slurper) SubscribeToPds(ctx context.Context, host string, reg bool, adminOverride bool, rateOverrides *PDSRates) error {
+func (s *Slurper) SubscribeToPds(ctx context.Context, host string, reg bool, adminOverride, sslUrl bool, rateOverrides *PDSRates) error {
 	// TODO: for performance, lock on the hostname instead of global
 	s.lk.Lock()
 	defer s.lk.Unlock()
@@ -389,7 +452,7 @@ func (s *Slurper) SubscribeToPds(ctx context.Context, host string, reg bool, adm
 		// New PDS!
 		npds := models.PDS{
 			Host:             host,
-			SSL:              s.ssl,
+			SSL:              sslUrl,
 			Registered:       reg,
 			RateLimit:        float64(s.DefaultPerSecondLimit),
 			HourlyEventLimit: s.DefaultPerHourLimit,
@@ -474,7 +537,7 @@ func (s *Slurper) subscribeWithRedialer(ctx context.Context, host *models.PDS, s
 	}
 
 	protocol := "ws"
-	if s.ssl {
+	if host.SSL {
 		protocol = "wss"
 	}
 

--- a/cmd/bigsky/main.go
+++ b/cmd/bigsky/main.go
@@ -99,6 +99,12 @@ func run(args []string) error {
 			Name:  "crawl-insecure-ws",
 			Usage: "when connecting to PDS instances, use ws:// instead of wss://",
 		},
+		&cli.StringFlag{
+			Name:    "crawl-ssl-policy",
+			Usage:   "when connecting to PDS instances, 'any' allows either ws:// or wss://, 'require' requires wss://, 'prod' requires wss:// of external requestCrawl hosts, 'none' rejects wss:// connections",
+			Value:   "prod",
+			EnvVars: []string{"RELAY_CRAWL_NONSSL"},
+		},
 		&cli.BoolFlag{
 			Name:    "spidering",
 			Value:   false,
@@ -506,12 +512,30 @@ func runBigsky(cctx *cli.Context) error {
 
 	slog.Info("constructing bgs")
 	bgsConfig := libbgs.DefaultBGSConfig()
-	bgsConfig.SSL = !cctx.Bool("crawl-insecure-ws")
+	switch strings.ToLower(cctx.String("crawl-ssl-policy")) {
+	case "any":
+		bgsConfig.SSL = libbgs.SlurperMixedSSL
+	case "none":
+		bgsConfig.SSL = libbgs.SlurperDisableSSL
+	case "require":
+		bgsConfig.SSL = libbgs.SlurperRequireSSL
+	case "prod":
+		bgsConfig.SSL = libbgs.SlurperRequireExternalSSL
+	case "":
+		if cctx.Bool("crawl-insecure-ws") {
+			bgsConfig.SSL = libbgs.SlurperDisableSSL
+		} else {
+			bgsConfig.SSL = libbgs.SlurperRequireSSL
+		}
+	default:
+		return fmt.Errorf("crawl-ssl-policy/RELAY_CRAWL_NONSSL exepected any|none|require|prod, got %s", cctx.String("crawl-ssl-policy"))
+	}
 	bgsConfig.CompactInterval = cctx.Duration("compact-interval")
 	bgsConfig.ConcurrencyPerPDS = cctx.Int64("concurrency-per-pds")
 	bgsConfig.MaxQueuePerPDS = cctx.Int64("max-queue-per-pds")
 	bgsConfig.DefaultRepoLimit = cctx.Int64("default-repo-limit")
 	bgsConfig.NumCompactionWorkers = cctx.Int("num-compaction-workers")
+	bgsConfig.VerboseAPILog = cctx.String("env") == "dev"
 	nextCrawlers := cctx.StringSlice("next-crawler")
 	if len(nextCrawlers) != 0 {
 		nextCrawlerUrls := make([]*url.URL, len(nextCrawlers))

--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,7 @@ require (
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/getsentry/sentry-go v0.27.0 // indirect
 	github.com/go-redis/redis v6.15.9+incompatible // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,9 @@ github.com/flosch/pongo2/v6 v6.0.0/go.mod h1:CuDpFm47R0uGGE7z13/tTlt1Y6zdxvr2RLT
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
+github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
 github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=

--- a/models/models.go
+++ b/models/models.go
@@ -119,6 +119,9 @@ type PDS struct {
 
 	HourlyEventLimit int64
 	DailyEventLimit  int64
+
+	// We accept events from this firehose source even if they are not from the origin PDS
+	RelayAllowed bool
 }
 
 func ClientForPds(pds *PDS) *xrpc.Client {

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -595,7 +595,7 @@ func SetupRelay(ctx context.Context, didr plc.PLCClient, archive bool) (*TestRel
 	tr := &api.TestHandleResolver{}
 
 	bgsConfig := bgs.DefaultBGSConfig()
-	bgsConfig.SSL = false
+	bgsConfig.SSL = bgs.SlurperDisableSSL
 	b, err := bgs.NewBGS(maindb, ix, repoman, evtman, didr, rf, tr, bgsConfig)
 	if err != nil {
 		return nil, err

--- a/ts/bgs-dash/src/components/Dash/Dash.tsx
+++ b/ts/bgs-dash/src/components/Dash/Dash.tsx
@@ -283,10 +283,11 @@ const Dash: FC<{}> = () => {
   }
 
   const requestCrawlHost = (host: string) => {
-    fetch(`${RELAY_HOST}/xrpc/com.atproto.sync.requestCrawl`, {
+    fetch(`${RELAY_HOST}/admin/pds/requestCrawl`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        Authorization: `Bearer ${adminToken}`,
       },
       body: JSON.stringify({
         hostname: host,
@@ -391,6 +392,7 @@ const Dash: FC<{}> = () => {
           per_day: pds.PerDayEventRate.Max,
           crawl_rate: pds.CrawlRate.Max,
           repo_limit: pds.RepoLimit,
+          relay_allowed: pds.RelayAllowed,
         }),
       }
     ).then((res) => {
@@ -866,6 +868,14 @@ const Dash: FC<{}> = () => {
                   scope="col"
                   className="px-3 py-3.5 text-right text-sm font-semibold text-gray-900 pr-6 whitespace-nowrap"
                 >
+                  <a href="#" className="group inline-flex">
+                    Allow Relay
+                  </a>
+                </th>
+                <th
+                  scope="col"
+                  className="px-3 py-3.5 text-right text-sm font-semibold text-gray-900 pr-6 whitespace-nowrap"
+                >
                   <a
                     href="#"
                     className="group inline-flex"
@@ -1280,6 +1290,18 @@ const Dash: FC<{}> = () => {
                             aria-hidden="true"
                           />
                         </a>
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-sm text-gray-400 text-center w-8 pr-6">
+                        <input
+                            type="checkbox"
+                            name={`relay-allow-${pds.ID}`}
+                            id={`relay-allow-${pds.ID}`}
+                            onChange={() => {
+                              pds.RelayAllowed = (document.getElementById(`relay-allow-${pds.ID}`) as HTMLInputElement).checked;
+                              updateRateLimits(pds);
+                            }}
+                            checked={pds.RelayAllowed}
+                        ></input>
                       </td>
                       <td className="whitespace-nowrap px-3 py-2 text-sm text-gray-400 text-center w-8 pr-6">
                         {new Date(Date.parse(pds.CreatedAt)).toLocaleString()}

--- a/ts/bgs-dash/src/models/pds.ts
+++ b/ts/bgs-dash/src/models/pds.ts
@@ -22,6 +22,7 @@ interface PDS {
   PerDayEventRate: RateLimit;
   RepoCount: number;
   RepoLimit: number;
+  RelayAllowed: boolean;
 }
 
 type PDSKey = keyof PDS;


### PR DESCRIPTION
BGS and Slurper allow mixed SSL or not upstreams
-crawl-ssl-policy|RELAY_CRAWL_NONSSL = any|require|none|prod
/admin/pds/crawl can add either; public requestCrawl normally SSL only
BGS AllowPDSProxies for nested relay setups
-allow-pds-proxy|RELAY_ALLOW_PDS_PROXY = true