### PR TITLE
Hydrate DeleteRecords events with deleted Record

### DIFF
--- a/cmd/bigsky/main.go
+++ b/cmd/bigsky/main.go
@@ -482,7 +482,7 @@ func runBigsky(cctx *cli.Context) error {
 		if err := ix.HandleRepoEvent(ctx, evt); err != nil {
 			slog.Error("failed to handle repo event", "err", err)
 		}
-	}, false)
+	}, true)
 
 	prodHR, err := api.NewProdHandleResolver(100_000, cctx.String("resolve-address"), cctx.Bool("force-dns-udp"))
 	if err != nil {


### PR DESCRIPTION
To enable Firehose users to action deleted records without necessarily storing the records being deleted (e.g. by decrementing counters, etc.), we include the record being deleted in the Firehose.

This is only enabled when `hydrateRecords` is enabled, as per `UpdateRecords`.

Currently, BigSky has `hydrateRecords` set to `false`. We set this to `true` so that the Firehose provided by BigSky hydrates records for `update` and `delete` events.

Closes #927