### PR TITLE
rainbow: fix getRepo redirects

### DIFF
--- a/splitter/handlers.go
+++ b/splitter/handlers.go
@@ -72,7 +72,7 @@ func (s *Splitter) HandleComAtprotoSyncRequestCrawl(c echo.Context) error {
 			// new context to outlive original HTTP request
 			ctx := context.Background()
 			xrpcc := xrpc.Client{
-				Client: s.upstreamClient,
+				Client: s.peerClient,
 				Host:   hostname,
 			}
 			if err := comatproto.SyncRequestCrawl(ctx, &xrpcc, &body); err != nil {

--- a/splitter/handlers.go
+++ b/splitter/handlers.go
@@ -129,7 +129,13 @@ func (s *Splitter) ProxyRequest(c echo.Context, hostname, scheme string) error {
 	}
 	defer upstreamResp.Body.Close()
 
-	respWriter.Header()["Content-Type"] = []string{upstreamResp.Header.Get("Content-Type")}
+	// copy a subset of headers
+	for _, hdr := range []string{"Content-Type", "Content-Length", "Location"} {
+		val := upstreamResp.Header.Get(hdr)
+		if val != "" {
+			respWriter.Header().Set(hdr, val)
+		}
+	}
 	respWriter.WriteHeader(upstreamResp.StatusCode)
 
 	_, err = io.Copy(respWriter, upstreamResp.Body)


### PR DESCRIPTION
Rainbow was accidentially following HTTP redirects and streaming back full CAR files when handling getRepo requests.

This correctly passes through the HTTP 3xx response back to the client, which then does the request to the PDS.

Note that proxying or returning the CAR directly isn't *forbidden*, it just isn't the behavior we want right now. We might eventually do proxying and coalescing/caching in rainbow/relay to reduce network load.