### PR TITLE
only depend on scylla in bigsky build

### DIFF
--- a/carstore/scylla.go
+++ b/carstore/scylla.go
@@ -1,3 +1,5 @@
+//go:build scylla
+
 package carstore
 
 import (

--- a/carstore/scylla_stub.go
+++ b/carstore/scylla_stub.go
@@ -1,0 +1,9 @@
+//go:build !scylla
+
+package carstore
+
+import "errors"
+
+func NewScyllaStore(addrs []string, keyspace string) (CarStore, error) {
+	return nil, errors.New("scylla compiled out")
+}

--- a/cmd/bigsky/Dockerfile
+++ b/cmd/bigsky/Dockerfile
@@ -12,7 +12,9 @@ WORKDIR /dockerbuild
 # timezone data for alpine builds
 ENV GOEXPERIMENT=loopvar
 RUN GIT_VERSION=$(git describe --tags --long --always) && \
-    go build -tags timetzdata -o /bigsky ./cmd/bigsky
+    echo "replace github.com/gocql/gocql => github.com/scylladb/gocql v1.14.4" >> go.mod && \
+    go mod tidy && \
+    go build -tags timetzdata,scylla -o /bigsky ./cmd/bigsky
 
 ### Build Frontend stage
 FROM node:18-alpine as web-builder

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/flosch/pongo2/v6 v6.0.0
 	github.com/go-redis/cache/v9 v9.0.0
 	github.com/goccy/go-json v0.10.2
-	github.com/gocql/gocql v0.0.0-00010101000000-000000000000
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gorilla/websocket v1.5.1
 	github.com/hashicorp/go-retryablehttp v0.7.5
@@ -191,5 +190,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.2.1 // indirect
 )
-
-replace github.com/gocql/gocql => github.com/scylladb/gocql v1.14.4

--- a/models/dbcid.go
+++ b/models/dbcid.go
@@ -4,8 +4,6 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
-	"github.com/gocql/gocql"
-
 	"github.com/ipfs/go-cid"
 )
 
@@ -62,16 +60,4 @@ func (dbc *DbCID) UnmarshalJSON(b []byte) error {
 
 func (dbc *DbCID) GormDataType() string {
 	return "bytes"
-}
-
-func (dbc *DbCID) MarshalCQL(info gocql.TypeInfo) ([]byte, error) {
-	return dbc.CID.Bytes(), nil
-}
-func (dbc *DbCID) UnmarshalCQL(info gocql.TypeInfo, data []byte) error {
-	xcid, err := cid.Cast(data)
-	if err != nil {
-		return err
-	}
-	dbc.CID = xcid
-	return nil
 }


### PR DESCRIPTION
importing scylla via replace doesn't work when indigo is imported as a library.
erase dependency on scylla except when building bigsky