### PR TITLE
Revert "make identity.Identity more easily JSON serializable"

### DIFF
--- a/atproto/identity/identity.go
+++ b/atproto/identity/identity.go
@@ -13,25 +13,25 @@ import (
 
 // Represents an atproto identity. Could be a regular user account, or a service account (eg, feed generator)
 type Identity struct {
-	DID syntax.DID `json:"did"`
+	DID syntax.DID
 
 	// Handle/DID mapping must be bi-directionally verified. If that fails, the Handle should be the special 'handle.invalid' value
-	Handle syntax.Handle `json:"handle"`
+	Handle syntax.Handle
 
 	// These fields represent a parsed subset of a DID document. They are all nullable. Note that the services and keys maps do not preserve order, so they don't exactly round-trip DID documents.
-	AlsoKnownAs []string           `json:"alsoKnownAs"`
-	Services    map[string]Service `json:"services"`
-	Keys        map[string]Key     `json:"keys"`
+	AlsoKnownAs []string
+	Services    map[string]Service
+	Keys        map[string]Key
 }
 
 type Key struct {
-	Type               string `json:"type"`
-	PublicKeyMultibase string `json:"publicKeyMultibase"`
+	Type               string
+	PublicKeyMultibase string
 }
 
 type Service struct {
-	Type string `json:"type"`
-	URL  string `json:"url"`
+	Type string
+	URL  string
 }
 
 // Extracts the information relevant to atproto from an arbitrary DID document.


### PR DESCRIPTION
This caused problems in prod. Unbeknownst to me, we had been serializing identity metadata as JSON using this struct and persisting it. Then passing back to TypeScript (not golang!), which depended on the capitalization (case-sensitive JSON parsing).

Reverting for now. Note that the go stdlib JSON code is actually case-insensitive for keys, so the text fixtures in this repo which had been updated to depend on this are not impacted (!).

Direct link to original PR: https://github.com/bluesky-social/indigo/pull/1017