### PR TITLE
goat: update to v3 of urfav/cli

### DIFF
--- a/cmd/goat/account_migrate.go
+++ b/cmd/goat/account_migrate.go
@@ -14,7 +14,7 @@ import (
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/bluesky-social/indigo/xrpc"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 var cmdAccountMigrate = &cli.Command{
@@ -25,25 +25,25 @@ var cmdAccountMigrate = &cli.Command{
 			Name:     "pds-host",
 			Usage:    "URL of the new PDS to create account on",
 			Required: true,
-			EnvVars:  []string{"ATP_PDS_HOST"},
+			Sources:  cli.EnvVars("ATP_PDS_HOST"),
 		},
 		&cli.StringFlag{
 			Name:     "new-handle",
 			Required: true,
 			Usage:    "handle on new PDS",
-			EnvVars:  []string{"NEW_ACCOUNT_HANDLE"},
+			Sources:  cli.EnvVars("NEW_ACCOUNT_HANDLE"),
 		},
 		&cli.StringFlag{
 			Name:     "new-password",
 			Required: true,
 			Usage:    "password on new PDS",
-			EnvVars:  []string{"NEW_ACCOUNT_PASSWORD"},
+			Sources:  cli.EnvVars("NEW_ACCOUNT_PASSWORD"),
 		},
 		&cli.StringFlag{
 			Name:     "plc-token",
 			Required: true,
 			Usage:    "token from old PDS authorizing token signature",
-			EnvVars:  []string{"PLC_SIGN_TOKEN"},
+			Sources:  cli.EnvVars("PLC_SIGN_TOKEN"),
 		},
 		&cli.StringFlag{
 			Name:  "invite-code",
@@ -57,9 +57,8 @@ var cmdAccountMigrate = &cli.Command{
 	Action: runAccountMigrate,
 }
 
-func runAccountMigrate(cctx *cli.Context) error {
+func runAccountMigrate(ctx context.Context, cmd *cli.Command) error {
 	// NOTE: this could check rev / commit before and after and ensure last-minute content additions get lost
-	ctx := context.Background()
 
 	oldClient, err := loadAuthClient(ctx)
 	if err == ErrNoAuthSession {
@@ -69,19 +68,19 @@ func runAccountMigrate(cctx *cli.Context) error {
 	}
 	did := oldClient.Auth.Did
 
-	newHostURL := cctx.String("pds-host")
+	newHostURL := cmd.String("pds-host")
 	if !strings.Contains(newHostURL, "://") {
 		return fmt.Errorf("PDS host is not a url: %s", newHostURL)
 	}
-	newHandle := cctx.String("new-handle")
+	newHandle := cmd.String("new-handle")
 	_, err = syntax.ParseHandle(newHandle)
 	if err != nil {
 		return err
 	}
-	newPassword := cctx.String("new-password")
-	plcToken := cctx.String("plc-token")
-	inviteCode := cctx.String("invite-code")
-	newEmail := cctx.String("new-email")
+	newPassword := cmd.String("new-password")
+	plcToken := cmd.String("plc-token")
+	inviteCode := cmd.String("invite-code")
+	newEmail := cmd.String("new-email")
 
 	newClient := xrpc.Client{
 		Host: newHostURL,

--- a/cmd/goat/account_plc.go
+++ b/cmd/goat/account_plc.go
@@ -9,13 +9,13 @@ import (
 	"github.com/bluesky-social/indigo/api/agnostic"
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 var cmdAccountPlc = &cli.Command{
 	Name:  "plc",
 	Usage: "sub-commands for managing PLC DID via PDS host",
-	Subcommands: []*cli.Command{
+	Commands: []*cli.Command{
 		&cli.Command{
 			Name:   "recommended",
 			Usage:  "list recommended DID fields for current account",
@@ -47,8 +47,7 @@ var cmdAccountPlc = &cli.Command{
 	},
 }
 
-func runAccountPlcRecommended(cctx *cli.Context) error {
-	ctx := context.Background()
+func runAccountPlcRecommended(ctx context.Context, cmd *cli.Command) error {
 
 	xrpcc, err := loadAuthClient(ctx)
 	if err == ErrNoAuthSession {
@@ -71,8 +70,7 @@ func runAccountPlcRecommended(cctx *cli.Context) error {
 	return nil
 }
 
-func runAccountPlcRequestToken(cctx *cli.Context) error {
-	ctx := context.Background()
+func runAccountPlcRequestToken(ctx context.Context, cmd *cli.Command) error {
 
 	xrpcc, err := loadAuthClient(ctx)
 	if err == ErrNoAuthSession {
@@ -90,10 +88,9 @@ func runAccountPlcRequestToken(cctx *cli.Context) error {
 	return nil
 }
 
-func runAccountPlcSign(cctx *cli.Context) error {
-	ctx := context.Background()
+func runAccountPlcSign(ctx context.Context, cmd *cli.Command) error {
 
-	opPath := cctx.Args().First()
+	opPath := cmd.Args().First()
 	if opPath == "" {
 		return fmt.Errorf("need to provide JSON file path as an argument")
 	}
@@ -115,7 +112,7 @@ func runAccountPlcSign(cctx *cli.Context) error {
 		return fmt.Errorf("failed decoding PLC op JSON: %w", err)
 	}
 
-	token := cctx.String("token")
+	token := cmd.String("token")
 	if token != "" {
 		body.Token = &token
 	}
@@ -134,10 +131,9 @@ func runAccountPlcSign(cctx *cli.Context) error {
 	return nil
 }
 
-func runAccountPlcSubmit(cctx *cli.Context) error {
-	ctx := context.Background()
+func runAccountPlcSubmit(ctx context.Context, cmd *cli.Command) error {
 
-	opPath := cctx.Args().First()
+	opPath := cmd.Args().First()
 	if opPath == "" {
 		return fmt.Errorf("need to provide JSON file path as an argument")
 	}

--- a/cmd/goat/blob.go
+++ b/cmd/goat/blob.go
@@ -10,14 +10,14 @@ import (
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/xrpc"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 var cmdBlob = &cli.Command{
 	Name:  "blob",
 	Usage: "sub-commands for blobs",
 	Flags: []cli.Flag{},
-	Subcommands: []*cli.Command{
+	Commands: []*cli.Command{
 		&cli.Command{
 			Name:      "export",
 			Usage:     "download all blobs for given account",
@@ -66,9 +66,8 @@ var cmdBlob = &cli.Command{
 	},
 }
 
-func runBlobExport(cctx *cli.Context) error {
-	ctx := context.Background()
-	username := cctx.Args().First()
+func runBlobExport(ctx context.Context, cmd *cli.Command) error {
+	username := cmd.Args().First()
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
@@ -77,7 +76,7 @@ func runBlobExport(cctx *cli.Context) error {
 		return err
 	}
 
-	pdsHost := cctx.String("pds-host")
+	pdsHost := cmd.String("pds-host")
 	if pdsHost == "" {
 		pdsHost = ident.PDSEndpoint()
 	}
@@ -90,7 +89,7 @@ func runBlobExport(cctx *cli.Context) error {
 		return fmt.Errorf("no PDS endpoint for identity")
 	}
 
-	topDir := cctx.String("output")
+	topDir := cmd.String("output")
 	if topDir == "" {
 		topDir = fmt.Sprintf("%s_blobs", username)
 	}
@@ -128,9 +127,8 @@ func runBlobExport(cctx *cli.Context) error {
 	return nil
 }
 
-func runBlobList(cctx *cli.Context) error {
-	ctx := context.Background()
-	username := cctx.Args().First()
+func runBlobList(ctx context.Context, cmd *cli.Command) error {
+	username := cmd.Args().First()
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
@@ -165,16 +163,15 @@ func runBlobList(cctx *cli.Context) error {
 	return nil
 }
 
-func runBlobDownload(cctx *cli.Context) error {
-	ctx := context.Background()
-	username := cctx.Args().First()
+func runBlobDownload(ctx context.Context, cmd *cli.Command) error {
+	username := cmd.Args().First()
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
-	if cctx.Args().Len() < 2 {
+	if cmd.Args().Len() < 2 {
 		return fmt.Errorf("need to provide blob CID as second argument")
 	}
-	blobCID := cctx.Args().Get(1)
+	blobCID := cmd.Args().Get(1)
 	ident, err := resolveIdent(ctx, username)
 	if err != nil {
 		return err
@@ -188,7 +185,7 @@ func runBlobDownload(cctx *cli.Context) error {
 		return fmt.Errorf("no PDS endpoint for identity")
 	}
 
-	blobPath := cctx.String("output")
+	blobPath := cmd.String("output")
 	if blobPath == "" {
 		blobPath = blobCID
 	}
@@ -205,9 +202,8 @@ func runBlobDownload(cctx *cli.Context) error {
 	return os.WriteFile(blobPath, blobBytes, 0666)
 }
 
-func runBlobUpload(cctx *cli.Context) error {
-	ctx := context.Background()
-	blobPath := cctx.Args().First()
+func runBlobUpload(ctx context.Context, cmd *cli.Command) error {
+	blobPath := cmd.Args().First()
 	if blobPath == "" {
 		return fmt.Errorf("need to provide file path as an argument")
 	}

--- a/cmd/goat/bsky.go
+++ b/cmd/goat/bsky.go
@@ -9,14 +9,14 @@ import (
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	lexutil "github.com/bluesky-social/indigo/lex/util"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 var cmdBsky = &cli.Command{
 	Name:  "bsky",
 	Usage: "sub-commands for bsky app",
 	Flags: []cli.Flag{},
-	Subcommands: []*cli.Command{
+	Commands: []*cli.Command{
 		&cli.Command{
 			Name:      "post",
 			Usage:     "create a post",
@@ -27,9 +27,8 @@ var cmdBsky = &cli.Command{
 	},
 }
 
-func runBskyPost(cctx *cli.Context) error {
-	ctx := context.Background()
-	text := cctx.Args().First()
+func runBskyPost(ctx context.Context, cmd *cli.Command) error {
+	text := cmd.Args().First()
 	if text == "" {
 		return fmt.Errorf("need to provide post text as argument")
 	}

--- a/cmd/goat/bsky_prefs.go
+++ b/cmd/goat/bsky_prefs.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/bluesky-social/indigo/api/agnostic"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 var cmdBskyPrefs = &cli.Command{
 	Name:  "prefs",
 	Usage: "sub-commands for preferences",
 	Flags: []cli.Flag{},
-	Subcommands: []*cli.Command{
+	Commands: []*cli.Command{
 		&cli.Command{
 			Name:   "export",
 			Usage:  "dump preferences out as JSON",
@@ -30,8 +30,7 @@ var cmdBskyPrefs = &cli.Command{
 	},
 }
 
-func runBskyPrefsExport(cctx *cli.Context) error {
-	ctx := context.Background()
+func runBskyPrefsExport(ctx context.Context, cmd *cli.Command) error {
 
 	xrpcc, err := loadAuthClient(ctx)
 	if err == ErrNoAuthSession {
@@ -55,9 +54,8 @@ func runBskyPrefsExport(cctx *cli.Context) error {
 	return nil
 }
 
-func runBskyPrefsImport(cctx *cli.Context) error {
-	ctx := context.Background()
-	prefsPath := cctx.Args().First()
+func runBskyPrefsImport(ctx context.Context, cmd *cli.Command) error {
+	prefsPath := cmd.Args().First()
 	if prefsPath == "" {
 		return fmt.Errorf("need to provide file path as an argument")
 	}

--- a/cmd/goat/crypto.go
+++ b/cmd/goat/crypto.go
@@ -1,17 +1,18 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bluesky-social/indigo/atproto/crypto"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 var cmdCrypto = &cli.Command{
 	Name:  "crypto",
 	Usage: "sub-commands for cryptographic keys",
-	Subcommands: []*cli.Command{
+	Commands: []*cli.Command{
 		&cli.Command{
 			Name:  "generate",
 			Usage: "outputs a new secret key",
@@ -32,8 +33,8 @@ var cmdCrypto = &cli.Command{
 	},
 }
 
-func runCryptoGenerate(cctx *cli.Context) error {
-	switch cctx.String("type") {
+func runCryptoGenerate(ctx context.Context, cmd *cli.Command) error {
+	switch cmd.String("type") {
 	case "", "P-256", "p256", "ES256", "secp256r1":
 		priv, err := crypto.GeneratePrivateKeyP256()
 		if err != nil {
@@ -47,7 +48,7 @@ func runCryptoGenerate(cctx *cli.Context) error {
 		}
 		fmt.Println(priv.Multibase())
 	default:
-		return fmt.Errorf("unknown key type: %s", cctx.String("type"))
+		return fmt.Errorf("unknown key type: %s", cmd.String("type"))
 	}
 	return nil
 }
@@ -67,8 +68,8 @@ func descKeyType(val interface{}) string {
 	}
 }
 
-func runCryptoInspect(cctx *cli.Context) error {
-	s := cctx.Args().First()
+func runCryptoInspect(ctx context.Context, cmd *cli.Command) error {
+	s := cmd.Args().First()
 	if s == "" {
 		return fmt.Errorf("need to provide key as an argument")
 	}

--- a/cmd/goat/firehose.go
+++ b/cmd/goat/firehose.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/carlmjohnson/versioninfo"
 	"github.com/gorilla/websocket"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 var cmdFirehose = &cli.Command{
@@ -33,7 +33,7 @@ var cmdFirehose = &cli.Command{
 			Name:    "relay-host",
 			Usage:   "method, hostname, and port of Relay instance (websocket)",
 			Value:   "wss://bsky.network",
-			EnvVars: []string{"ATP_RELAY_HOST"},
+			Sources: cli.EnvVars("ATP_RELAY_HOST"),
 		},
 		&cli.IntFlag{
 			Name:  "cursor",
@@ -66,20 +66,19 @@ type GoatFirehoseConsumer struct {
 	CollectionFilter []string
 }
 
-func runFirehose(cctx *cli.Context) error {
-	ctx := context.Background()
+func runFirehose(ctx context.Context, cmd *cli.Command) error {
 
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
 
 	gfc := GoatFirehoseConsumer{
 		EventLogger:      slog.New(slog.NewJSONHandler(os.Stdout, nil)),
-		OpsMode:          cctx.Bool("ops"),
-		AccountsOnly:     cctx.Bool("account-events"),
-		CollectionFilter: cctx.StringSlice("collection"),
+		OpsMode:          cmd.Bool("ops"),
+		AccountsOnly:     cmd.Bool("account-events"),
+		CollectionFilter: cmd.StringSlice("collection"),
 	}
 
-	relayHost := cctx.String("relay-host")
-	cursor := cctx.Int("cursor")
+	relayHost := cmd.String("relay-host")
+	cursor := cmd.Int("cursor")
 
 	dialer := websocket.DefaultDialer
 	u, err := url.Parse(relayHost)

--- a/cmd/goat/identity.go
+++ b/cmd/goat/identity.go
@@ -8,7 +8,7 @@ import (
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 var cmdResolve = &cli.Command{
@@ -24,9 +24,8 @@ var cmdResolve = &cli.Command{
 	Action: runResolve,
 }
 
-func runResolve(cctx *cli.Context) error {
-	ctx := context.Background()
-	s := cctx.Args().First()
+func runResolve(ctx context.Context, cmd *cli.Command) error {
+	s := cmd.Args().First()
 	if s == "" {
 		return fmt.Errorf("need to provide account identifier as an argument")
 	}
@@ -38,7 +37,7 @@ func runResolve(cctx *cli.Context) error {
 	dir := identity.BaseDirectory{}
 	var doc *identity.DIDDocument
 
-	if cctx.Bool("did") {
+	if cmd.Bool("did") {
 		if atid.IsDID() {
 		}
 	}
@@ -48,7 +47,7 @@ func runResolve(cctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		if cctx.Bool("did") {
+		if cmd.Bool("did") {
 			fmt.Println(did)
 			return nil
 		}
@@ -65,7 +64,7 @@ func runResolve(cctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		if cctx.Bool("did") {
+		if cmd.Bool("did") {
 			fmt.Println(did)
 			return nil
 		}

--- a/cmd/goat/main.go
+++ b/cmd/goat/main.go
@@ -1,13 +1,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	_ "github.com/joho/godotenv/autoload"
 
 	"github.com/carlmjohnson/versioninfo"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 func main() {
@@ -19,7 +20,7 @@ func main() {
 
 func run(args []string) error {
 
-	app := cli.App{
+	app := cli.Command{
 		Name:    "goat",
 		Usage:   "Go AT protocol CLI tool",
 		Version: versioninfo.Short(),
@@ -40,5 +41,5 @@ func run(args []string) error {
 		cmdCrypto,
 		cmdPds,
 	}
-	return app.Run(args)
+	return app.Run(context.Background(), args)
 }

--- a/cmd/goat/pds.go
+++ b/cmd/goat/pds.go
@@ -9,14 +9,14 @@ import (
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/xrpc"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 var cmdPds = &cli.Command{
 	Name:  "pds",
 	Usage: "sub-commands for pds hosts",
 	Flags: []cli.Flag{},
-	Subcommands: []*cli.Command{
+	Commands: []*cli.Command{
 		&cli.Command{
 			Name:      "describe",
 			Usage:     "shows info about a PDS info",
@@ -26,10 +26,9 @@ var cmdPds = &cli.Command{
 	},
 }
 
-func runPdsDescribe(cctx *cli.Context) error {
-	ctx := context.Background()
+func runPdsDescribe(ctx context.Context, cmd *cli.Command) error {
 
-	pdsHost := cctx.Args().First()
+	pdsHost := cmd.Args().First()
 	if pdsHost == "" {
 		return fmt.Errorf("need to provide new handle as argument")
 	}

--- a/cmd/goat/plc.go
+++ b/cmd/goat/plc.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 var cmdPLC = &cli.Command{
@@ -24,7 +24,7 @@ var cmdPLC = &cli.Command{
 			Value: "https://plc.directory",
 		},
 	},
-	Subcommands: []*cli.Command{
+	Commands: []*cli.Command{
 		cmdPLCHistory,
 		cmdPLCDump,
 	},
@@ -38,10 +38,9 @@ var cmdPLCHistory = &cli.Command{
 	Action:    runPLCHistory,
 }
 
-func runPLCHistory(cctx *cli.Context) error {
-	ctx := context.Background()
-	plcURL := cctx.String("plc-directory")
-	s := cctx.Args().First()
+func runPLCHistory(ctx context.Context, cmd *cli.Command) error {
+	plcURL := cmd.String("plc-directory")
+	s := cmd.Args().First()
 	if s == "" {
 		return fmt.Errorf("need to provide account identifier as an argument")
 	}
@@ -120,13 +119,12 @@ var cmdPLCDump = &cli.Command{
 	Action: runPLCDump,
 }
 
-func runPLCDump(cctx *cli.Context) error {
-	ctx := context.Background()
-	plcURL := cctx.String("plc-directory")
+func runPLCDump(ctx context.Context, cmd *cli.Command) error {
+	plcURL := cmd.String("plc-directory")
 	client := http.DefaultClient
-	tailMode := cctx.Bool("tail")
+	tailMode := cmd.Bool("tail")
 
-	cursor := cctx.String("cursor")
+	cursor := cmd.String("cursor")
 	if cursor == "now" {
 		cursor = syntax.DatetimeNow().String()
 	}

--- a/cmd/goat/repo.go
+++ b/cmd/goat/repo.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ipfs/go-cid"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	ipld "github.com/ipfs/go-ipld-format"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 	"github.com/xlab/treeprint"
 )
 
@@ -30,7 +30,7 @@ var cmdRepo = &cli.Command{
 	Name:  "repo",
 	Usage: "sub-commands for repositories",
 	Flags: []cli.Flag{},
-	Subcommands: []*cli.Command{
+	Commands: []*cli.Command{
 		&cli.Command{
 			Name:      "export",
 			Usage:     "download CAR file for given account",
@@ -99,9 +99,8 @@ var cmdRepo = &cli.Command{
 	},
 }
 
-func runRepoExport(cctx *cli.Context) error {
-	ctx := context.Background()
-	username := cctx.Args().First()
+func runRepoExport(ctx context.Context, cmd *cli.Command) error {
+	username := cmd.Args().First()
 	if username == "" {
 		return fmt.Errorf("need to provide username as an argument")
 	}
@@ -122,7 +121,7 @@ func runRepoExport(cctx *cli.Context) error {
 	xrpcc.Client = util.RobustHTTPClient()
 	xrpcc.Client.Timeout = 600 * time.Second
 
-	carPath := cctx.String("output")
+	carPath := cmd.String("output")
 	if carPath == "" {
 		// NOTE: having the rev in the the path might be nice
 		now := time.Now().Format("20060102150405")
@@ -149,10 +148,9 @@ func runRepoExport(cctx *cli.Context) error {
 	return nil
 }
 
-func runRepoImport(cctx *cli.Context) error {
-	ctx := context.Background()
+func runRepoImport(ctx context.Context, cmd *cli.Command) error {
 
-	carPath := cctx.Args().First()
+	carPath := cmd.Args().First()
 	if carPath == "" {
 		return fmt.Errorf("need to provide CAR file path as an argument")
 	}
@@ -177,9 +175,8 @@ func runRepoImport(cctx *cli.Context) error {
 	return nil
 }
 
-func runRepoList(cctx *cli.Context) error {
-	ctx := context.Background()
-	carPath := cctx.Args().First()
+func runRepoList(ctx context.Context, cmd *cli.Command) error {
+	carPath := cmd.Args().First()
 	if carPath == "" {
 		return fmt.Errorf("need to provide path to CAR file as argument")
 	}
@@ -204,9 +201,8 @@ func runRepoList(cctx *cli.Context) error {
 	return nil
 }
 
-func runRepoInspect(cctx *cli.Context) error {
-	ctx := context.Background()
-	carPath := cctx.Args().First()
+func runRepoInspect(ctx context.Context, cmd *cli.Command) error {
+	carPath := cmd.Args().First()
 	if carPath == "" {
 		return fmt.Errorf("need to provide path to CAR file as argument")
 	}
@@ -232,12 +228,11 @@ func runRepoInspect(cctx *cli.Context) error {
 	return nil
 }
 
-func runRepoMST(cctx *cli.Context) error {
-	ctx := context.Background()
+func runRepoMST(ctx context.Context, cmd *cli.Command) error {
 	opts := repoMSTOptions{
-		carPath: cctx.Args().First(),
-		fullCID: cctx.Bool("full-cid"),
-		root:    cctx.String("root"),
+		carPath: cmd.Args().First(),
+		fullCID: cmd.Bool("full-cid"),
+		root:    cmd.String("root"),
 	}
 	// read from file or stdin
 	if opts.carPath == "" {
@@ -354,9 +349,8 @@ func nodeExists(ctx context.Context, cst *cbor.BasicIpldStore, cid cid.Cid) (boo
 	return true, nil
 }
 
-func runRepoUnpack(cctx *cli.Context) error {
-	ctx := context.Background()
-	carPath := cctx.Args().First()
+func runRepoUnpack(ctx context.Context, cmd *cli.Command) error {
+	carPath := cmd.Args().First()
 	if carPath == "" {
 		return fmt.Errorf("need to provide path to CAR file as argument")
 	}
@@ -377,7 +371,7 @@ func runRepoUnpack(cctx *cli.Context) error {
 		return err
 	}
 
-	topDir := cctx.String("output")
+	topDir := cmd.String("output")
 	if topDir == "" {
 		topDir = did.String()
 	}

--- a/cmd/goat/syntax.go
+++ b/cmd/goat/syntax.go
@@ -1,22 +1,23 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 var cmdSyntax = &cli.Command{
 	Name:  "syntax",
 	Usage: "sub-commands for string syntax helpers",
-	Subcommands: []*cli.Command{
+	Commands: []*cli.Command{
 		&cli.Command{
 			Name:  "tid",
 			Usage: "sub-commands for TIDs",
-			Subcommands: []*cli.Command{
+			Commands: []*cli.Command{
 				&cli.Command{
 					Name:      "check",
 					Usage:     "validates TID syntax",
@@ -40,7 +41,7 @@ var cmdSyntax = &cli.Command{
 		&cli.Command{
 			Name:  "handle",
 			Usage: "sub-commands for handle syntax",
-			Subcommands: []*cli.Command{
+			Commands: []*cli.Command{
 				&cli.Command{
 					Name:      "check",
 					Usage:     "validates handle syntax",
@@ -52,7 +53,7 @@ var cmdSyntax = &cli.Command{
 		&cli.Command{
 			Name:  "did",
 			Usage: "sub-commands for DID syntax",
-			Subcommands: []*cli.Command{
+			Commands: []*cli.Command{
 				&cli.Command{
 					Name:      "check",
 					Usage:     "validates DID syntax",
@@ -64,7 +65,7 @@ var cmdSyntax = &cli.Command{
 		&cli.Command{
 			Name:  "rkey",
 			Usage: "sub-commands for record key syntax",
-			Subcommands: []*cli.Command{
+			Commands: []*cli.Command{
 				&cli.Command{
 					Name:      "check",
 					Usage:     "validates record key syntax",
@@ -76,7 +77,7 @@ var cmdSyntax = &cli.Command{
 		&cli.Command{
 			Name:  "nsid",
 			Usage: "sub-commands for NSID syntax",
-			Subcommands: []*cli.Command{
+			Commands: []*cli.Command{
 				&cli.Command{
 					Name:      "check",
 					Usage:     "validates NSID syntax",
@@ -88,7 +89,7 @@ var cmdSyntax = &cli.Command{
 		&cli.Command{
 			Name:  "at-uri",
 			Usage: "sub-commands for AT-URI syntax",
-			Subcommands: []*cli.Command{
+			Commands: []*cli.Command{
 				&cli.Command{
 					Name:      "check",
 					Usage:     "validates AT-URI syntax",
@@ -100,8 +101,8 @@ var cmdSyntax = &cli.Command{
 	},
 }
 
-func runSyntaxTIDCheck(cctx *cli.Context) error {
-	s := cctx.Args().First()
+func runSyntaxTIDCheck(ctx context.Context, cmd *cli.Command) error {
+	s := cmd.Args().First()
 	if s == "" {
 		return fmt.Errorf("need to provide identifier as argument")
 	}
@@ -113,13 +114,13 @@ func runSyntaxTIDCheck(cctx *cli.Context) error {
 	return nil
 }
 
-func runSyntaxTIDGenerate(cctx *cli.Context) error {
+func runSyntaxTIDGenerate(ctx context.Context, cmd *cli.Command) error {
 	fmt.Printf("%s\n", syntax.NewTIDNow(0).String())
 	return nil
 }
 
-func runSyntaxTIDInspect(cctx *cli.Context) error {
-	s := cctx.Args().First()
+func runSyntaxTIDInspect(ctx context.Context, cmd *cli.Command) error {
+	s := cmd.Args().First()
 	if s == "" {
 		return fmt.Errorf("need to provide identifier as argument")
 	}
@@ -134,8 +135,8 @@ func runSyntaxTIDInspect(cctx *cli.Context) error {
 	return nil
 }
 
-func runSyntaxRecordKeyCheck(cctx *cli.Context) error {
-	s := cctx.Args().First()
+func runSyntaxRecordKeyCheck(ctx context.Context, cmd *cli.Command) error {
+	s := cmd.Args().First()
 	if s == "" {
 		return fmt.Errorf("need to provide identifier as argument")
 	}
@@ -147,8 +148,8 @@ func runSyntaxRecordKeyCheck(cctx *cli.Context) error {
 	return nil
 }
 
-func runSyntaxDIDCheck(cctx *cli.Context) error {
-	s := cctx.Args().First()
+func runSyntaxDIDCheck(ctx context.Context, cmd *cli.Command) error {
+	s := cmd.Args().First()
 	if s == "" {
 		return fmt.Errorf("need to provide identifier as argument")
 	}
@@ -159,8 +160,8 @@ func runSyntaxDIDCheck(cctx *cli.Context) error {
 	fmt.Println("valid")
 	return nil
 }
-func runSyntaxHandleCheck(cctx *cli.Context) error {
-	s := cctx.Args().First()
+func runSyntaxHandleCheck(ctx context.Context, cmd *cli.Command) error {
+	s := cmd.Args().First()
 	if s == "" {
 		return fmt.Errorf("need to provide identifier as argument")
 	}
@@ -172,8 +173,8 @@ func runSyntaxHandleCheck(cctx *cli.Context) error {
 	return nil
 }
 
-func runSyntaxNSIDCheck(cctx *cli.Context) error {
-	s := cctx.Args().First()
+func runSyntaxNSIDCheck(ctx context.Context, cmd *cli.Command) error {
+	s := cmd.Args().First()
 	if s == "" {
 		return fmt.Errorf("need to provide identifier as argument")
 	}
@@ -185,8 +186,8 @@ func runSyntaxNSIDCheck(cctx *cli.Context) error {
 	return nil
 }
 
-func runSyntaxATURICheck(cctx *cli.Context) error {
-	s := cctx.Args().First()
+func runSyntaxATURICheck(ctx context.Context, cmd *cli.Command) error {
+	s := cmd.Args().First()
 	if s == "" {
 		return fmt.Errorf("need to provide identifier as argument")
 	}

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/samber/slog-echo v1.8.0
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.25.7
+	github.com/urfave/cli/v3 v3.0.0-beta1
 	github.com/whyrusleeping/cbor-gen v0.2.1-0.20241030202151-b7a6831be65e
 	github.com/whyrusleeping/go-did v0.0.0-20230824162731-404d1707d5d6
 	github.com/xlab/treeprint v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -637,6 +637,8 @@ github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807/go.mod h1:7jxm
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.25.7 h1:VAzn5oq403l5pHjc4OhD54+XGO9cdKVL/7lDjF+iKUs=
 github.com/urfave/cli/v2 v2.25.7/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=
+github.com/urfave/cli/v3 v3.0.0-beta1 h1:6DTaaUarcM0wX7qj5Hcvs+5Dm3dyUTBbEwIWAjcw9Zg=
+github.com/urfave/cli/v3 v3.0.0-beta1/go.mod h1:FnIeEMYu+ko8zP1F9Ypr3xkZMIDqW3DR92yUtY39q1Y=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=


### PR DESCRIPTION
Transition guide here: https://cli.urfave.org/migrate-v2-to-v3/

Overall updates are good/fine, but the big win and motivation here is finally having CLI arg parsing order be more flexible.

Eg:

```shell
# --did is a boolean flag

goat resolve --did atproto.com
goat resolve atproto.com --did
```

In v2, only the first is allowed, while with v3 the later works.

I'll probably do this update/refactor across all our commands soon.