### PR TITLE
add runit to Dockerfiles (for consistency)

### DIFF
--- a/cmd/beemo/Dockerfile
+++ b/cmd/beemo/Dockerfile
@@ -17,7 +17,7 @@ RUN GIT_VERSION=$(git describe --tags --long --always) && \
 ### Run stage
 FROM alpine:3.20
 
-RUN apk add --no-cache --update dumb-init ca-certificates
+RUN apk add --no-cache --update dumb-init ca-certificates runit
 ENTRYPOINT ["dumb-init", "--"]
 
 WORKDIR /

--- a/cmd/hepa/Dockerfile
+++ b/cmd/hepa/Dockerfile
@@ -17,7 +17,7 @@ RUN GIT_VERSION=$(git describe --tags --long --always) && \
 ### Run stage
 FROM alpine:3.20
 
-RUN apk add --no-cache --update dumb-init ca-certificates
+RUN apk add --no-cache --update dumb-init ca-certificates runit
 ENTRYPOINT ["dumb-init", "--"]
 
 WORKDIR /

--- a/cmd/palomar/Dockerfile
+++ b/cmd/palomar/Dockerfile
@@ -17,7 +17,7 @@ RUN GIT_VERSION=$(git describe --tags --long --always) && \
 ### Run stage
 FROM alpine:3.20
 
-RUN apk add --no-cache --update dumb-init ca-certificates
+RUN apk add --no-cache --update dumb-init ca-certificates runit
 ENTRYPOINT ["dumb-init", "--"]
 
 WORKDIR /


### PR DESCRIPTION
In production we use `svlogd` as part of our docker CMD. This is provided by the `runit` package.