### PR TITLE
events: add sync event support to persist implementations

### DIFF
--- a/events/diskpersist/diskpersist.go
+++ b/events/diskpersist/diskpersist.go
@@ -282,6 +282,7 @@ const (
 	evtKindTombstone = 3
 	evtKindIdentity  = 4
 	evtKindAccount   = 5
+	evtKindSync      = 6
 )
 
 var emptyHeader = make([]byte, headerSize)
@@ -455,6 +456,8 @@ func (dp *DiskPersistence) doPersist(ctx context.Context, j persistJob) error {
 	switch {
 	case e.RepoCommit != nil:
 		e.RepoCommit.Seq = seq
+	case e.RepoSync != nil:
+		e.RepoSync.Seq = seq
 	case e.RepoHandle != nil:
 		e.RepoHandle.Seq = seq
 	case e.RepoIdentity != nil:
@@ -507,6 +510,12 @@ func (dp *DiskPersistence) Persist(ctx context.Context, e *events.XRPCStreamEven
 		evtKind = evtKindCommit
 		did = e.RepoCommit.Repo
 		if err := e.RepoCommit.MarshalCBOR(cw); err != nil {
+			return fmt.Errorf("failed to marshal: %w", err)
+		}
+	case e.RepoSync != nil:
+		evtKind = evtKindSync
+		did = e.RepoSync.Did
+		if err := e.RepoSync.MarshalCBOR(cw); err != nil {
 			return fmt.Errorf("failed to marshal: %w", err)
 		}
 	case e.RepoHandle != nil:
@@ -743,6 +752,15 @@ func (dp *DiskPersistence) readEventsFrom(ctx context.Context, since int64, fn s
 			}
 			evt.Seq = h.Seq
 			if err := cb(&events.XRPCStreamEvent{RepoCommit: &evt}); err != nil {
+				return nil, err
+			}
+		case evtKindSync:
+			var evt atproto.SyncSubscribeRepos_Sync
+			if err := evt.UnmarshalCBOR(io.LimitReader(bufr, h.Len64())); err != nil {
+				return nil, err
+			}
+			evt.Seq = h.Seq
+			if err := cb(&events.XRPCStreamEvent{RepoSync: &evt}); err != nil {
 				return nil, err
 			}
 		case evtKindHandle:

--- a/events/yolopersist/yolopersist.go
+++ b/events/yolopersist/yolopersist.go
@@ -28,6 +28,8 @@ func (yp *YoloPersister) Persist(ctx context.Context, e *events.XRPCStreamEvent)
 	switch {
 	case e.RepoCommit != nil:
 		e.RepoCommit.Seq = yp.seq
+	case e.RepoSync != nil:
+		e.RepoSync.Seq = yp.seq
 	case e.RepoHandle != nil:
 		e.RepoHandle.Seq = yp.seq
 	case e.RepoIdentity != nil:


### PR DESCRIPTION
Adds basic support for the new `#sync` event to persister implementations. Note that the pebble persister (used in rainbow) is agnostic to event type, so didn't need any update.

This PR is a bit drive-by: the new relay work doesn't use this copy of the persist code, and these patches haven't been demonstrated to work.