### PR TITLE
automod: have ozone engine handle newer event types

### DIFF
--- a/automod/engine/engine_ozone.go
+++ b/automod/engine/engine_ozone.go
@@ -46,6 +46,8 @@ func NewOzoneEventContext(ctx context.Context, eng *Engine, eventView *toolsozon
 		eventType = "divert"
 	} else if eventView.Event.ModerationDefs_ModEventTag != nil {
 		eventType = "tag"
+	} else if eventView.Event.ModerationDefs_ModEventPriorityScore != nil {
+		eventType = "priorityScore"
 	} else {
 		return nil, fmt.Errorf("unhandled ozone event type")
 	}


### PR DESCRIPTION
We don't actually have any rules or behavior around this event type, just need to handle it here to reduce false-positive error logging.

Will need to be paired with an update and deploy in another internal repo, after this is merged.