### PR TITLE
more `goat relay` helpers

### DIFF
--- a/cmd/goat/firehose.go
+++ b/cmd/goat/firehose.go
@@ -277,10 +277,12 @@ func (gfc *GoatFirehoseConsumer) handleSyncEvent(ctx context.Context, evt *comat
 	if gfc.Quiet {
 		return nil
 	}
-	evt.Blocks = nil
+	if !gfc.Blocks {
+		evt.Blocks = nil
+	}
 	out := make(map[string]interface{})
 	out["type"] = "sync"
-	out["commit"] = commit.AsData()
+	out["commit"] = commit.AsData() // NOTE: funky, but helpful, to include this in output
 	out["payload"] = evt
 	b, err := json.Marshal(out)
 	if err != nil {

--- a/cmd/goat/firehose.go
+++ b/cmd/goat/firehose.go
@@ -141,6 +141,12 @@ func runFirehose(cctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("invalid relayHost URI: %w", err)
 	}
+	switch u.Scheme {
+	case "http":
+		u.Scheme = "ws"
+	case "https":
+		u.Scheme = "wss"
+	}
 	u.Path = "xrpc/com.atproto.sync.subscribeRepos"
 	if cctx.IsSet("cursor") {
 		u.RawQuery = fmt.Sprintf("cursor=%d", cctx.Int("cursor"))

--- a/cmd/goat/relay_admin.go
+++ b/cmd/goat/relay_admin.go
@@ -92,16 +92,7 @@ var cmdRelayAdmin = &cli.Command{
 					ArgsUsage: `<hostname>`,
 					Flags: []cli.Flag{
 						&cli.IntFlag{
-							Name: "per-second",
-						},
-						&cli.IntFlag{
-							Name: "per-hour",
-						},
-						&cli.IntFlag{
-							Name: "per-day",
-						},
-						&cli.IntFlag{
-							Name: "repo-limit",
+							Name: "account-limit",
 						},
 					},
 					Action: runRelayAdminHostConfig,
@@ -376,17 +367,8 @@ func runRelayAdminHostConfig(cctx *cli.Context) error {
 	body := map[string]any{
 		"host": hostname,
 	}
-	if cctx.IsSet("per-second") {
-		body["per_second"] = cctx.Int("per-second")
-	}
-	if cctx.IsSet("per-hour") {
-		body["per_hour"] = cctx.Int("per-hour")
-	}
-	if cctx.IsSet("per-day") {
-		body["per_day"] = cctx.Int("per-day")
-	}
-	if cctx.IsSet("repo-limit") {
-		body["repo_limit"] = cctx.Int("repo-limit")
+	if cctx.IsSet("account-limit") {
+		body["repo_limit"] = cctx.Int("account-limit")
 	}
 
 	_, err = client.Do("POST", path, nil, body)


### PR DESCRIPTION
- host lists and status info
- more flexible firehose-mode host parsing (wss:// vs https://)
- include blocks in `#sync` firehose output (if requested)