### PR TITLE
go.mod: specify full version (1.23.0)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/bluesky-social/indigo
 
-go 1.23.0
+go 1.23
+toolchain go1.23.8
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bluesky-social/indigo
 
-go 1.23
+go 1.23.0
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2


### PR DESCRIPTION
For the automatic go toolchain stuff to work, we need the full version, including patch (not just minor)