### PR TITLE
remove automod "notifications event" support

### DIFF
--- a/automod/engine/context.go
+++ b/automod/engine/context.go
@@ -91,22 +91,6 @@ type OzoneEvent struct {
 	Event toolsozone.ModerationDefs_ModEventView_Event
 }
 
-// Originally intended for push notifications, but can also work for any inter-account notification.
-type NotificationContext struct {
-	AccountContext
-
-	Recipient    AccountMeta
-	Notification NotificationMeta
-}
-
-// Additional notification metadata, with fields aligning with the `app.bsky.notification.listNotifications` Lexicon schemas
-type NotificationMeta struct {
-	// Expected values are 'like', 'repost', 'follow', 'mention', 'reply', and 'quote'; arbitrary values may be added in the future.
-	Reason string
-	// The content (atproto record) which was the cause of this notification. Could be a post with a mention, or a like, follow, or repost record.
-	Subject syntax.ATURI
-}
-
 // Checks that op has expected fields, based on the action type
 func (op *RecordOp) Validate() error {
 	switch op.Action {
@@ -195,19 +179,6 @@ func NewRecordContext(ctx context.Context, eng *Engine, meta AccountMeta, op Rec
 	return RecordContext{
 		AccountContext: ac,
 		RecordOp:       op,
-	}
-}
-
-func NewNotificationContext(ctx context.Context, eng *Engine, sender, recipient AccountMeta, reason string, subject syntax.ATURI) NotificationContext {
-	ac := NewAccountContext(ctx, eng, sender)
-	ac.BaseContext.Logger = ac.BaseContext.Logger.With("recipient", recipient.Identity.DID, "reason", reason, "subject", subject.String())
-	return NotificationContext{
-		AccountContext: ac,
-		Recipient:      recipient,
-		Notification: NotificationMeta{
-			Reason:  reason,
-			Subject: subject,
-		},
 	}
 }
 
@@ -321,8 +292,4 @@ func (c *RecordContext) AcknowledgeRecord() {
 
 func (c *RecordContext) TakedownBlob(cid string) {
 	c.effects.TakedownBlob(cid)
-}
-
-func (c *NotificationContext) Reject() {
-	c.effects.Reject()
 }

--- a/automod/engine/ruleset.go
+++ b/automod/engine/ruleset.go
@@ -18,7 +18,6 @@ type RuleSet struct {
 	IdentityRules     []IdentityRuleFunc
 	AccountRules      []AccountRuleFunc
 	BlobRules         []BlobRuleFunc
-	NotificationRules []NotificationRuleFunc
 	OzoneEventRules   []OzoneEventRuleFunc
 }
 
@@ -96,16 +95,6 @@ func (r *RuleSet) CallAccountRules(c *AccountContext) error {
 		err := f(c)
 		if err != nil {
 			c.Logger.Error("account rule execution failed", "err", err)
-		}
-	}
-	return nil
-}
-
-func (r *RuleSet) CallNotificationRules(c *NotificationContext) error {
-	for _, f := range r.NotificationRules {
-		err := f(c)
-		if err != nil {
-			c.Logger.Error("notification rule execution failed", "err", err)
 		}
 	}
 	return nil

--- a/automod/engine/ruletypes.go
+++ b/automod/engine/ruletypes.go
@@ -11,5 +11,4 @@ type RecordRuleFunc = func(c *RecordContext) error
 type PostRuleFunc = func(c *RecordContext, post *appbsky.FeedPost) error
 type ProfileRuleFunc = func(c *RecordContext, profile *appbsky.ActorProfile) error
 type BlobRuleFunc = func(c *RecordContext, blob lexutil.LexBlob, data []byte) error
-type NotificationRuleFunc = func(c *NotificationContext) error
 type OzoneEventRuleFunc = func(c *OzoneEventContext) error

--- a/automod/pkg.go
+++ b/automod/pkg.go
@@ -18,7 +18,6 @@ type SlackNotifier = engine.SlackNotifier
 type AccountContext = engine.AccountContext
 type RecordContext = engine.RecordContext
 type OzoneEventContext = engine.OzoneEventContext
-type NotificationContext = engine.NotificationContext
 type RecordOp = engine.RecordOp
 
 type IdentityRuleFunc = engine.IdentityRuleFunc
@@ -26,7 +25,6 @@ type RecordRuleFunc = engine.RecordRuleFunc
 type PostRuleFunc = engine.PostRuleFunc
 type ProfileRuleFunc = engine.ProfileRuleFunc
 type BlobRuleFunc = engine.BlobRuleFunc
-type NotificationRuleFunc = engine.NotificationRuleFunc
 type OzoneEventRuleFunc = engine.OzoneEventRuleFunc
 
 var (

--- a/automod/rules/all.go
+++ b/automod/rules/all.go
@@ -56,9 +56,6 @@ func DefaultRules() automod.RuleSet {
 		BlobRules: []automod.BlobRuleFunc{
 			//BlobVerifyRule,
 		},
-		NotificationRules: []automod.NotificationRuleFunc{
-			// none
-		},
 		OzoneEventRules: []automod.OzoneEventRuleFunc{
 			HarassmentProtectionOzoneEventRule,
 		},


### PR DESCRIPTION
The idea was to integrate the automod framework with other services
which do push notifications. This never happened, and this code is
dead/untested, so removing for now.

This kind of functionality might be useful (we have lots of interaction
spam!) and could be pulled back in from git history if we ever need it.