### PR TITLE
identity package tweaks

### DIFF
--- a/atproto/identity/base_directory.go
+++ b/atproto/identity/base_directory.go
@@ -107,7 +107,7 @@ func (d *BaseDirectory) Lookup(ctx context.Context, a syntax.AtIdentifier) (*Ide
 	return nil, fmt.Errorf("at-identifier neither a Handle nor a DID")
 }
 
-func (d *BaseDirectory) Purge(ctx context.Context, a syntax.AtIdentifier) error {
+func (d *BaseDirectory) Purge(ctx context.Context, atid syntax.AtIdentifier) error {
 	// BaseDirectory itself does not implement caching
 	return nil
 }

--- a/atproto/identity/base_directory.go
+++ b/atproto/identity/base_directory.go
@@ -33,6 +33,8 @@ type BaseDirectory struct {
 	//
 	// The intended use-case for this flag is as an optimization for services which do not care about handles, but still want to use the `Directory` interface (instead of `ResolveDID`). For example, relay implementations, or services validating inter-service auth requests.
 	SkipHandleVerification bool
+	// User-Agent header for HTTP requests. Optional (ignored if empty string).
+	UserAgent string
 }
 
 var _ Directory = (*BaseDirectory)(nil)

--- a/atproto/identity/cache_directory.go
+++ b/atproto/identity/cache_directory.go
@@ -250,14 +250,14 @@ func (d *CacheDirectory) Lookup(ctx context.Context, a syntax.AtIdentifier) (*Id
 	return nil, fmt.Errorf("at-identifier neither a Handle nor a DID")
 }
 
-func (d *CacheDirectory) Purge(ctx context.Context, a syntax.AtIdentifier) error {
-	handle, err := a.AsHandle()
+func (d *CacheDirectory) Purge(ctx context.Context, atid syntax.AtIdentifier) error {
+	handle, err := atid.AsHandle()
 	if nil == err { // if not an error, is a handle
 		handle = handle.Normalize()
 		d.handleCache.Remove(handle)
 		return nil
 	}
-	did, err := a.AsDID()
+	did, err := atid.AsDID()
 	if nil == err { // if not an error, is a DID
 		d.identityCache.Remove(did)
 		return nil

--- a/atproto/identity/did.go
+++ b/atproto/identity/did.go
@@ -112,9 +112,11 @@ func (d *BaseDirectory) resolveDIDWeb(ctx context.Context, did syntax.DID) ([]by
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
+		io.Copy(io.Discard, resp.Body)
 		return nil, fmt.Errorf("%w: did:web HTTP status 404", ErrDIDNotFound)
 	}
 	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, resp.Body)
 		return nil, fmt.Errorf("%w: did:web HTTP status %d", ErrDIDResolutionFailed, resp.StatusCode)
 	}
 
@@ -147,9 +149,11 @@ func (d *BaseDirectory) resolveDIDPLC(ctx context.Context, did syntax.DID) ([]by
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
+		io.Copy(io.Discard, resp.Body)
 		return nil, fmt.Errorf("%w: PLC directory 404", ErrDIDNotFound)
 	}
 	if resp.StatusCode != http.StatusOK {
+		io.Copy(io.Discard, resp.Body)
 		return nil, fmt.Errorf("%w: PLC directory status %d", ErrDIDResolutionFailed, resp.StatusCode)
 	}
 

--- a/atproto/identity/did.go
+++ b/atproto/identity/did.go
@@ -98,6 +98,10 @@ func (d *BaseDirectory) resolveDIDWeb(ctx context.Context, did syntax.DID) ([]by
 	if err != nil {
 		return nil, fmt.Errorf("constructing HTTP request for did:web resolution: %w", err)
 	}
+	if d.UserAgent != "" {
+		req.Header.Set("User-Agent", d.UserAgent)
+	}
+
 	resp, err := d.HTTPClient.Do(req)
 
 	// look for NXDOMAIN
@@ -143,6 +147,10 @@ func (d *BaseDirectory) resolveDIDPLC(ctx context.Context, did syntax.DID) ([]by
 	if err != nil {
 		return nil, fmt.Errorf("constructing HTTP request for did:plc resolution: %w", err)
 	}
+	if d.UserAgent != "" {
+		req.Header.Set("User-Agent", d.UserAgent)
+	}
+
 	resp, err := d.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%w: PLC directory lookup: %w", ErrDIDResolutionFailed, err)

--- a/atproto/identity/directory.go
+++ b/atproto/identity/directory.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
+
+	"github.com/carlmjohnson/versioninfo"
 )
 
 // Ergonomic interface for atproto identity lookup, by DID or handle.
@@ -80,6 +82,7 @@ func DefaultDirectory() Directory {
 		TryAuthoritativeDNS: true,
 		// primary Bluesky PDS instance only supports HTTP resolution method
 		SkipDNSDomainSuffixes: []string{".bsky.social"},
+		UserAgent:             "indigo-identity/" + versioninfo.Short(),
 	}
 	cached := NewCacheDirectory(&base, 250_000, time.Hour*24, time.Minute*2, time.Minute*5)
 	return &cached

--- a/atproto/identity/directory.go
+++ b/atproto/identity/directory.go
@@ -27,7 +27,7 @@ type Directory interface {
 	Lookup(ctx context.Context, atid syntax.AtIdentifier) (*Identity, error)
 
 	// Flushes any cache of the indicated identifier. If directory is not using caching, can ignore this.
-	Purge(ctx context.Context, i syntax.AtIdentifier) error
+	Purge(ctx context.Context, atid syntax.AtIdentifier) error
 }
 
 // Indicates that handle resolution failed. A wrapped error may provide more context. This is only returned when looking up a handle, not when looking up a DID.

--- a/atproto/identity/handle.go
+++ b/atproto/identity/handle.go
@@ -131,6 +131,9 @@ func (d *BaseDirectory) ResolveHandleWellKnown(ctx context.Context, handle synta
 	if err != nil {
 		return "", fmt.Errorf("constructing HTTP request for handle resolution: %w", err)
 	}
+	if d.UserAgent != "" {
+		req.Header.Set("User-Agent", d.UserAgent)
+	}
 
 	resp, err := d.HTTPClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
- add user-agent
- ensure we drain HTTP requests in more code paths (allows connections/streams to be re-used more efficiently)