### PR TITLE
use ipld cbor Blockstore interface

### DIFF
--- a/mst/diff.go
+++ b/mst/diff.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/bluesky-social/indigo/util"
 	cid "github.com/ipfs/go-cid"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	cbor "github.com/ipfs/go-ipld-cbor"
 )
 
 type DiffOp struct {
@@ -18,7 +18,7 @@ type DiffOp struct {
 }
 
 // TODO: this code isn't great, should be rewritten on top of the baseline datastructures once functional and correct
-func DiffTrees(ctx context.Context, bs blockstore.Blockstore, from, to cid.Cid) ([]*DiffOp, error) {
+func DiffTrees(ctx context.Context, bs cbor.IpldBlockstore, from, to cid.Cid) ([]*DiffOp, error) {
 	cst := util.CborStore(bs)
 
 	if from == cid.Undef {
@@ -185,7 +185,7 @@ func nodeEntriesEqual(a, b *nodeEntry) bool {
 	return false
 }
 
-func identityDiff(ctx context.Context, bs blockstore.Blockstore, root cid.Cid) ([]*DiffOp, error) {
+func identityDiff(ctx context.Context, bs cbor.IpldBlockstore, root cid.Cid) ([]*DiffOp, error) {
 	cst := util.CborStore(bs)
 	tt := LoadMST(cst, root)
 

--- a/repo/repo.go
+++ b/repo/repo.go
@@ -43,7 +43,7 @@ type UnsignedCommit struct {
 type Repo struct {
 	sc  SignedCommit
 	cst cbor.IpldStore
-	bs  blockstore.Blockstore
+	bs  cbor.IpldBlockstore
 
 	repoCid cid.Cid
 
@@ -74,7 +74,7 @@ func (uc *UnsignedCommit) BytesForSigning() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func IngestRepo(ctx context.Context, bs blockstore.Blockstore, r io.Reader) (cid.Cid, error) {
+func IngestRepo(ctx context.Context, bs cbor.IpldBlockstore, r io.Reader) (cid.Cid, error) {
 	ctx, span := otel.Tracer("repo").Start(ctx, "Ingest")
 	defer span.End()
 
@@ -110,7 +110,7 @@ func ReadRepoFromCar(ctx context.Context, r io.Reader) (*Repo, error) {
 	return OpenRepo(ctx, bs, root)
 }
 
-func NewRepo(ctx context.Context, did string, bs blockstore.Blockstore) *Repo {
+func NewRepo(ctx context.Context, did string, bs cbor.IpldBlockstore) *Repo {
 	cst := util.CborStore(bs)
 
 	t := mst.NewEmptyMST(cst)
@@ -128,7 +128,7 @@ func NewRepo(ctx context.Context, did string, bs blockstore.Blockstore) *Repo {
 	}
 }
 
-func OpenRepo(ctx context.Context, bs blockstore.Blockstore, root cid.Cid) (*Repo, error) {
+func OpenRepo(ctx context.Context, bs cbor.IpldBlockstore, root cid.Cid) (*Repo, error) {
 	cst := util.CborStore(bs)
 
 	var sc SignedCommit
@@ -173,7 +173,7 @@ func (r *Repo) SignedCommit() SignedCommit {
 	return r.sc
 }
 
-func (r *Repo) Blockstore() blockstore.Blockstore {
+func (r *Repo) Blockstore() cbor.IpldBlockstore {
 	return r.bs
 }
 
@@ -435,11 +435,11 @@ func (r *Repo) DiffSince(ctx context.Context, oldrepo cid.Cid) ([]*mst.DiffOp, e
 	return mst.DiffTrees(ctx, r.bs, oldTree, curptr)
 }
 
-func (r *Repo) CopyDataTo(ctx context.Context, bs blockstore.Blockstore) error {
+func (r *Repo) CopyDataTo(ctx context.Context, bs cbor.IpldBlockstore) error {
 	return copyRecCbor(ctx, r.bs, bs, r.sc.Data, make(map[cid.Cid]struct{}))
 }
 
-func copyRecCbor(ctx context.Context, from, to blockstore.Blockstore, c cid.Cid, seen map[cid.Cid]struct{}) error {
+func copyRecCbor(ctx context.Context, from, to cbor.IpldBlockstore, c cid.Cid, seen map[cid.Cid]struct{}) error {
 	if _, ok := seen[c]; ok {
 		return nil
 	}

--- a/util/cbor.go
+++ b/util/cbor.go
@@ -1,12 +1,11 @@
 package util
 
 import (
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	mh "github.com/multiformats/go-multihash"
 )
 
-func CborStore(bs blockstore.Blockstore) *cbor.BasicIpldStore {
+func CborStore(bs cbor.IpldBlockstore) *cbor.BasicIpldStore {
 	cst := cbor.NewCborStore(bs)
 	cst.DefaultMultihash = mh.SHA2_256
 	return cst


### PR DESCRIPTION
We already used the ipld-cbor Blockstore interface in a few places, and it's a simpler smaller interface that does all we need and isn't deprecated; spread its usage around a bit to simplify some things I was working on elsewhere in relay code