### PR TITLE
refactor metrics middleware in to `util/svcutil`

### DIFF
--- a/bgs/bgs.go
+++ b/bgs/bgs.go
@@ -24,6 +24,7 @@ import (
 	"github.com/bluesky-social/indigo/indexer"
 	"github.com/bluesky-social/indigo/models"
 	"github.com/bluesky-social/indigo/repomgr"
+	"github.com/bluesky-social/indigo/util/svcutil"
 	"github.com/bluesky-social/indigo/xrpc"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/sync/semaphore"
@@ -237,7 +238,7 @@ func (bgs *BGS) StartWithListener(listen net.Listener) error {
 	e.File("/dash/*", "public/index.html")
 	e.Static("/assets", "public/assets")
 
-	e.Use(MetricsMiddleware)
+	e.Use(svcutil.MetricsMiddleware)
 
 	e.HTTPErrorHandler = func(err error, ctx echo.Context) {
 		switch err := err.(type) {

--- a/bgs/metrics.go
+++ b/bgs/metrics.go
@@ -1,12 +1,6 @@
 package bgs
 
 import (
-	"errors"
-	"net/http"
-	"strconv"
-	"time"
-
-	"github.com/labstack/echo/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -68,29 +62,6 @@ var newUsersDiscovered = promauto.NewCounter(prometheus.CounterOpts{
 	Help: "The total number of new users discovered directly from the firehose (not from refs)",
 })
 
-var reqSz = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Name:    "http_request_size_bytes",
-	Help:    "A histogram of request sizes for requests.",
-	Buckets: prometheus.ExponentialBuckets(100, 10, 8),
-}, []string{"code", "method", "path"})
-
-var reqDur = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Name:    "http_request_duration_seconds",
-	Help:    "A histogram of latencies for requests.",
-	Buckets: prometheus.ExponentialBuckets(0.001, 2, 15),
-}, []string{"code", "method", "path"})
-
-var reqCnt = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "http_requests_total",
-	Help: "A counter for requests to the wrapped handler.",
-}, []string{"code", "method", "path"})
-
-var resSz = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Name:    "http_response_size_bytes",
-	Help:    "A histogram of response sizes for requests.",
-	Buckets: prometheus.ExponentialBuckets(100, 10, 8),
-}, []string{"code", "method", "path"})
-
 var userLookupDuration = promauto.NewHistogram(prometheus.HistogramOpts{
 	Name:    "relay_user_lookup_duration",
 	Help:    "A histogram of user lookup latencies",
@@ -102,67 +73,3 @@ var newUserDiscoveryDuration = promauto.NewHistogram(prometheus.HistogramOpts{
 	Help:    "A histogram of new user discovery latencies",
 	Buckets: prometheus.ExponentialBuckets(0.001, 2, 15),
 })
-
-// MetricsMiddleware defines handler function for metrics middleware
-func MetricsMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		path := c.Path()
-		if path == "/metrics" || path == "/_health" {
-			return next(c)
-		}
-
-		start := time.Now()
-		requestSize := computeApproximateRequestSize(c.Request())
-
-		err := next(c)
-
-		status := c.Response().Status
-		if err != nil {
-			var httpError *echo.HTTPError
-			if errors.As(err, &httpError) {
-				status = httpError.Code
-			}
-			if status == 0 || status == http.StatusOK {
-				status = http.StatusInternalServerError
-			}
-		}
-
-		elapsed := float64(time.Since(start)) / float64(time.Second)
-
-		statusStr := strconv.Itoa(status)
-		method := c.Request().Method
-
-		responseSize := float64(c.Response().Size)
-
-		reqDur.WithLabelValues(statusStr, method, path).Observe(elapsed)
-		reqCnt.WithLabelValues(statusStr, method, path).Inc()
-		reqSz.WithLabelValues(statusStr, method, path).Observe(float64(requestSize))
-		resSz.WithLabelValues(statusStr, method, path).Observe(responseSize)
-
-		return err
-	}
-}
-
-func computeApproximateRequestSize(r *http.Request) int {
-	s := 0
-	if r.URL != nil {
-		s = len(r.URL.Path)
-	}
-
-	s += len(r.Method)
-	s += len(r.Proto)
-	for name, values := range r.Header {
-		s += len(name)
-		for _, value := range values {
-			s += len(value)
-		}
-	}
-	s += len(r.Host)
-
-	// N.B. r.Form and r.MultipartForm are assumed to be included in r.URL.
-
-	if r.ContentLength != -1 {
-		s += int(r.ContentLength)
-	}
-	return s
-}

--- a/cmd/collectiondir/metrics.go
+++ b/cmd/collectiondir/metrics.go
@@ -1,13 +1,8 @@
 package main
 
 import (
-	"errors"
-	"github.com/labstack/echo/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"net/http"
-	"strconv"
-	"time"
 )
 
 var firehoseReceivedCounter = promauto.NewCounter(prometheus.CounterOpts{
@@ -52,50 +47,3 @@ var statsCalculations = promauto.NewHistogram(prometheus.HistogramOpts{
 	Help:    "how long it takes to calculate total stats",
 	Buckets: prometheus.ExponentialBuckets(0.01, 2, 13),
 })
-
-var reqDur = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Name:    "http_request_duration_seconds",
-	Help:    "A histogram of latencies for requests.",
-	Buckets: prometheus.ExponentialBuckets(0.001, 2, 15),
-}, []string{"code", "method", "path"})
-
-var reqCnt = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "http_requests_total",
-	Help: "A counter for requests to the wrapped handler.",
-}, []string{"code", "method", "path"})
-
-// MetricsMiddleware defines handler function for metrics middleware
-// TODO: reunify with bgs/metrics.go ?
-func MetricsMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		path := c.Path()
-		if path == "/metrics" || path == "/_health" {
-			return next(c)
-		}
-
-		start := time.Now()
-
-		err := next(c)
-
-		status := c.Response().Status
-		if err != nil {
-			var httpError *echo.HTTPError
-			if errors.As(err, &httpError) {
-				status = httpError.Code
-			}
-			if status == 0 || status == http.StatusOK {
-				status = http.StatusInternalServerError
-			}
-		}
-
-		elapsed := float64(time.Since(start)) / float64(time.Second)
-
-		statusStr := strconv.Itoa(status)
-		method := c.Request().Method
-
-		reqDur.WithLabelValues(statusStr, method, path).Observe(elapsed)
-		reqCnt.WithLabelValues(statusStr, method, path).Inc()
-
-		return err
-	}
-}

--- a/cmd/collectiondir/serve.go
+++ b/cmd/collectiondir/serve.go
@@ -25,6 +25,7 @@ import (
 
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/events"
+	"github.com/bluesky-social/indigo/util/svcutil"
 	"github.com/bluesky-social/indigo/xrpc"
 
 	"github.com/labstack/echo/v4"
@@ -405,7 +406,7 @@ func (cs *collectionServer) StartApiServer(ctx context.Context, addr string) err
 	e := echo.New()
 	e.HideBanner = true
 
-	e.Use(MetricsMiddleware)
+	e.Use(svcutil.MetricsMiddleware)
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins: []string{"*"},
 		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept, echo.HeaderAuthorization},

--- a/splitter/splitter.go
+++ b/splitter/splitter.go
@@ -21,11 +21,11 @@ import (
 
 	"github.com/bluesky-social/indigo/api/atproto"
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
-	"github.com/bluesky-social/indigo/bgs"
 	"github.com/bluesky-social/indigo/events"
 	"github.com/bluesky-social/indigo/events/pebblepersist"
 	"github.com/bluesky-social/indigo/events/schedulers/sequential"
 	"github.com/bluesky-social/indigo/util"
+	"github.com/bluesky-social/indigo/util/svcutil"
 	"github.com/bluesky-social/indigo/xrpc"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
@@ -211,7 +211,7 @@ func (s *Splitter) StartWithListener(listen net.Listener) error {
 		}
 	*/
 
-	e.Use(bgs.MetricsMiddleware)
+	e.Use(svcutil.MetricsMiddleware)
 
 	e.HTTPErrorHandler = func(err error, ctx echo.Context) {
 		switch err := err.(type) {

--- a/util/svcutil/metrics_middleware.go
+++ b/util/svcutil/metrics_middleware.go
@@ -1,0 +1,99 @@
+package svcutil
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var reqSz = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "http_request_size_bytes",
+	Help:    "A histogram of request sizes for requests.",
+	Buckets: prometheus.ExponentialBuckets(100, 10, 8),
+}, []string{"code", "method", "path"})
+
+var reqDur = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "http_request_duration_seconds",
+	Help:    "A histogram of latencies for requests.",
+	Buckets: prometheus.ExponentialBuckets(0.001, 2, 15),
+}, []string{"code", "method", "path"})
+
+var reqCnt = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "http_requests_total",
+	Help: "A counter for requests to the wrapped handler.",
+}, []string{"code", "method", "path"})
+
+var resSz = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "http_response_size_bytes",
+	Help:    "A histogram of response sizes for requests.",
+	Buckets: prometheus.ExponentialBuckets(100, 10, 8),
+}, []string{"code", "method", "path"})
+
+// MetricsMiddleware defines handler function for metrics middleware
+func MetricsMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		path := c.Path()
+		if path == "/metrics" || path == "/_health" {
+			return next(c)
+		}
+
+		start := time.Now()
+		requestSize := computeApproximateRequestSize(c.Request())
+
+		err := next(c)
+
+		status := c.Response().Status
+		if err != nil {
+			var httpError *echo.HTTPError
+			if errors.As(err, &httpError) {
+				status = httpError.Code
+			}
+			if status == 0 || status == http.StatusOK {
+				status = http.StatusInternalServerError
+			}
+		}
+
+		elapsed := float64(time.Since(start)) / float64(time.Second)
+
+		statusStr := strconv.Itoa(status)
+		method := c.Request().Method
+
+		responseSize := float64(c.Response().Size)
+
+		reqDur.WithLabelValues(statusStr, method, path).Observe(elapsed)
+		reqCnt.WithLabelValues(statusStr, method, path).Inc()
+		reqSz.WithLabelValues(statusStr, method, path).Observe(float64(requestSize))
+		resSz.WithLabelValues(statusStr, method, path).Observe(responseSize)
+
+		return err
+	}
+}
+
+func computeApproximateRequestSize(r *http.Request) int {
+	s := 0
+	if r.URL != nil {
+		s = len(r.URL.Path)
+	}
+
+	s += len(r.Method)
+	s += len(r.Proto)
+	for name, values := range r.Header {
+		s += len(name)
+		for _, value := range values {
+			s += len(value)
+		}
+	}
+	s += len(r.Host)
+
+	// N.B. r.Form and r.MultipartForm are assumed to be included in r.URL.
+
+	if r.ContentLength != -1 {
+		s += int(r.ContentLength)
+	}
+	return s
+}


### PR DESCRIPTION
The main motivation here is to not have `splitter` import from `bgs`; it was only doing so for MetricsMiddleware.

This moves MetricsMiddleware out to new service-oriented util package (not directly in `util/` because it depends on prometheus and echo), and updates the trivial usage to that.

Not touching `cmd/relay/` because that is getting refactored in a separate branch; and not touching `search/metrics.go` because it adds "extra" labels.