### PR TITLE
agnostic: default putRecord to not include swapRecord field

### DIFF
--- a/api/agnostic/repoputRecord.go
+++ b/api/agnostic/repoputRecord.go
@@ -23,7 +23,7 @@ type RepoPutRecord_Input struct {
 	// swapCommit: Compare and swap with the previous commit by CID.
 	SwapCommit *string `json:"swapCommit,omitempty" cborgen:"swapCommit,omitempty"`
 	// swapRecord: Compare and swap with the previous record by CID. WARNING: nullable and optional field; may cause problems with golang implementation
-	SwapRecord *string `json:"swapRecord" cborgen:"swapRecord"`
+	SwapRecord *string `json:"swapRecord,omitempty" cborgen:"swapRecord,omitempty"`
 	// validate: Can be set to 'false' to skip Lexicon schema validation of record data, 'true' to require it, or leave unset to validate only for known Lexicons.
 	Validate *bool `json:"validate,omitempty" cborgen:"validate,omitempty"`
 }


### PR DESCRIPTION
The root issue here is "nullable and optional" not being easy to express with default golang struct marshaling. The result is this swap field getting set, but as null, which prevents actual updates (only allows creation).

This PR swaps to omitting the field. Makes it impossible to do a forced swap check of nil... but can just use create for that?