### PR TITLE
Streaming repo parsing

### DIFF
--- a/cmd/gosky/main.go
+++ b/cmd/gosky/main.go
@@ -661,9 +661,13 @@ var listAllRecordsCmd = &cli.Command{
 
 		var repob []byte
 		if strings.HasPrefix(arg, "did:") {
-			xrpcc, err := cliutil.GetXrpcClient(cctx, true)
+			resp, err := identity.DefaultDirectory().LookupDID(ctx, syntax.DID(arg))
 			if err != nil {
 				return err
+			}
+
+			xrpcc := &xrpc.Client{
+				Host: resp.PDSEndpoint(),
 			}
 
 			if arg == "" {
@@ -675,6 +679,7 @@ var listAllRecordsCmd = &cli.Command{
 				return err
 			}
 			repob = rrb
+			fmt.Println("GOT REPO BYTES")
 		} else {
 			if len(arg) == 0 {
 				return cli.Exit("must specify DID string or repo path", 127)
@@ -687,11 +692,6 @@ var listAllRecordsCmd = &cli.Command{
 			repob = fb
 		}
 
-		rr, err := repo.ReadRepoFromCar(ctx, bytes.NewReader(repob))
-		if err != nil {
-			return err
-		}
-
 		collection := "app.bsky.feed.post"
 		if cctx.Bool("all") {
 			collection = ""
@@ -699,24 +699,19 @@ var listAllRecordsCmd = &cli.Command{
 		vals := cctx.Bool("values")
 		cids := cctx.Bool("cids")
 
-		if err := rr.ForEach(ctx, collection, func(k string, v cid.Cid) error {
+		if err := repo.StreamRepoRecords(ctx, bytes.NewReader(repob), collection, func(k string, cc cid.Cid, v []byte) error {
 			if !strings.HasPrefix(k, collection) {
 				return repo.ErrDoneIterating
 			}
 
 			fmt.Print(k)
 			if cids {
-				fmt.Println(" - ", v)
+				fmt.Println(" - ", cc)
 			} else {
 				fmt.Println()
 			}
 			if vals {
-				b, err := rr.Blockstore().Get(ctx, v)
-				if err != nil {
-					return err
-				}
-
-				convb, err := cborToJson(b.RawData())
+				convb, err := cborToJson(v)
 				if err != nil {
 					return err
 				}

--- a/cmd/gosky/sync.go
+++ b/cmd/gosky/sync.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/bluesky-social/indigo/util/cliutil"
+	"github.com/bluesky-social/indigo/xrpc"
 
 	cli "github.com/urfave/cli/v2"
 )
@@ -53,11 +54,10 @@ var syncGetRepoCmd = &cli.Command{
 			carPath = ident.DID.String() + ".car"
 		}
 
-		xrpcc, err := cliutil.GetXrpcClient(cctx, false)
-		if err != nil {
-			return err
+		xrpcc := &xrpc.Client{
+			Host: ident.PDSEndpoint(),
 		}
-		xrpcc.Host = ident.PDSEndpoint()
+
 		if xrpcc.Host == "" {
 			return fmt.Errorf("no PDS endpoint for identity")
 		}

--- a/repo/carutil/reader.go
+++ b/repo/carutil/reader.go
@@ -1,0 +1,102 @@
+package carutil
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	car "github.com/ipld/go-car"
+)
+
+type Reader struct {
+	r *bufio.Reader
+
+	bufs [][]byte
+}
+
+func NewReader(r *bufio.Reader) (*Reader, cid.Cid, error) {
+	h, err := car.ReadHeader(r)
+	if err != nil {
+		return nil, cid.Undef, err
+	}
+
+	if h.Version != 1 {
+		return nil, cid.Undef, fmt.Errorf("invalid version: %d", h.Version)
+	}
+
+	if len(h.Roots) != 1 {
+		return nil, cid.Undef, fmt.Errorf("expected only 1 root in car file")
+	}
+
+	return &Reader{
+		r:    r,
+		bufs: make([][]byte, 0, 10),
+	}, h.Roots[0], nil
+}
+
+func (r *Reader) Free(alloc *sync.Pool) {
+	for _, b := range r.bufs {
+		alloc.Put(b)
+	}
+	r.bufs = nil
+}
+
+const MaxAllowedSectionSize = 32 << 20
+
+func (r *Reader) NextBlock(allocator *sync.Pool, allocMax uint64) (blocks.Block, error) {
+	data, err := ldRead(r.r, allocator, allocMax)
+	if err != nil {
+		return nil, err
+	}
+
+	r.bufs = append(r.bufs, data)
+
+	n, c, err := cid.CidFromBytes(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return blocks.NewBlockWithCid(data[n:], c)
+}
+
+func ldRead(r *bufio.Reader, alloc *sync.Pool, allocMax uint64) ([]byte, error) {
+	if _, err := r.Peek(1); err != nil { // no more blocks, likely clean io.EOF
+		return nil, err
+	}
+
+	l, err := binary.ReadUvarint(r)
+	if err != nil {
+		if err == io.EOF {
+			return nil, io.ErrUnexpectedEOF // don't silently pretend this is a clean EOF
+		}
+		return nil, err
+	}
+
+	if l > uint64(MaxAllowedSectionSize) { // Don't OOM
+		return nil, errors.New("malformed car; header is bigger than util.MaxAllowedSectionSize")
+	}
+
+	if l > allocMax {
+		// direct allocation, not great
+		buf := make([]byte, l)
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, err
+		}
+
+		return buf, nil
+	}
+
+	buf := alloc.Get().([]byte)
+	buf = buf[:l]
+
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}

--- a/repo/stream.go
+++ b/repo/stream.go
@@ -1,0 +1,162 @@
+package repo
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+
+	"github.com/bluesky-social/indigo/mst"
+	"github.com/bluesky-social/indigo/repo/carutil"
+	"github.com/bluesky-social/indigo/util"
+	block "github.com/ipfs/go-block-format"
+	cid "github.com/ipfs/go-cid"
+	"go.opentelemetry.io/otel"
+)
+
+type waitingBlockstore struct {
+	lk             sync.Mutex
+	blockWaits     map[cid.Cid]chan block.Block
+	otherBlocks    map[cid.Cid]block.Block
+	streamComplete bool
+}
+
+func newWaitingBlockstore() *waitingBlockstore {
+	return &waitingBlockstore{
+		blockWaits:  make(map[cid.Cid]chan block.Block),
+		otherBlocks: make(map[cid.Cid]block.Block),
+	}
+}
+
+func (bs *waitingBlockstore) Get(ctx context.Context, cc cid.Cid) (block.Block, error) {
+	bs.lk.Lock()
+
+	if blk, ok := bs.otherBlocks[cc]; ok {
+		delete(bs.otherBlocks, cc)
+		bs.lk.Unlock()
+		return blk, nil
+	}
+
+	if bs.streamComplete {
+		bs.lk.Unlock()
+		return nil, ErrMissingBlock
+	}
+
+	bw, ok := bs.blockWaits[cc]
+	if ok {
+		bs.lk.Unlock()
+		return nil, fmt.Errorf("somehow already have active wait for block in question: %s", cc)
+	}
+
+	bw = make(chan block.Block, 1)
+
+	bs.blockWaits[cc] = bw
+
+	bs.lk.Unlock()
+
+	select {
+	case blk, ok := <-bw:
+		if !ok {
+			return nil, ErrMissingBlock
+		}
+
+		return blk, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+
+	}
+}
+
+var ErrMissingBlock = fmt.Errorf("block was missing from archive")
+
+func (bs *waitingBlockstore) Put(ctx context.Context, blk block.Block) error {
+	bs.lk.Lock()
+	defer bs.lk.Unlock()
+
+	bw, ok := bs.blockWaits[blk.Cid()]
+	if ok {
+		bw <- blk
+		delete(bs.blockWaits, blk.Cid())
+		return nil
+	}
+
+	bs.otherBlocks[blk.Cid()] = blk.(*block.BasicBlock)
+	return nil
+}
+
+func (bs *waitingBlockstore) Complete() {
+	bs.lk.Lock()
+	defer bs.lk.Unlock()
+	bs.streamComplete = true
+	for _, ch := range bs.blockWaits {
+		close(ch)
+	}
+}
+
+func StreamRepoRecords(ctx context.Context, r io.Reader, prefix string, cb func(k string, c cid.Cid, v []byte) error) error {
+	ctx, span := otel.Tracer("repo").Start(ctx, "RepoStream")
+	defer span.End()
+
+	br, root, err := carutil.NewReader(bufio.NewReader(r))
+	if err != nil {
+		return fmt.Errorf("opening CAR block reader: %w", err)
+	}
+
+	bs := newWaitingBlockstore()
+	cst := util.CborStore(bs)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var walkErr error
+	go func() {
+		defer wg.Done()
+
+		var sc SignedCommit
+		if err := cst.Get(ctx, root, &sc); err != nil {
+			walkErr = fmt.Errorf("loading root from blockstore: %w", err)
+			return
+		}
+
+		if sc.Version != ATP_REPO_VERSION && sc.Version != ATP_REPO_VERSION_2 {
+			walkErr = fmt.Errorf("unsupported repo version: %d", sc.Version)
+			return
+		}
+		// TODO: verify that signature
+
+		t := mst.LoadMST(cst, sc.Data)
+
+		if err := t.WalkLeavesFrom(ctx, prefix, func(k string, val cid.Cid) error {
+			blk, err := bs.Get(ctx, val)
+			if err != nil {
+				slog.Error("failed to get record from tree", "key", k, "cid", val, "error", err)
+				return nil
+			}
+
+			return cb(k, val, blk.RawData())
+		}); err != nil {
+			walkErr = fmt.Errorf("failed to walk mst: %w", err)
+		}
+	}()
+
+	for {
+		blk, err := br.NextBlock(repoBlockBufferPool, repoBlockBufferSize)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("reading block from CAR: %w", err)
+		}
+
+		if err := bs.Put(ctx, blk); err != nil {
+			return fmt.Errorf("copying block to store: %w", err)
+		}
+	}
+
+	bs.Complete()
+
+	wg.Wait()
+
+	return walkErr
+}


### PR DESCRIPTION
First pass at a streaming repo parse utility. This iterates the repo in mst order, waiting for the blocks it needs to be read from the passed in stream.

It currently doesnt have a good backpressure mechanism, will need to add that next. I kinda wanted to get this to be a generator pattern type thing instead of using goroutines, but since the blocks can be reordered it gets sticky... we will see