### PR TITLE
use syntax.HandleInvalid instead of string (fix typo)

### DIFF
--- a/atproto/identity/identity.go
+++ b/atproto/identity/identity.go
@@ -76,7 +76,7 @@ func ParseIdentity(doc *DIDDocument) Identity {
 	}
 	return Identity{
 		DID:         doc.DID,
-		Handle:      syntax.Handle("invalid.handle"),
+		Handle:      syntax.HandleInvalid,
 		AlsoKnownAs: doc.AlsoKnownAs,
 		Services:    svc,
 		Keys:        keys,

--- a/atproto/syntax/handle.go
+++ b/atproto/syntax/handle.go
@@ -59,7 +59,7 @@ func (h Handle) TLD() string {
 
 // Is this the special "handle.invalid" handle?
 func (h Handle) IsInvalidHandle() bool {
-	return h.Normalize() == "handle.invalid"
+	return h.Normalize() == HandleInvalid
 }
 
 func (h Handle) Normalize() Handle {

--- a/cmd/bluepages/handlers.go
+++ b/cmd/bluepages/handlers.go
@@ -154,12 +154,12 @@ func (srv *Server) resolveIdentityFromDID(c echo.Context, did syntax.DID) error 
 	handle, err := ident.DeclaredHandle()
 	if err != nil {
 		// no handle declared, or invalid syntax
-		handle = syntax.Handle("handle.invalid")
+		handle = syntax.HandleInvalid
 	}
 
 	checkDID, err := srv.dir.ResolveHandle(ctx, handle)
 	if err != nil || checkDID != did {
-		handle = syntax.Handle("handle.invalid")
+		handle = syntax.HandleInvalid
 	}
 
 	return c.JSON(200, comatproto.IdentityDefs_IdentityInfo{


### PR DESCRIPTION
This fixes a specific typo, and also uses the declared const in more places (to avoid similar typos).

thanks @rafaelbsky for reporting!