### PR TITLE
basic JWK support in crypto SDK

### DIFF
--- a/atproto/crypto/jwk.go
+++ b/atproto/crypto/jwk.go
@@ -1,0 +1,124 @@
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	secp256k1 "gitlab.com/yawning/secp256k1-voi"
+	secp256k1secec "gitlab.com/yawning/secp256k1-voi/secec"
+)
+
+// Representation of a JSON Web Key (JWK), as relevant to the keys supported by this package.
+//
+// Expected to be marshalled/unmarshalled as JSON.
+type JWK struct {
+	Algorithm string  `json:"alg"`
+	Curve     string  `json:"crv"`
+	X         string  `json:"x"` // base64url, no padding
+	Y         string  `json:"y"` // base64url, no padding
+	Use       string  `json:"use,omitempty"`
+	KeyID     *string `json:"kid,omitempty"`
+}
+
+// Loads a [PublicKey] from JWK (serialized as JSON bytes)
+func ParsePublicJWKBytes(jwkBytes []byte) (PublicKey, error) {
+	var jwk JWK
+	if err := json.Unmarshal(jwkBytes, &jwk); err != nil {
+		return nil, fmt.Errorf("parsing JWK JSON: %w", err)
+	}
+	return ParsePublicJWK(jwk)
+}
+
+// Loads a [PublicKey] from JWK struct.
+func ParsePublicJWK(jwk JWK) (PublicKey, error) {
+
+	if jwk.Algorithm != "EC" {
+		return nil, fmt.Errorf("unsupported JWK cryptography: %s", jwk.Algorithm)
+	}
+
+	// base64url with no encoding
+	xbuf, err := base64.RawURLEncoding.DecodeString(jwk.X)
+	if err != nil {
+		return nil, fmt.Errorf("invalid JWK base64 encoding: %w", err)
+	}
+	ybuf, err := base64.RawURLEncoding.DecodeString(jwk.Y)
+	if err != nil {
+		return nil, fmt.Errorf("invalid JWK base64 encoding: %w", err)
+	}
+
+	switch jwk.Curve {
+	case "P-256":
+		curve := elliptic.P256()
+
+		var x, y big.Int
+		x.SetBytes(xbuf)
+		y.SetBytes(ybuf)
+
+		if !curve.Params().IsOnCurve(&x, &y) {
+			return nil, fmt.Errorf("invalid P-256 public key (not on curve)")
+		}
+		pubECDSA := &ecdsa.PublicKey{
+			Curve: curve,
+			X:     &x,
+			Y:     &y,
+		}
+		pub := PublicKeyP256{pubP256: *pubECDSA}
+		err := pub.checkCurve()
+		if err != nil {
+			return nil, err
+		}
+		return &pub, nil
+	case "secp256k1": // K-256
+		if len(xbuf) != 32 || len(ybuf) != 32 {
+			return nil, fmt.Errorf("invalid K-256 coordinates")
+		}
+		xarr := ([32]byte)(xbuf[:32])
+		yarr := ([32]byte)(ybuf[:32])
+		p, err := secp256k1.NewPointFromCoords(&xarr, &yarr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid K-256 coordinates: %w", err)
+		}
+		pubK, err := secp256k1secec.NewPublicKeyFromPoint(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid K-256/secp256k1 public key: %w", err)
+		}
+		pub := PublicKeyK256{pubK256: pubK}
+		err = pub.ensureBytes()
+		if err != nil {
+			return nil, err
+		}
+		return &pub, nil
+	default:
+		return nil, fmt.Errorf("unsupported JWK cryptography: %s", jwk.Curve)
+	}
+}
+
+func (k *PublicKeyP256) JWK() (*JWK, error) {
+	jwk := JWK{
+		Algorithm: "EC",
+		Curve:     "P-256",
+		X:         base64.RawURLEncoding.EncodeToString(k.pubP256.X.Bytes()),
+		Y:         base64.RawURLEncoding.EncodeToString(k.pubP256.Y.Bytes()),
+	}
+	return &jwk, nil
+}
+
+func (k *PublicKeyK256) JWK() (*JWK, error) {
+	raw := k.UncompressedBytes()
+	if len(raw) != 65 {
+		return nil, fmt.Errorf("unexpected K-256 bytes size")
+	}
+	xbytes := raw[1:33]
+	ybytes := raw[33:65]
+	jwk := JWK{
+		Algorithm: "EC",
+		Curve:     "secp256k1",
+		X:         base64.RawURLEncoding.EncodeToString(xbytes),
+		Y:         base64.RawURLEncoding.EncodeToString(ybytes),
+	}
+	return &jwk, nil
+}

--- a/atproto/crypto/jwk.go
+++ b/atproto/crypto/jwk.go
@@ -16,12 +16,12 @@ import (
 //
 // Expected to be marshalled/unmarshalled as JSON.
 type JWK struct {
-	Algorithm string  `json:"alg"`
-	Curve     string  `json:"crv"`
-	X         string  `json:"x"` // base64url, no padding
-	Y         string  `json:"y"` // base64url, no padding
-	Use       string  `json:"use,omitempty"`
-	KeyID     *string `json:"kid,omitempty"`
+	KeyType string  `json:"kty"`
+	Curve   string  `json:"crv"`
+	X       string  `json:"x"` // base64url, no padding
+	Y       string  `json:"y"` // base64url, no padding
+	Use     string  `json:"use,omitempty"`
+	KeyID   *string `json:"kid,omitempty"`
 }
 
 // Loads a [PublicKey] from JWK (serialized as JSON bytes)
@@ -36,8 +36,8 @@ func ParsePublicJWKBytes(jwkBytes []byte) (PublicKey, error) {
 // Loads a [PublicKey] from JWK struct.
 func ParsePublicJWK(jwk JWK) (PublicKey, error) {
 
-	if jwk.Algorithm != "EC" {
-		return nil, fmt.Errorf("unsupported JWK cryptography: %s", jwk.Algorithm)
+	if jwk.KeyType != "EC" {
+		return nil, fmt.Errorf("unsupported JWK key type: %s", jwk.KeyType)
 	}
 
 	// base64url with no encoding
@@ -99,10 +99,10 @@ func ParsePublicJWK(jwk JWK) (PublicKey, error) {
 
 func (k *PublicKeyP256) JWK() (*JWK, error) {
 	jwk := JWK{
-		Algorithm: "EC",
-		Curve:     "P-256",
-		X:         base64.RawURLEncoding.EncodeToString(k.pubP256.X.Bytes()),
-		Y:         base64.RawURLEncoding.EncodeToString(k.pubP256.Y.Bytes()),
+		KeyType: "EC",
+		Curve:   "P-256",
+		X:       base64.RawURLEncoding.EncodeToString(k.pubP256.X.Bytes()),
+		Y:       base64.RawURLEncoding.EncodeToString(k.pubP256.Y.Bytes()),
 	}
 	return &jwk, nil
 }
@@ -115,10 +115,10 @@ func (k *PublicKeyK256) JWK() (*JWK, error) {
 	xbytes := raw[1:33]
 	ybytes := raw[33:65]
 	jwk := JWK{
-		Algorithm: "EC",
-		Curve:     "secp256k1",
-		X:         base64.RawURLEncoding.EncodeToString(xbytes),
-		Y:         base64.RawURLEncoding.EncodeToString(ybytes),
+		KeyType: "EC",
+		Curve:   "secp256k1",
+		X:       base64.RawURLEncoding.EncodeToString(xbytes),
+		Y:       base64.RawURLEncoding.EncodeToString(ybytes),
 	}
 	return &jwk, nil
 }

--- a/atproto/crypto/jwk_test.go
+++ b/atproto/crypto/jwk_test.go
@@ -1,0 +1,86 @@
+package crypto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseJWK(t *testing.T) {
+	assert := assert.New(t)
+
+	jwkTestFixtures := []string{
+		// https://openid.net/specs/draft-jones-json-web-key-03.html
+		`{
+			"alg":"EC",
+			"crv":"P-256",
+			"x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+			"y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+			"use":"enc",
+			"kid":"1"
+		}`,
+		// https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/
+		`{
+    		"alg": "EC",
+    		"crv": "secp256k1",
+    		"kid": "JUvpllMEYUZ2joO59UNui_XYDqxVqiFLLAJ8klWuPBw",
+    		"x": "dWCvM4fTdeM0KmloF57zxtBPXTOythHPMm1HCLrdd3A",
+    		"y": "36uMVGM7hnw-N6GnjFcihWE3SkrhMLzzLCdPMXPEXlA"
+  		}`,
+	}
+
+	for _, jwkBytes := range jwkTestFixtures {
+		_, err := ParsePublicJWKBytes([]byte(jwkBytes))
+		assert.NoError(err)
+	}
+}
+
+func TestP256GenJWK(t *testing.T) {
+	assert := assert.New(t)
+
+	priv, err := GeneratePrivateKeyP256()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, err := priv.PublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pk, ok := pub.(*PublicKeyP256)
+	if !ok {
+		t.Fatal()
+	}
+	jwk, err := pk.JWK()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ParsePublicJWK(*jwk)
+	assert.NoError(err)
+}
+
+func TestK256GenJWK(t *testing.T) {
+	assert := assert.New(t)
+
+	priv, err := GeneratePrivateKeyK256()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, err := priv.PublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pk, ok := pub.(*PublicKeyK256)
+	if !ok {
+		t.Fatal()
+	}
+	jwk, err := pk.JWK()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ParsePublicJWK(*jwk)
+	assert.NoError(err)
+}

--- a/atproto/crypto/jwk_test.go
+++ b/atproto/crypto/jwk_test.go
@@ -10,18 +10,30 @@ func TestParseJWK(t *testing.T) {
 	assert := assert.New(t)
 
 	jwkTestFixtures := []string{
-		// https://openid.net/specs/draft-jones-json-web-key-03.html
+		// https://datatracker.ietf.org/doc/html/rfc7517#appendix-A.1
+		`{
+			"kty":"EC",
+          	"crv":"P-256",
+          	"x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+          	"y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+          	"d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE",
+          	"use":"enc",
+          	"kid":"1"
+      	}`,
+		// https://openid.net/specs/draft-jones-json-web-key-03.html; with kty in addition to alg
 		`{
 			"alg":"EC",
+			"kty":"EC",
 			"crv":"P-256",
 			"x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
 			"y":"4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
 			"use":"enc",
 			"kid":"1"
 		}`,
-		// https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/
+		// https://w3c-ccg.github.io/lds-ecdsa-secp256k1-2019/; with kty in addition to alg
 		`{
     		"alg": "EC",
+    		"kty": "EC",
     		"crv": "secp256k1",
     		"kid": "JUvpllMEYUZ2joO59UNui_XYDqxVqiFLLAJ8klWuPBw",
     		"x": "dWCvM4fTdeM0KmloF57zxtBPXTOythHPMm1HCLrdd3A",

--- a/atproto/crypto/keys.go
+++ b/atproto/crypto/keys.go
@@ -63,6 +63,9 @@ type PublicKey interface {
 	// For systems with no compressed/uncompressed distinction, returns the same
 	// value as Bytes().
 	UncompressedBytes() []byte
+
+	// Serialization as JWK struct (which can be marshalled to JSON)
+	JWK() (*JWK, error)
 }
 
 var ErrInvalidSignature = errors.New("crytographic signature invalid")


### PR DESCRIPTION
Basic JWK serialization of the curves we use for atproto crypto (P-256, K-256), for public keys only. This will get used in OAuth implementation.

The decision to implement this directly instead of using something like https://github.com/lestrrat-go/jwx is entangled with deciding to use `golang-jwt` for service auth implementation (which is distinct from OAuth implementation, and doesn't directly require JWKs). I think the secp256k1 experimental support in `jwx/jwt` would pull in a new dependency/implementation, and I like our current choice, and it doesn't seem as easy to wedge in a new curve type/implementation with `jwx` family of packages.

On the other hand, I sure don't love parsing those uncompressed bytes out in to `(x, y)` coordinates!

I thought about only exposing `[]byte` JSON instead of the `JWK` struct itself, but feels more idiomatic and flexible to just expose the struct. For example, will make it easier for calling code to deal with JWK sets (arrays of keys, used in OAuth client metadata).