### PR TITLE
implement sibling relay admin request forwarding

### DIFF
--- a/cmd/relay/handlers_admin.go
+++ b/cmd/relay/handlers_admin.go
@@ -24,7 +24,6 @@ func (s *Service) handleAdminRequestCrawl(c echo.Context) error {
 		return &echo.HTTPError{Code: http.StatusBadRequest, Message: fmt.Sprintf("invalid body: %s", err)}
 	}
 
-	// func (s *Service) handleComAtprotoSyncRequestCrawl(ctx context.Context,body *comatproto.SyncRequestCrawl_Input) error
 	return s.handleComAtprotoSyncRequestCrawl(c, &body, true)
 }
 
@@ -59,7 +58,8 @@ func (s *Service) handleAdminSetNewHostPerDayRateLimit(c echo.Context) error {
 
 	s.relay.HostPerDayLimiter.SetLimit(limit)
 
-	// TODO: forward to SiblingRelayHosts
+	// NOTE: *not* forwarding to sibling instances
+
 	return c.JSON(http.StatusOK, map[string]any{
 		"success": "true",
 	})
@@ -97,7 +97,9 @@ func (s *Service) handleAdminTakeDownRepo(c echo.Context) error {
 		}
 	}
 
-	// TODO: forward to SiblingRelayHosts
+	// forward on to any sibling instances
+	go s.ForwardAdminRequest(c)
+
 	return c.JSON(http.StatusOK, map[string]any{
 		"success": "true",
 	})
@@ -135,7 +137,9 @@ func (s *Service) handleAdminReverseTakedown(c echo.Context) error {
 		}
 	}
 
-	// TODO: forward to SiblingRelayHosts
+	// forward on to any sibling instances
+	go s.ForwardAdminRequest(c)
+
 	return c.JSON(http.StatusOK, map[string]any{
 		"success": "true",
 	})
@@ -306,6 +310,8 @@ func (s *Service) handleAdminKillUpstreamConn(c echo.Context) error {
 		return err
 	}
 
+	// NOTE: *not* forwarding this request to sibling relays
+
 	return c.JSON(http.StatusOK, map[string]any{
 		"success": "true",
 	})
@@ -337,7 +343,9 @@ func (s *Service) handleBlockHost(c echo.Context) error {
 	// kill any active connection (there may not be one, so ignore error)
 	_ = s.relay.Slurper.KillUpstreamConnection(ctx, host.Hostname, false)
 
-	// TODO: forward to SiblingRelayHosts
+	// forward on to any sibling instances
+	go s.ForwardAdminRequest(c)
+
 	return c.JSON(http.StatusOK, map[string]any{
 		"success": "true",
 	})
@@ -366,7 +374,9 @@ func (s *Service) handleUnblockHost(c echo.Context) error {
 		}
 	}
 
-	// TODO: forward to SiblingRelayHosts
+	// forward on to any sibling instances
+	go s.ForwardAdminRequest(c)
+
 	return c.JSON(http.StatusOK, map[string]any{
 		"success": "true",
 	})
@@ -412,7 +422,9 @@ func (s *Service) handleAdminBanDomain(c echo.Context) error {
 		return err
 	}
 
-	// TODO: forward to SiblingRelayHosts
+	// forward on to any sibling instances
+	go s.ForwardAdminRequest(c)
+
 	return c.JSON(http.StatusOK, map[string]any{
 		"success": "true",
 	})
@@ -431,7 +443,9 @@ func (s *Service) handleAdminUnbanDomain(c echo.Context) error {
 		return err
 	}
 
-	// TODO: forward to SiblingRelayHosts
+	// forward on to any sibling instances
+	go s.ForwardAdminRequest(c)
+
 	return c.JSON(http.StatusOK, map[string]any{
 		"success": "true",
 	})
@@ -470,7 +484,74 @@ func (s *Service) handleAdminChangeHostRateLimits(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to update limits: %s", err))
 	}
 
+	// forward on to any sibling instances
+	go s.ForwardAdminRequest(c)
+
 	return c.JSON(http.StatusOK, map[string]any{
 		"success": "true",
 	})
+}
+
+// this method expects to be run in a goroutine. it does not take a `context.Context`, the input `echo.Context` has likely be cancelled/closed, and does not return an error (only logs)
+func (s *Service) ForwardAdminRequest(c echo.Context) {
+
+	if len(s.config.SiblingRelayHosts) == 0 {
+		return
+	}
+
+	// if this request was forwarded, or user-agent matches, then don't forward
+	req := c.Request()
+	fwd := req.Header.Get("Forwarded")
+	if strings.Contains(fwd, "by=relay") {
+		return
+	}
+	userAgent := req.Header.Get("User-Agent")
+	if strings.Contains(userAgent, "rainbow") || strings.Contains(userAgent, "relay") {
+		return
+	}
+
+	client := http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	for _, rawHost := range s.config.SiblingRelayHosts {
+		hostname, noSSL, err := relay.ParseHostname(rawHost)
+		if err != nil {
+			s.logger.Error("invalid sibling hostname configured", "host", rawHost, "err", err)
+			return
+		}
+		u := req.URL
+		u.Host = hostname
+		if noSSL {
+			u.Scheme = "http"
+		} else {
+			u.Scheme = "https"
+		}
+		upstreamReq, err := http.NewRequest(req.Method, u.String(), req.Body)
+		if err != nil {
+			s.logger.Error("creating admin forward request failed", "method", req.Method, "url", u.String(), "err", err)
+			continue
+		}
+
+		// copy some headers from inbound request
+		for k, vals := range req.Header {
+			if strings.ToLower(k) == "accept" || strings.ToLower(k) == "authentication" {
+				upstreamReq.Header.Add(k, vals[0])
+			}
+		}
+		upstreamReq.Header.Add("User-Agent", s.relay.Config.UserAgent)
+		upstreamReq.Header.Add("Forwarded", "by=relay")
+
+		upstreamResp, err := client.Do(upstreamReq)
+		if err != nil {
+			s.logger.Error("forwarded admin HTTP request failed", "method", req.Method, "url", u.String(), "err", err)
+			continue
+		}
+		upstreamResp.Body.Close()
+		if upstreamResp.StatusCode != http.StatusOK {
+			s.logger.Error("forwarded admin HTTP request failed", "method", req.Method, "url", u.String(), "statusCode", upstreamResp.StatusCode)
+			continue
+		}
+		s.logger.Info("successfully forwarded admin HTTP request", "method", req.Method, "url", u.String())
+	}
 }


### PR DESCRIPTION
This is the sketch of the feature, haven't tested it yet.

In particular, realized we don't have direct access between our multiple prod relay instances across WAN. Might need rainbow proxying support? Or some other hole-punch.