### PR TITLE
atproto/repo: new SDK package supporting inductive firehose

### DIFF
--- a/api/atproto/cbor_gen.go
+++ b/api/atproto/cbor_gen.go
@@ -343,9 +343,13 @@ func (t *SyncSubscribeRepos_Commit) MarshalCBOR(w io.Writer) error {
 	}
 
 	cw := cbg.NewCborWriter(w)
-	fieldCount := 12
+	fieldCount := 13
 
 	if t.Blocks == nil {
+		fieldCount--
+	}
+
+	if t.PrevData == nil {
 		fieldCount--
 	}
 
@@ -616,6 +620,25 @@ func (t *SyncSubscribeRepos_Commit) MarshalCBOR(w io.Writer) error {
 	if err := cbg.WriteBool(w, t.TooBig); err != nil {
 		return err
 	}
+
+	// t.PrevData (util.LexLink) (struct)
+	if t.PrevData != nil {
+
+		if len("prevData") > 1000000 {
+			return xerrors.Errorf("Value in field \"prevData\" was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("prevData"))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string("prevData")); err != nil {
+			return err
+		}
+
+		if err := t.PrevData.MarshalCBOR(cw); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -644,7 +667,7 @@ func (t *SyncSubscribeRepos_Commit) UnmarshalCBOR(r io.Reader) (err error) {
 
 	n := extra
 
-	nameBuf := make([]byte, 6)
+	nameBuf := make([]byte, 8)
 	for i := uint64(0); i < n; i++ {
 		nameLen, ok, err := cbg.ReadFullStringIntoBuf(cr, nameBuf, 1000000)
 		if err != nil {
@@ -916,6 +939,26 @@ func (t *SyncSubscribeRepos_Commit) UnmarshalCBOR(r io.Reader) (err error) {
 				t.TooBig = true
 			default:
 				return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+			}
+			// t.PrevData (util.LexLink) (struct)
+		case "prevData":
+
+			{
+
+				b, err := cr.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := cr.UnreadByte(); err != nil {
+						return err
+					}
+					t.PrevData = new(util.LexLink)
+					if err := t.PrevData.UnmarshalCBOR(cr); err != nil {
+						return xerrors.Errorf("unmarshaling t.PrevData pointer: %w", err)
+					}
+				}
+
 			}
 
 		default:
@@ -2055,8 +2098,13 @@ func (t *SyncSubscribeRepos_RepoOp) MarshalCBOR(w io.Writer) error {
 	}
 
 	cw := cbg.NewCborWriter(w)
+	fieldCount := 4
 
-	if _, err := cw.Write([]byte{163}); err != nil {
+	if t.Prev == nil {
+		fieldCount--
+	}
+
+	if _, err := cw.Write(cbg.CborEncodeMajorType(cbg.MajMap, uint64(fieldCount))); err != nil {
 		return err
 	}
 
@@ -2097,6 +2145,25 @@ func (t *SyncSubscribeRepos_RepoOp) MarshalCBOR(w io.Writer) error {
 	}
 	if _, err := cw.WriteString(string(t.Path)); err != nil {
 		return err
+	}
+
+	// t.Prev (util.LexLink) (struct)
+	if t.Prev != nil {
+
+		if len("prev") > 1000000 {
+			return xerrors.Errorf("Value in field \"prev\" was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("prev"))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string("prev")); err != nil {
+			return err
+		}
+
+		if err := t.Prev.MarshalCBOR(cw); err != nil {
+			return err
+		}
 	}
 
 	// t.Action (string) (string)
@@ -2195,6 +2262,26 @@ func (t *SyncSubscribeRepos_RepoOp) UnmarshalCBOR(r io.Reader) (err error) {
 				}
 
 				t.Path = string(sval)
+			}
+			// t.Prev (util.LexLink) (struct)
+		case "prev":
+
+			{
+
+				b, err := cr.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := cr.UnreadByte(); err != nil {
+						return err
+					}
+					t.Prev = new(util.LexLink)
+					if err := t.Prev.UnmarshalCBOR(cr); err != nil {
+						return xerrors.Errorf("unmarshaling t.Prev pointer: %w", err)
+					}
+				}
+
 			}
 			// t.Action (string) (string)
 		case "action":

--- a/api/atproto/syncsubscribeRepos.go
+++ b/api/atproto/syncsubscribeRepos.go
@@ -29,8 +29,10 @@ type SyncSubscribeRepos_Commit struct {
 	// blocks: CAR file containing relevant blocks, as a diff since the previous repo state.
 	Blocks util.LexBytes `json:"blocks,omitempty" cborgen:"blocks,omitempty"`
 	// commit: Repo commit object CID.
-	Commit util.LexLink                 `json:"commit" cborgen:"commit"`
-	Ops    []*SyncSubscribeRepos_RepoOp `json:"ops" cborgen:"ops"`
+	Commit util.LexLink `json:"commit" cborgen:"commit"`
+	// prevData
+	PrevData *util.LexLink                `json:"prevData,omitempty" cborgen:"prevData,omitempty"`
+	Ops      []*SyncSubscribeRepos_RepoOp `json:"ops" cborgen:"ops"`
 	// prev: DEPRECATED -- unused. WARNING -- nullable and optional; stick with optional to ensure golang interoperability.
 	Prev *util.LexLink `json:"prev" cborgen:"prev"`
 	// rebase: DEPRECATED -- unused
@@ -92,7 +94,9 @@ type SyncSubscribeRepos_Migrate struct {
 type SyncSubscribeRepos_RepoOp struct {
 	Action string `json:"action" cborgen:"action"`
 	// cid: For creates and updates, the new record CID. For deletions, null.
-	Cid  *util.LexLink `json:"cid" cborgen:"cid"`
+	Cid *util.LexLink `json:"cid" cborgen:"cid"`
+	// prev
+	Prev *util.LexLink `json:"prev,omitempty" cborgen:"prev,omitempty"`
 	Path string        `json:"path" cborgen:"path"`
 }
 

--- a/atproto/repo/car.go
+++ b/atproto/repo/car.go
@@ -62,9 +62,10 @@ func LoadFromCAR(ctx context.Context, r io.Reader) (*Repo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading MST from CAR file: %w", err)
 	}
+	clk := syntax.ClockFromTID(syntax.TID(commit.Rev))
 	repo := Repo{
-		DID:         syntax.DID(commit.DID), // VerifyStructure() verified syntax
-		Clock:       syntax.NewTIDClock(0),  // TODO: initialize with commit.Rev
+		DID:         syntax.DID(commit.DID), // NOTE: VerifyStructure() already checked DID syntax
+		Clock:       &clk,
 		Commit:      &commit,
 		MST:         *tree,
 		RecordStore: bs, // TODO: put just records in a smaller blockstore?

--- a/atproto/repo/cbor_gen.go
+++ b/atproto/repo/cbor_gen.go
@@ -25,13 +25,8 @@ func (t *Commit) MarshalCBOR(w io.Writer) error {
 	}
 
 	cw := cbg.NewCborWriter(w)
-	fieldCount := 6
 
-	if t.Rev == "" {
-		fieldCount--
-	}
-
-	if _, err := cw.Write(cbg.CborEncodeMajorType(cbg.MajMap, uint64(fieldCount))); err != nil {
+	if _, err := cw.Write([]byte{166}); err != nil {
 		return err
 	}
 
@@ -59,29 +54,26 @@ func (t *Commit) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Rev (string) (string)
-	if t.Rev != "" {
+	if len("rev") > 1000000 {
+		return xerrors.Errorf("Value in field \"rev\" was too long")
+	}
 
-		if len("rev") > 1000000 {
-			return xerrors.Errorf("Value in field \"rev\" was too long")
-		}
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("rev"))); err != nil {
+		return err
+	}
+	if _, err := cw.WriteString(string("rev")); err != nil {
+		return err
+	}
 
-		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("rev"))); err != nil {
-			return err
-		}
-		if _, err := cw.WriteString(string("rev")); err != nil {
-			return err
-		}
+	if len(t.Rev) > 1000000 {
+		return xerrors.Errorf("Value in field t.Rev was too long")
+	}
 
-		if len(t.Rev) > 1000000 {
-			return xerrors.Errorf("Value in field t.Rev was too long")
-		}
-
-		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Rev))); err != nil {
-			return err
-		}
-		if _, err := cw.WriteString(string(t.Rev)); err != nil {
-			return err
-		}
+	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Rev))); err != nil {
+		return err
+	}
+	if _, err := cw.WriteString(string(t.Rev)); err != nil {
+		return err
 	}
 
 	// t.Sig ([]uint8) (slice)

--- a/atproto/repo/cbor_gen.go
+++ b/atproto/repo/cbor_gen.go
@@ -25,8 +25,17 @@ func (t *Commit) MarshalCBOR(w io.Writer) error {
 	}
 
 	cw := cbg.NewCborWriter(w)
+	fieldCount := 6
 
-	if _, err := cw.Write([]byte{166}); err != nil {
+	if t.Sig == nil {
+		fieldCount--
+	}
+
+	if t.Rev == "" {
+		fieldCount--
+	}
+
+	if _, err := cw.Write(cbg.CborEncodeMajorType(cbg.MajMap, uint64(fieldCount))); err != nil {
 		return err
 	}
 
@@ -54,50 +63,57 @@ func (t *Commit) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Rev (string) (string)
-	if len("rev") > 1000000 {
-		return xerrors.Errorf("Value in field \"rev\" was too long")
-	}
+	if t.Rev != "" {
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("rev"))); err != nil {
-		return err
-	}
-	if _, err := cw.WriteString(string("rev")); err != nil {
-		return err
-	}
+		if len("rev") > 1000000 {
+			return xerrors.Errorf("Value in field \"rev\" was too long")
+		}
 
-	if len(t.Rev) > 1000000 {
-		return xerrors.Errorf("Value in field t.Rev was too long")
-	}
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("rev"))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string("rev")); err != nil {
+			return err
+		}
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Rev))); err != nil {
-		return err
-	}
-	if _, err := cw.WriteString(string(t.Rev)); err != nil {
-		return err
+		if len(t.Rev) > 1000000 {
+			return xerrors.Errorf("Value in field t.Rev was too long")
+		}
+
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len(t.Rev))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string(t.Rev)); err != nil {
+			return err
+		}
 	}
 
 	// t.Sig ([]uint8) (slice)
-	if len("sig") > 1000000 {
-		return xerrors.Errorf("Value in field \"sig\" was too long")
-	}
+	if t.Sig != nil {
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("sig"))); err != nil {
-		return err
-	}
-	if _, err := cw.WriteString(string("sig")); err != nil {
-		return err
-	}
+		if len("sig") > 1000000 {
+			return xerrors.Errorf("Value in field \"sig\" was too long")
+		}
 
-	if len(t.Sig) > 2097152 {
-		return xerrors.Errorf("Byte array in field t.Sig was too long")
-	}
+		if err := cw.WriteMajorTypeHeader(cbg.MajTextString, uint64(len("sig"))); err != nil {
+			return err
+		}
+		if _, err := cw.WriteString(string("sig")); err != nil {
+			return err
+		}
 
-	if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.Sig))); err != nil {
-		return err
-	}
+		if len(t.Sig) > 2097152 {
+			return xerrors.Errorf("Byte array in field t.Sig was too long")
+		}
 
-	if _, err := cw.Write(t.Sig); err != nil {
-		return err
+		if err := cw.WriteMajorTypeHeader(cbg.MajByteString, uint64(len(t.Sig))); err != nil {
+			return err
+		}
+
+		if _, err := cw.Write(t.Sig); err != nil {
+			return err
+		}
+
 	}
 
 	// t.Data (cid.Cid) (struct)

--- a/atproto/repo/cmd/repo-tool/main.go
+++ b/atproto/repo/cmd/repo-tool/main.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/repo"
+	"github.com/bluesky-social/indigo/atproto/syntax"
 
 	"github.com/urfave/cli/v2"
 )
@@ -31,6 +33,12 @@ func main() {
 			Usage:     "load a CAR file and check the MST tree",
 			ArgsUsage: "<path>",
 			Action:    runVerifyCarMst,
+		},
+		&cli.Command{
+			Name:      "verify-car-signature",
+			Usage:     "load a CAR file and check the commit message signature",
+			ArgsUsage: "<path>",
+			Action:    runVerifyCarSignature,
 		},
 		&cli.Command{
 			Name:   "verify-firehose",
@@ -99,5 +107,48 @@ func runVerifyCarMst(cctx *cli.Context) error {
 		return fmt.Errorf("failed to re-compute: %s != %s", computedCID, commit.Data)
 	}
 	fmt.Println("verified tree")
+	return nil
+}
+
+func runVerifyCarSignature(cctx *cli.Context) error {
+	ctx := context.Background()
+	dir := identity.DefaultDirectory()
+
+	p := cctx.Args().First()
+	if p == "" {
+		return fmt.Errorf("need to provide path to CAR file")
+	}
+
+	f, err := os.Open(p)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	commit, _, err := repo.LoadFromCAR(ctx, f)
+	if err != nil {
+		return err
+	}
+
+	if err := commit.VerifyStructure(); err != nil {
+		return err
+	}
+	did, err := syntax.ParseDID(commit.DID)
+	if err != nil {
+		return err
+	}
+
+	ident, err := dir.LookupDID(ctx, did)
+	if err != nil {
+		return err
+	}
+	pubkey, err := ident.PublicKey()
+	if err != nil {
+		return err
+	}
+	if err := commit.VerifySignature(pubkey); err != nil {
+		return err
+	}
+	fmt.Println("verified signature")
 	return nil
 }

--- a/atproto/repo/cmd/repo-tool/main.go
+++ b/atproto/repo/cmd/repo-tool/main.go
@@ -85,7 +85,7 @@ func runVerifyCarMst(cctx *cli.Context) error {
 	}
 	defer f.Close()
 
-	repo, err := repo.LoadFromCAR(ctx, f)
+	commit, repo, err := repo.LoadFromCAR(ctx, f)
 	if err != nil {
 		return err
 	}
@@ -95,8 +95,8 @@ func runVerifyCarMst(cctx *cli.Context) error {
 		return err
 	}
 
-	if repo.Commit.Data != *computedCID {
-		return fmt.Errorf("failed to re-compute: %s != %s", computedCID, repo.Commit.Data)
+	if commit.Data != *computedCID {
+		return fmt.Errorf("failed to re-compute: %s != %s", computedCID, commit.Data)
 	}
 	fmt.Println("verified tree")
 	return nil

--- a/atproto/repo/commit.go
+++ b/atproto/repo/commit.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ipfs/go-cid"
 )
 
+// atproto repo commit object as a struct type. Can be used for direct CBOR or JSON serialization.
 type Commit struct {
 	DID     string   `json:"did" cborgen:"did"`
 	Version int64    `json:"version" cborgen:"version"` // currently: 3
@@ -19,7 +20,7 @@ type Commit struct {
 	Rev     string   `json:"rev,omitempty" cborgen:"rev,omitempty"`
 }
 
-// basic checks that field syntax is correct
+// does basic checks that field values and syntax are correct
 func (c *Commit) VerifyStructure() error {
 	if c.Version != ATPROTO_REPO_VERSION {
 		return fmt.Errorf("unsupported repo version: %d", c.Version)
@@ -60,6 +61,7 @@ func (c *Commit) UnsignedBytes() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// Signs the commit, storing the signature in the `Sig` field
 func (c *Commit) Sign(privkey crypto.PrivateKey) error {
 	b, err := c.UnsignedBytes()
 	if err != nil {
@@ -73,6 +75,7 @@ func (c *Commit) Sign(privkey crypto.PrivateKey) error {
 	return nil
 }
 
+// Verifies `Sig` field using the provided key. Returns `nil` if signature is valid.
 func (c *Commit) VerifySignature(pubkey crypto.PublicKey) error {
 	if c.Sig == nil {
 		return fmt.Errorf("can not verify unsigned commit")

--- a/atproto/repo/commit.go
+++ b/atproto/repo/commit.go
@@ -16,7 +16,7 @@ type Commit struct {
 	Prev    *cid.Cid `json:"prev" cborgen:"prev"`       // NOTE: omitempty would break signature verification for repo v3
 	Data    cid.Cid  `json:"data" cborgen:"data"`
 	Sig     []byte   `json:"sig,omitempty" cborgen:"sig,omitempty"`
-	Rev     string   `json:"rev" cborgen:"rev"`
+	Rev     string   `json:"rev,omitempty" cborgen:"rev,omitempty"`
 }
 
 // basic checks that field syntax is correct

--- a/atproto/repo/doc.go
+++ b/atproto/repo/doc.go
@@ -1,0 +1,6 @@
+/*
+Implementation of atproto repository and sync APIs, built on the MST data structure.
+
+The current package works for processing a sync firehose, including validation of "inductive firehose". It does not yet work for implementing a repository host (PDS).
+*/
+package repo

--- a/atproto/repo/operation.go
+++ b/atproto/repo/operation.go
@@ -9,10 +9,16 @@ import (
 	"github.com/ipfs/go-cid"
 )
 
+// Metadata about update to a single record (key) in the repo.
+//
+// Used as an abstraction for creating or validating "commit diffs" (eg, `#commit` firehose events)
 type Operation struct {
-	Path  string
+	// key of the record, eg, '{collection}/{record-key}'
+	Path string
+	// the new record CID value (or nil if this is a deletion)
 	Value *cid.Cid
-	Prev  *cid.Cid
+	// the previous record CID value (or nil if this is a creation)
+	Prev *cid.Cid
 }
 
 func (op *Operation) IsCreate() bool {

--- a/atproto/repo/repo.go
+++ b/atproto/repo/repo.go
@@ -15,6 +15,7 @@ import (
 // Version of the repo data format implemented in this package
 const ATPROTO_REPO_VERSION int64 = 3
 
+// High-level wrapper struct for an atproto repository.
 type Repo struct {
 	DID   syntax.DID
 	Clock *syntax.TIDClock
@@ -60,6 +61,7 @@ func (repo *Repo) GetRecordBytes(ctx context.Context, collection syntax.NSID, rk
 	return blk.RawData(), nil
 }
 
+// Snapshots the current state of the repository, resulting in a new (unsigned) `Commit` struct.
 func (repo *Repo) Commit() (*Commit, error) {
 	root, err := repo.MST.RootCID()
 	if err != nil {

--- a/atproto/repo/repo.go
+++ b/atproto/repo/repo.go
@@ -27,9 +27,10 @@ type Repo struct {
 var ErrNotFound = errors.New("record not found in repository")
 
 func NewRepo(did syntax.DID) Repo {
+	clk := syntax.NewTIDClock(0)
 	return Repo{
 		DID:         did,
-		Clock:       syntax.NewTIDClock(0),
+		Clock:       &clk,
 		Commit:      nil,
 		RecordStore: blockstore.NewBlockstore(datastore.NewMapDatastore()),
 		MST:         mst.NewEmptyTree(),
@@ -60,14 +61,3 @@ func (repo *Repo) GetRecordBytes(ctx context.Context, collection syntax.NSID, rk
 	// TODO: not verifying CID
 	return blk.RawData(), nil
 }
-
-// TODO:
-// IsComplete()
-// LoadFromStore
-// LoadFromCAR(reader)
-// WriteBlocks
-// WriteCAR
-// VerifyCIDs(bool)
-// Export
-// GetRecordStruct
-// GetRecordProof

--- a/atproto/repo/sync.go
+++ b/atproto/repo/sync.go
@@ -13,7 +13,9 @@ import (
 	"github.com/ipfs/go-cid"
 )
 
-// temporary/experimental method to parse and verify a firehose commit message
+// temporary/experimental method to parse and verify a firehose commit message.
+//
+// TODO: move to a separate 'sync' package? break up in to smaller components?
 func VerifyCommitMessage(ctx context.Context, msg *comatproto.SyncSubscribeRepos_Commit) (*Repo, error) {
 
 	logger := slog.Default().With("did", msg.Repo, "rev", msg.Rev, "seq", msg.Seq, "time", msg.Time)
@@ -168,7 +170,7 @@ func parseCommitOps(ops []*comatproto.SyncSubscribeRepos_RepoOp) ([]Operation, e
 
 // temporary/experimental code showing how to verify a commit signature from firehose
 //
-// in real implementation, will want to merge this code with `VerifyCommitMessage` above, and have it hanging off some service struct with a configured `identity.Directory`
+// TODO: in real implementation, will want to merge this code with `VerifyCommitMessage` above, and have it hanging off some service struct with a configured `identity.Directory`
 func VerifyCommitSignature(ctx context.Context, dir identity.Directory, msg *comatproto.SyncSubscribeRepos_Commit) error {
 	commit, _, err := LoadFromCAR(ctx, bytes.NewReader([]byte(msg.Blocks)))
 	if err != nil {

--- a/atproto/repo/sync.go
+++ b/atproto/repo/sync.go
@@ -37,15 +37,15 @@ func VerifyCommitMessage(ctx context.Context, msg *comatproto.SyncSubscribeRepos
 		logger.Warn("event with rebase flag set")
 	}
 
-	repo, err := LoadFromCAR(ctx, bytes.NewReader([]byte(msg.Blocks)))
+	commit, repo, err := LoadFromCAR(ctx, bytes.NewReader([]byte(msg.Blocks)))
 	if err != nil {
 		return nil, err
 	}
 
-	if repo.Commit.Rev != rev.String() {
+	if commit.Rev != rev.String() {
 		return nil, fmt.Errorf("rev did not match commit")
 	}
-	if repo.Commit.DID != did.String() {
+	if commit.DID != did.String() {
 		return nil, fmt.Errorf("rev did not match commit")
 	}
 	// TODO: check that commit CID matches root? re-compute?

--- a/atproto/repo/sync.go
+++ b/atproto/repo/sync.go
@@ -114,6 +114,7 @@ func VerifyCommitMessage(ctx context.Context, msg *comatproto.SyncSubscribeRepos
 		if *computed != *c {
 			return nil, fmt.Errorf("inverted tree root didn't match prevData")
 		}
+		logger.Debug("prevData matched", "prevData", c.String(), "computed", computed.String())
 	} else {
 		logger.Info("prevData was null; skipping tree root check")
 	}

--- a/atproto/repo/sync_test.go
+++ b/atproto/repo/sync_test.go
@@ -47,7 +47,7 @@ func testCommitFile(t *testing.T, p string) {
 	_, err = VerifyCommitMessage(ctx, &msg)
 	assert.NoError(err)
 	if err != nil {
-		repo, err := LoadFromCAR(ctx, bytes.NewReader([]byte(msg.Blocks)))
+		_, repo, err := LoadFromCAR(ctx, bytes.NewReader([]byte(msg.Blocks)))
 		if err != nil {
 			t.Fail()
 		}

--- a/atproto/syntax/tid.go
+++ b/atproto/syntax/tid.go
@@ -123,9 +123,18 @@ type TIDClock struct {
 	lastUnixMicro int64
 }
 
-func NewTIDClock(clockId uint) *TIDClock {
-	return &TIDClock{
+func NewTIDClock(clockId uint) TIDClock {
+	return TIDClock{
 		ClockID: clockId,
+	}
+}
+
+func ClockFromTID(t TID) TIDClock {
+	um := t.Integer()
+	um = (um >> 10) & 0x1FFF_FFFF_FFFF_FFFF
+	return TIDClock{
+		ClockID:       t.ClockID(),
+		lastUnixMicro: int64(um),
 	}
 }
 


### PR DESCRIPTION
This is a new/alternative SDK for atproto repositories, to replace the top-level `repo` package.

It wraps the newer `atproto/repo/mst` package, and support inductive firehose.

The initial scope (eg, for this PR) is relay and consumption use-cases, not PDS and repo-maintenance use-cases (there there is some initial code supporting the later).

The earlier MST PR included a skeleton of this package; this PR fleshes it out.

Things to maybe look at before merging:

- [ ] this PR contains manual updates to `subscribeRepos` struct. maybe we should wait for https://github.com/bluesky-social/atproto/pull/3391 or https://github.com/bluesky-social/atproto/pull/3449 to land
- [x] the `VerifyCommitMessage` function is included as an example. maybe that should go in a different package? in the CLI tool? or explicitly as a test/example function. (added more detailed comment about status)
- [x] add doc strings, especially disclaiming the overall state of this package (isn't ready for a PDS implementation, for example)