### PR TITLE
bgs: ensure output channel is closed if it isn't sub.output

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -453,10 +453,13 @@ func (em *EventManager) Subscribe(ctx context.Context, ident string, filter func
 			select {
 			case out <- evt:
 			case <-done:
+				close(out)
 				em.rmSubscriber(sub)
 				return
 			}
 		}
+		close(out)
+		em.rmSubscriber(sub)
 	}()
 
 	return out, sub.cleanup, nil

--- a/events/events.go
+++ b/events/events.go
@@ -415,12 +415,19 @@ func (em *EventManager) Subscribe(ctx context.Context, ident string, filter func
 			}
 
 			// TODO: send an error frame or something?
+			// NOTE: not doing em.rmSubscriber(sub) here because it hasn't been added yet
 			close(out)
 			return
 		}
 
 		// now, start buffering events from the live stream
 		em.addSubscriber(sub)
+
+		// ensure that we clean up any return paths from here out, after having added the subscriber. Note that `out` is not `sub.output`, so needs to be closed separately.
+		defer func() {
+			close(out)
+			em.rmSubscriber(sub)
+		}()
 
 		first := <-sub.outgoing
 
@@ -440,10 +447,6 @@ func (em *EventManager) Subscribe(ctx context.Context, ident string, filter func
 		}); err != nil {
 			if !errors.Is(err, ErrCaughtUp) {
 				em.log.Error("events playback", "err", err)
-
-				// TODO: send an error frame or something?
-				close(out)
-				em.rmSubscriber(sub)
 				return
 			}
 		}
@@ -453,13 +456,9 @@ func (em *EventManager) Subscribe(ctx context.Context, ident string, filter func
 			select {
 			case out <- evt:
 			case <-done:
-				close(out)
-				em.rmSubscriber(sub)
 				return
 			}
 		}
-		close(out)
-		em.rmSubscriber(sub)
 	}()
 
 	return out, sub.cleanup, nil


### PR DESCRIPTION
The issue here is that when a cursor is supplied, sub.output isn't actually the channel which is passed along to calling code; the 'out' chan is what gets returned.

This means that sub.output getting closed needs to be wired through to 'out' getting closed as well.

NOTE: this is in old relay code ("BGS"). If we like this fix, should copy it to new relay code (`indigo:cmd/relay/stream`) before merging.