### PR TITLE
Collectiondir Improvements

### DIFF
--- a/cmd/collectiondir/serve.go
+++ b/cmd/collectiondir/serve.go
@@ -194,12 +194,12 @@ func (cs *collectionServer) run(cctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("lru init, %w", err)
 	}
-	cs.wg.Add(1)
-	go cs.ingestReceiver()
 	cs.log = log
 	cs.ctx = cctx.Context
 	cs.AdminToken = cctx.String("admin-token")
 	cs.ExepctedAuthHeader = "Bearer " + cs.AdminToken
+	cs.wg.Add(1)
+	go cs.ingestReceiver()
 	pebblePath := cctx.String("pebble")
 	cs.pcd = &PebbleCollectionDirectory{
 		log: cs.log,


### PR DESCRIPTION
Perhaps best reviewed by looking at each individual commit.

All of these were found by running this, then sending a ctrl+c:

```bash
go run -race ./cmd/collectiondir serve --pebble ~/local/data/collectiondir --dau-directory ~/local/data/collectiondir
```

This PR improves a few small but important things about the collectiondir service:

1. This service does not have pprof on the metrics router (f16258882a1c6a82c25465547ae824afbeec9486)
    a. `/metrics` and `/debug/pprof/` now live side-by-side
    b. All services should have pprof enabled on private metrics routers
2. Fixes a race condition on startup where we're binding a bunch of fields on `cs` after launching a goroutine that uses some of those fields (82656e88f5ed5ff706c00cfabb98701c3e8e6d0a)
3. Fixes an issue where sending a SIGTERM to the service causes it to start shutting down, but the service never actually dies because there is an infinite hang due to an errant `cs.wg.Wait()`
    a. In general though, the `errchan` is not a good approach. Prefer to let each background goroutine do its logging and only coordinate on shutdown timing through a single variable (`cs.wg`)
4. Fix a race condition on the API server startup/shutdown (5191ddd755928d5763cee92d7510c5999583d006)
5. Fix a race condition on the metrics server startup/shutdown (c90e279b78482bea54451cbf6d0520faa432fa8d)