### PR TITLE
batch of golangci-lint fixes in `atproto/*`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ test-coverage.out
 # Don't ignore this file itself, or other specific dotfiles
 !.gitignore
 !.github/
+!.golangci.yaml
 
 # Don't commit your (default location) creds
 bsky.auth

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,17 @@
+version: "2"
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  disable:
+    - errcheck
+    - gocritic
+    - unused
+  settings:
+    errcheck:
+      check-type-assertions: true
+      disable-default-exclusions: true
+    gocritic:
+      enable-all: true

--- a/atproto/identity/apidir/apidir.go
+++ b/atproto/identity/apidir/apidir.go
@@ -40,11 +40,6 @@ type handleBody struct {
 	DID syntax.DID `json:"did"`
 }
 
-type errorBody struct {
-	Name    string `json:"error"`
-	Message string `json:"message,omitempty"`
-}
-
 func NewAPIDirectory(host string) APIDirectory {
 	return APIDirectory{
 		Client: &http.Client{

--- a/atproto/identity/directory.go
+++ b/atproto/identity/directory.go
@@ -57,7 +57,7 @@ var ErrDIDResolutionFailed = errors.New("DID resolution failed")
 var ErrKeyNotDeclared = errors.New("DID document did not declare a relevant public key")
 
 // Handle was invalid, in a situation where a valid handle is required.
-var ErrInvalidHandle = errors.New("Invalid Handle")
+var ErrInvalidHandle = errors.New("invalid handle")
 
 var DefaultPLCURL = "https://plc.directory"
 

--- a/atproto/lexicon/cmd/lextool/net.go
+++ b/atproto/lexicon/cmd/lextool/net.go
@@ -65,6 +65,9 @@ func runValidateRecord(cctx *cli.Context) error {
 	}
 
 	body, err := data.UnmarshalJSON(respBytes)
+	if err != nil {
+		return err
+	}
 	record, ok := body["value"].(map[string]any)
 	if !ok {
 		return fmt.Errorf("fetched record was not an object")

--- a/atproto/repo/mst/mst_interop_test.go
+++ b/atproto/repo/mst/mst_interop_test.go
@@ -104,9 +104,8 @@ func TestInteropKnownMaps(t *testing.T) {
 }
 
 func TestInteropKnownMapsTricky(t *testing.T) {
-	assert := assert.New(t)
-
 	t.Skip("TODO: these are currently disallowed in typescript implementation")
+	assert := assert.New(t)
 
 	cid1str := "bafyreie5cvv4h45feadgeuwhbcutmh6t2ceseocckahdoe6uat64zmz454"
 

--- a/atproto/repo/mst/mst_test.go
+++ b/atproto/repo/mst/mst_test.go
@@ -180,7 +180,7 @@ func TestRandomTree(t *testing.T) {
 
 	mapKeys := make([]string, len(inMap))
 	i := 0
-	for k, _ := range inMap {
+	for k := range inMap {
 		mapKeys[i] = k
 		i++
 	}

--- a/atproto/repo/mst/node.go
+++ b/atproto/repo/mst/node.go
@@ -186,7 +186,7 @@ func (n *Node) compareKey(key []byte, markDirty bool) (int, error) {
 		// TODO: should we actually return 0 in this case?
 		return 0, fmt.Errorf("can't determine key range of empty MST node")
 	}
-	if markDirty == true {
+	if markDirty {
 		n.Dirty = true
 	}
 	// check if lower than this entire node

--- a/atproto/repo/mst/node_insert.go
+++ b/atproto/repo/mst/node_insert.go
@@ -66,7 +66,9 @@ func (n *Node) insert(key []byte, val cid.Cid, height int) (*Node, *cid.Cid, err
 	}
 
 	// include "covering" proof for this operation
-	proveMutation(n, key)
+	if err := proveMutation(n, key); err != nil {
+		return nil, nil, err
+	}
 
 	if !split {
 		// TODO: is this really necessary? or can we just slices.Insert beyond the end of a slice?

--- a/atproto/repo/mst/node_insert.go
+++ b/atproto/repo/mst/node_insert.go
@@ -1,6 +1,7 @@
 package mst
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 
@@ -66,7 +67,7 @@ func (n *Node) insert(key []byte, val cid.Cid, height int) (*Node, *cid.Cid, err
 	}
 
 	// include "covering" proof for this operation
-	if err := proveMutation(n, key); err != nil {
+	if err := proveMutation(n, key); err != nil && !errors.Is(err, ErrPartialTree) {
 		return nil, nil, err
 	}
 

--- a/atproto/repo/mst/node_remove.go
+++ b/atproto/repo/mst/node_remove.go
@@ -61,7 +61,9 @@ func (n *Node) remove(key []byte, height int) (*Node, *cid.Cid, error) {
 	}
 
 	// marks adjacent child nodes dirty to include as "proof"
-	proveMutation(n, key)
+	if err := proveMutation(n, key); err != nil {
+		return nil, nil, err
+	}
 
 	// check if top of node is now just a pointer
 	if top {

--- a/atproto/repo/mst/node_remove.go
+++ b/atproto/repo/mst/node_remove.go
@@ -1,6 +1,7 @@
 package mst
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 
@@ -61,7 +62,7 @@ func (n *Node) remove(key []byte, height int) (*Node, *cid.Cid, error) {
 	}
 
 	// marks adjacent child nodes dirty to include as "proof"
-	if err := proveMutation(n, key); err != nil {
+	if err := proveMutation(n, key); err != nil && !errors.Is(err, ErrPartialTree) {
 		return nil, nil, err
 	}
 

--- a/atproto/repo/operation.go
+++ b/atproto/repo/operation.go
@@ -147,7 +147,7 @@ func NormalizeOps(list []Operation) ([]Operation, error) {
 
 	set := map[string]bool{}
 	for _, op := range list {
-		if _, ok := set[op.Path]; ok != false {
+		if _, ok := set[op.Path]; ok {
 			return nil, fmt.Errorf("duplicate path in operation list")
 		}
 		set[op.Path] = true

--- a/atproto/repo/operation_test.go
+++ b/atproto/repo/operation_test.go
@@ -91,9 +91,10 @@ func TestBasicOperation(t *testing.T) {
 	assert.NoError(err)
 	assert.Error(CheckOp(tree, op))
 
-	op, err = ApplyOp(tree, "color/pink", &c3)
+	_, err = ApplyOp(tree, "color/pink", &c3)
 	assert.NoError(err)
 	op, err = ApplyOp(tree, "color/pink", &c2)
+	assert.NoError(err)
 	assert.NoError(CheckOp(tree, op))
 	assert.True(op.IsUpdate())
 	err = InvertOp(tree, op)
@@ -130,7 +131,7 @@ func randomOperations(t *testing.T, size, opCount, iterations int) {
 	}
 	mapKeys := make([]string, len(startMap))
 	i := 0
-	for k, _ := range startMap {
+	for k := range startMap {
 		mapKeys[i] = k
 		i++
 	}

--- a/atproto/syntax/did.go
+++ b/atproto/syntax/did.go
@@ -14,7 +14,6 @@ import (
 type DID string
 
 var didRegex = regexp.MustCompile(`^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$`)
-var plcChars = ""
 
 func isASCIIAlphaNum(c rune) bool {
 	if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {

--- a/atproto/syntax/tid.go
+++ b/atproto/syntax/tid.go
@@ -58,7 +58,7 @@ func NewTIDFromInteger(v uint64) TID {
 
 // Constructs a new TID from a UNIX timestamp (in milliseconds) and clock ID value.
 func NewTID(unixMicros int64, clockId uint) TID {
-	var v uint64 = (uint64(unixMicros&0x1F_FFFF_FFFF_FFFF) << 10) | uint64(clockId&0x3FF)
+	v := (uint64(unixMicros&0x1F_FFFF_FFFF_FFFF) << 10) | uint64(clockId&0x3FF)
 	return NewTIDFromInteger(v)
 }
 


### PR DESCRIPTION
This isn't everything, just a first pass. There were some real issues with errors not getting wired through.

I'm kind of ambivalent about the pattern:

```go
	defer func() {
		_ = resp.Body.Close()
	}()
```

but do want to make any non-defer error returns explicit.