### PR TITLE
Fix Relay Admin Page Auth

### DIFF
--- a/cmd/relay/service.go
+++ b/cmd/relay/service.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"encoding/base64"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -197,7 +197,7 @@ func (svc *Service) Shutdown() []error {
 }
 
 func (svc *Service) checkAdminAuth(next echo.HandlerFunc) echo.HandlerFunc {
-	headerVal := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:"+svc.config.AdminPassword))
+	headerVal := fmt.Sprintf("Bearer %s", svc.config.AdminPassword)
 	return func(c echo.Context) error {
 		hdr := c.Request().Header.Get("Authorization")
 		if hdr != headerVal {


### PR DESCRIPTION
Found this while doing a read-through of the new code and poking around. Without this change, when attempting to log in to the local admin UI, I get `Failed to validate Admin Token: Status 403`.

Either the UI should send basic auth, or the server handler should receive a bearer token. I just went with the server-side change, but if you'd prefer that the UI sends basic auth, happy to do that instead.

<img width="1329" alt="Screenshot 2025-04-17 at 17 45 31" src="https://github.com/user-attachments/assets/5cad2209-790e-46f7-9093-e612e1b52d35" />
