### PR TITLE
support multiple admin passwords

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -42,9 +42,9 @@ func run(args []string) error {
 		Version: versioninfo.Short(),
 	}
 	app.Flags = []cli.Flag{
-		&cli.StringFlag{
+		&cli.StringSliceFlag{
 			Name:    "admin-password",
-			Usage:   "secret password/token for accessing admin endpoints (random is used if not set)",
+			Usage:   "secret password/token for accessing admin endpoints (multiple values allowed)",
 			EnvVars: []string{"RELAY_ADMIN_PASSWORD", "RELAY_ADMIN_KEY"},
 		},
 		&cli.StringFlag{
@@ -258,12 +258,13 @@ func runRelay(cctx *cli.Context) error {
 		logger.Info("sibling relay hosts configured for admin state forwarding", "servers", svcConfig.SiblingRelayHosts)
 	}
 	if cctx.IsSet("admin-password") {
-		svcConfig.AdminPassword = cctx.String("admin-password")
+		svcConfig.AdminPasswords = cctx.StringSlice("admin-password")
 	} else {
 		var rblob [10]byte
 		_, _ = rand.Read(rblob[:])
-		svcConfig.AdminPassword = base64.URLEncoding.EncodeToString(rblob[:])
-		logger.Info("generated random admin password", "username", "admin", "password", svcConfig.AdminPassword)
+		randPassword := base64.URLEncoding.EncodeToString(rblob[:])
+		svcConfig.AdminPasswords = []string{randPassword}
+		logger.Info("generated random admin password", "username", "admin", "password", randPassword)
 	}
 
 	evtman := eventmgr.NewEventManager(persister)

--- a/cmd/relay/service.go
+++ b/cmd/relay/service.go
@@ -210,13 +210,15 @@ func (svc *Service) checkAdminAuth(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		hdr := c.Request().Header.Get("Authorization")
 		if hdr == "" {
-			return echo.ErrForbidden
+			c.Response().Header().Set("WWW-Authenticate", "Basic")
+			return echo.ErrUnauthorized
 		}
 		for _, val := range validAuthHeaders {
 			if subtle.ConstantTimeCompare([]byte(hdr), []byte(val)) == 1 {
 				return next(c)
 			}
 		}
-		return echo.ErrForbidden
+		c.Response().Header().Set("WWW-Authenticate", "Basic")
+		return echo.ErrUnauthorized
 	}
 }


### PR DESCRIPTION
- relay support for multiple admin passwords at the same time (to make secret rotation easier)
- have a parallel PR going with README updates; will mention in that PR that the env var is comma-separated, so passwords can't contain a comma
- does not change the arg name or env var name, so existing configs work fine
- also switches to constant-time string comparison using go stdlib (more secure)