### PR TITLE
wire through ctx for all database (gorm) operations

### DIFF
--- a/cmd/relay/handlers.go
+++ b/cmd/relay/handlers.go
@@ -57,7 +57,7 @@ func (s *Service) handleComAtprotoSyncRequestCrawl(c echo.Context, body *comatpr
 		return c.JSON(http.StatusBadRequest, xrpc.XRPCError{ErrStr: "HostNotFound", Message: fmt.Sprintf("host server unreachable: %s", err)})
 	}
 
-	return s.relay.SubscribeToHost(hostname, noSSL, false)
+	return s.relay.SubscribeToHost(ctx, hostname, noSSL, false)
 }
 
 func (s *Service) handleComAtprotoSyncListHosts(c echo.Context, cursor int64, limit int) (*comatproto.SyncListHosts_Output, error) {
@@ -240,7 +240,8 @@ type HealthStatus struct {
 }
 
 func (svc *Service) HandleHealthCheck(c echo.Context) error {
-	if err := svc.relay.Healthcheck(); err != nil {
+	ctx := c.Request().Context()
+	if err := svc.relay.Healthcheck(ctx); err != nil {
 		svc.logger.Error("healthcheck can't connect to database", "err", err)
 		return c.JSON(http.StatusInternalServerError, HealthStatus{Status: "error", Message: "can't connect to database"})
 	} else {

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -205,6 +205,7 @@ func configLogger(cctx *cli.Context, writer io.Writer) *slog.Logger {
 }
 
 func runRelay(cctx *cli.Context) error {
+	ctx := cctx.Context
 	logger := configLogger(cctx, os.Stdout)
 
 	// Trap SIGINT to trigger a shutdown.
@@ -297,7 +298,7 @@ func runRelay(cctx *cli.Context) error {
 	}
 
 	// restart any existing subscriptions as worker goroutines
-	if err := r.ResubscribeAllHosts(); err != nil {
+	if err := r.ResubscribeAllHosts(ctx); err != nil {
 		return err
 	}
 

--- a/cmd/relay/relay/crawl.go
+++ b/cmd/relay/relay/crawl.go
@@ -2,11 +2,12 @@ package relay
 
 import (
 	"fmt"
+	"context"
 
 	"github.com/bluesky-social/indigo/cmd/relay/relay/models"
 )
 
-func (r *Relay) SubscribeToHost(hostname string, noSSL, adminForce bool) error {
+func (r *Relay) SubscribeToHost(ctx context.Context, hostname string, noSSL, adminForce bool) error {
 
 	// if we already have an active subscription, exit early
 	if r.Slurper.CheckIfSubscribed(hostname) {
@@ -16,7 +17,7 @@ func (r *Relay) SubscribeToHost(hostname string, noSSL, adminForce bool) error {
 	// fetch host info from database. this query will not error if host does not yet exist
 	newHost := false
 	var host models.Host
-	if err := r.db.Find(&host, "hostname = ?", hostname).Error; err != nil {
+	if err := r.db.WithContext(ctx).Find(&host, "hostname = ?", hostname).Error; err != nil {
 		return err
 	}
 
@@ -43,7 +44,7 @@ func (r *Relay) SubscribeToHost(hostname string, noSSL, adminForce bool) error {
 			AccountLimit: accountLimit,
 		}
 
-		if err := r.db.Create(&host).Error; err != nil {
+		if err := r.db.WithContext(ctx).Create(&host).Error; err != nil {
 			return err
 		}
 
@@ -56,10 +57,10 @@ func (r *Relay) SubscribeToHost(hostname string, noSSL, adminForce bool) error {
 }
 
 // This function expects to be run when starting up, to re-connect to known active hosts
-func (r *Relay) ResubscribeAllHosts() error {
+func (r *Relay) ResubscribeAllHosts(ctx context.Context) error {
 
 	var all []models.Host
-	if err := r.db.Find(&all, "status = ?", "active").Error; err != nil {
+	if err := r.db.WithContext(ctx).Find(&all, "status = ?", "active").Error; err != nil {
 		return err
 	}
 

--- a/cmd/relay/relay/domain_ban.go
+++ b/cmd/relay/relay/domain_ban.go
@@ -45,7 +45,7 @@ func (r *Relay) DomainIsBanned(ctx context.Context, hostname string) (bool, erro
 
 func (r *Relay) findDomainBan(ctx context.Context, domain string) (bool, error) {
 	var ban models.DomainBan
-	if err := r.db.Model(&models.DomainBan{}).Where("domain = ?", domain).First(&ban).Error; err != nil {
+	if err := r.db.WithContext(ctx).Model(&models.DomainBan{}).Where("domain = ?", domain).First(&ban).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return false, nil
 		}
@@ -56,17 +56,17 @@ func (r *Relay) findDomainBan(ctx context.Context, domain string) (bool, error) 
 
 func (r *Relay) CreateDomainBan(ctx context.Context, domain string) error {
 	domainBan := models.DomainBan{Domain: domain}
-	return r.db.Create(&domainBan).Error
+	return r.db.WithContext(ctx).Create(&domainBan).Error
 }
 
 func (r *Relay) RemoveDomainBan(ctx context.Context, domain string) error {
-	return r.db.Delete(&models.DomainBan{}, "domain = ?", domain).Error
+	return r.db.WithContext(ctx).Delete(&models.DomainBan{}, "domain = ?", domain).Error
 }
 
 // returns all domain bans
 func (r *Relay) ListDomainBans(ctx context.Context) ([]models.DomainBan, error) {
 	bans := []models.DomainBan{}
-	if err := r.db.Model(&models.DomainBan{}).Find(&bans).Error; err != nil {
+	if err := r.db.WithContext(ctx).Model(&models.DomainBan{}).Find(&bans).Error; err != nil {
 		return nil, err
 	}
 	return bans, nil

--- a/cmd/relay/relay/ingest.go
+++ b/cmd/relay/relay/ingest.go
@@ -137,7 +137,7 @@ func (r *Relay) processCommitEvent(ctx context.Context, evt *comatproto.SyncSubs
 		return err
 	}
 
-	err = r.UpsertAccountRepo(acc.UID, syntax.TID(newRepo.Rev), newRepo.CommitCID, newRepo.CommitDataCID)
+	err = r.UpsertAccountRepo(ctx, acc.UID, syntax.TID(newRepo.Rev), newRepo.CommitCID, newRepo.CommitDataCID)
 	if err != nil {
 		return fmt.Errorf("failed to upsert account repo (%s): %w", acc.DID, err)
 	}
@@ -182,7 +182,7 @@ func (r *Relay) processSyncEvent(ctx context.Context, evt *comatproto.SyncSubscr
 		return err
 	}
 
-	err = r.UpsertAccountRepo(acc.UID, syntax.TID(newRepo.Rev), newRepo.CommitCID, newRepo.CommitDataCID)
+	err = r.UpsertAccountRepo(ctx, acc.UID, syntax.TID(newRepo.Rev), newRepo.CommitCID, newRepo.CommitDataCID)
 	if err != nil {
 		return fmt.Errorf("failed to upsert account repo (%s): %w", acc.DID, err)
 	}

--- a/cmd/relay/relay/relay.go
+++ b/cmd/relay/relay/relay.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"log/slog"
 	"sync"
+	"context"
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/cmd/relay/relay/models"
@@ -125,6 +126,6 @@ func (r *Relay) MigrateDatabase() error {
 }
 
 // simple check of connection to database
-func (r *Relay) Healthcheck() error {
-	return r.db.Exec("SELECT 1").Error
+func (r *Relay) Healthcheck(ctx context.Context) error {
+	return r.db.WithContext(ctx).Exec("SELECT 1").Error
 }

--- a/cmd/relay/testing/runner.go
+++ b/cmd/relay/testing/runner.go
@@ -132,7 +132,7 @@ func RunScenario(ctx context.Context, s *Scenario) error {
 
 	sr := MustSimpleRelay(&dir, tmpd, s.Lenient)
 
-	err = sr.Relay.SubscribeToHost(fmt.Sprintf("localhost:%d", hostPort), true, true)
+	err = sr.Relay.SubscribeToHost(ctx, fmt.Sprintf("localhost:%d", hostPort), true, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This involved both adding `.WithContext(ctx)` to any database calls, and wiring through `ctx` in a couple functions which should have had it already.

The one place I didn't wire this through is gorm auto database migrations in the setup command. It felt less necessary during process initialization, though I can add if requested.