### PR TITLE
sync v1.1 event updates: add `#sync`, remove `#handle`, `#migrate`, `#tombstone`

### DIFF
--- a/cmd/gosky/debug.go
+++ b/cmd/gosky/debug.go
@@ -262,6 +262,14 @@ var debugStreamCmd = &cli.Command{
 
 				return nil
 			},
+			RepoSync: func(evt *comatproto.SyncSubscribeRepos_Sync) error {
+				fmt.Printf("\rChecking seq: %d      ", evt.Seq)
+				if lastSeq > 0 && evt.Seq != lastSeq+1 {
+					fmt.Println("Gap in sequence numbers: ", lastSeq, evt.Seq)
+				}
+				lastSeq = evt.Seq
+				return nil
+			},
 			RepoInfo: func(evt *comatproto.SyncSubscribeRepos_Info) error {
 				return nil
 			},

--- a/cmd/gosky/main.go
+++ b/cmd/gosky/main.go
@@ -284,6 +284,20 @@ var readRepoStreamCmd = &cli.Command{
 
 				return nil
 			},
+			RepoSync: func(sync *comatproto.SyncSubscribeRepos_Sync) error {
+				if jsonfmt {
+					b, err := json.Marshal(sync)
+					if err != nil {
+						return err
+					}
+					fmt.Println(string(b))
+				} else {
+					fmt.Printf("(%d) Sync: %s\n", sync.Seq, sync.Did)
+				}
+
+				return nil
+
+			},
 			RepoInfo: func(info *comatproto.SyncSubscribeRepos_Info) error {
 				if jsonfmt {
 					b, err := json.Marshal(info)

--- a/cmd/gosky/streamdiff.go
+++ b/cmd/gosky/streamdiff.go
@@ -127,6 +127,8 @@ func evtOp(evt *events.XRPCStreamEvent) string {
 		return "ERROR"
 	case evt.RepoCommit != nil:
 		return "#commit"
+	case evt.RepoSync != nil:
+		return "#sync"
 	case evt.RepoInfo != nil:
 		return "#info"
 	default:

--- a/cmd/sonar/sonar.go
+++ b/cmd/sonar/sonar.go
@@ -109,6 +109,13 @@ func (s *Sonar) HandleStreamEvent(ctx context.Context, xe *events.XRPCStreamEven
 	case xe.RepoCommit != nil:
 		eventsProcessedCounter.WithLabelValues("repo_commit", s.SocketURL).Inc()
 		return s.HandleRepoCommit(ctx, xe.RepoCommit)
+	case xe.RepoSync != nil:
+		eventsProcessedCounter.WithLabelValues("sync", s.SocketURL).Inc()
+		now := time.Now()
+		s.ProgMux.Lock()
+		s.Progress.LastSeq = xe.RepoSync.Seq
+		s.Progress.LastSeqProcessedAt = now
+		s.ProgMux.Unlock()
 	case xe.RepoIdentity != nil:
 		eventsProcessedCounter.WithLabelValues("identity", s.SocketURL).Inc()
 		now := time.Now()

--- a/cmd/supercollider/main.go
+++ b/cmd/supercollider/main.go
@@ -338,6 +338,9 @@ func Reload(cctx *cli.Context) error {
 				case evt.RepoCommit != nil:
 					header.MsgType = "#commit"
 					obj = evt.RepoCommit
+				case evt.RepoSync != nil:
+					header.MsgType = "#sync"
+					obj = evt.RepoSync
 				case evt.RepoInfo != nil:
 					header.MsgType = "#info"
 					obj = evt.RepoInfo

--- a/events/diskpersist/diskpersist.go
+++ b/events/diskpersist/diskpersist.go
@@ -278,8 +278,8 @@ func scanForLastSeq(fi *os.File, end int64) (int64, error) {
 
 const (
 	evtKindCommit    = 1
-	evtKindHandle    = 2
-	evtKindTombstone = 3
+	evtKindHandle    = 2 // DEPRECATED
+	evtKindTombstone = 3 // DEPRECATED
 	evtKindIdentity  = 4
 	evtKindAccount   = 5
 	evtKindSync      = 6

--- a/events/persist.go
+++ b/events/persist.go
@@ -42,6 +42,8 @@ func (mp *MemPersister) Persist(ctx context.Context, e *XRPCStreamEvent) error {
 	switch {
 	case e.RepoCommit != nil:
 		e.RepoCommit.Seq = mp.seq
+	case e.RepoSync != nil:
+		e.RepoSync.Seq = mp.seq
 	case e.RepoIdentity != nil:
 		e.RepoIdentity.Seq = mp.seq
 	case e.RepoAccount != nil:

--- a/pds/server.go
+++ b/pds/server.go
@@ -598,6 +598,9 @@ func (s *Server) EventsHandler(c echo.Context) error {
 		case evt.RepoCommit != nil:
 			header.MsgType = "#commit"
 			obj = evt.RepoCommit
+		case evt.RepoSync != nil:
+			header.MsgType = "#sync"
+			obj = evt.RepoSync
 		case evt.RepoIdentity != nil:
 			header.MsgType = "#identity"
 			obj = evt.RepoIdentity
@@ -651,6 +654,7 @@ func (s *Server) UpdateUserHandle(ctx context.Context, u *User, handle string) e
 		return fmt.Errorf("failed to update handle: %w", err)
 	}
 
+	// Push an Identity event
 	if err := s.events.AddEvent(ctx, &events.XRPCStreamEvent{
 		RepoIdentity: &comatproto.SyncSubscribeRepos_Identity{
 			Did:  u.Did,

--- a/search/firehose.go
+++ b/search/firehose.go
@@ -115,6 +115,28 @@ func (idx *Indexer) RunIndexer(ctx context.Context) error {
 			return nil
 
 		},
+		// TODO: process RepoIdentity
+		RepoIdentity: func(evt *comatproto.SyncSubscribeRepos_Identity) error {
+			ctx := context.Background()
+			ctx, span := tracer.Start(ctx, "RepoIdentity")
+			defer span.End()
+
+			did, err := syntax.ParseDID(evt.Did)
+			if err != nil {
+				idx.logger.Error("bad DID in RepoIdentity event", "did", evt.Did, "seq", evt.Seq, "err", err)
+				return nil
+			}
+			ident, err := idx.dir.LookupDID(ctx, did)
+			if err != nil {
+				idx.logger.Error("failed identity resolution in RepoIdentity event", "did", evt.Did, "seq", evt.Seq, "err", err)
+				return nil
+			}
+			if err := idx.updateUserHandle(ctx, did, ident.Handle.String()); err != nil {
+				// TODO: handle this case (instead of return nil)
+				idx.logger.Error("failed to update user handle", "did", evt.Did, "handle", ident.Handle, "seq", evt.Seq, "err", err)
+			}
+			return nil
+		},
 	}
 
 	return events.HandleRepoStream(

--- a/testing/utils.go
+++ b/testing/utils.go
@@ -666,6 +666,13 @@ func (b *TestRelay) Events(t *testing.T, since int64) *EventStream {
 				es.Lk.Unlock()
 				return nil
 			},
+			RepoSync: func(evt *atproto.SyncSubscribeRepos_Sync) error {
+				fmt.Println("received sync event: ", evt.Seq, evt.Did)
+				es.Lk.Lock()
+				es.Events = append(es.Events, &events.XRPCStreamEvent{RepoSync: evt})
+				es.Lk.Unlock()
+				return nil
+			},
 			RepoIdentity: func(evt *atproto.SyncSubscribeRepos_Identity) error {
 				fmt.Println("received identity event: ", evt.Seq, evt.Did)
 				es.Lk.Lock()


### PR DESCRIPTION
This was an old branch. which I have now rebased on top of https://github.com/bluesky-social/indigo/pull/1082 (which got merged to main).

It now basically just adds `#sync` support in a few more places it was missing.