### PR TITLE
lexgen: use lexutil.LexClient interface for codegen

### DIFF
--- a/api/agnostic/actorgetPreferences.go
+++ b/api/agnostic/actorgetPreferences.go
@@ -7,7 +7,7 @@ package agnostic
 import (
 	"context"
 
-	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/bluesky-social/indigo/lex/util"
 )
 
 // ActorGetPreferences_Output is the output of a app.bsky.actor.getPreferences call.
@@ -16,11 +16,11 @@ type ActorGetPreferences_Output struct {
 }
 
 // ActorGetPreferences calls the XRPC method "app.bsky.actor.getPreferences".
-func ActorGetPreferences(ctx context.Context, c *xrpc.Client) (*ActorGetPreferences_Output, error) {
+func ActorGetPreferences(ctx context.Context, c util.LexClient) (*ActorGetPreferences_Output, error) {
 	var out ActorGetPreferences_Output
 
 	params := map[string]interface{}{}
-	if err := c.Do(ctx, xrpc.Query, "", "app.bsky.actor.getPreferences", params, nil, &out); err != nil {
+	if err := c.LexDo(ctx, util.Query, "", "app.bsky.actor.getPreferences", params, nil, &out); err != nil {
 		return nil, err
 	}
 

--- a/api/agnostic/actorputPreferences.go
+++ b/api/agnostic/actorputPreferences.go
@@ -7,7 +7,7 @@ package agnostic
 import (
 	"context"
 
-	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/bluesky-social/indigo/lex/util"
 )
 
 // ActorPutPreferences_Input is the input argument to a app.bsky.actor.putPreferences call.
@@ -16,8 +16,8 @@ type ActorPutPreferences_Input struct {
 }
 
 // ActorPutPreferences calls the XRPC method "app.bsky.actor.putPreferences".
-func ActorPutPreferences(ctx context.Context, c *xrpc.Client, input *ActorPutPreferences_Input) error {
-	if err := c.Do(ctx, xrpc.Procedure, "application/json", "app.bsky.actor.putPreferences", nil, input, nil); err != nil {
+func ActorPutPreferences(ctx context.Context, c util.LexClient, input *ActorPutPreferences_Input) error {
+	if err := c.LexDo(ctx, util.Procedure, "application/json", "app.bsky.actor.putPreferences", nil, input, nil); err != nil {
 		return err
 	}
 

--- a/api/agnostic/identitygetRecommendedDidCredentials.go
+++ b/api/agnostic/identitygetRecommendedDidCredentials.go
@@ -8,14 +8,14 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/bluesky-social/indigo/lex/util"
 )
 
 // IdentityGetRecommendedDidCredentials calls the XRPC method "com.atproto.identity.getRecommendedDidCredentials".
-func IdentityGetRecommendedDidCredentials(ctx context.Context, c *xrpc.Client) (*json.RawMessage, error) {
+func IdentityGetRecommendedDidCredentials(ctx context.Context, c util.LexClient) (*json.RawMessage, error) {
 	var out json.RawMessage
 
-	if err := c.Do(ctx, xrpc.Query, "", "com.atproto.identity.getRecommendedDidCredentials", nil, nil, &out); err != nil {
+	if err := c.LexDo(ctx, util.Query, "", "com.atproto.identity.getRecommendedDidCredentials", nil, nil, &out); err != nil {
 		return nil, err
 	}
 

--- a/api/agnostic/identitysignPlcOperation.go
+++ b/api/agnostic/identitysignPlcOperation.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/bluesky-social/indigo/lex/util"
 )
 
 // IdentitySignPlcOperation_Input is the input argument to a com.atproto.identity.signPlcOperation call.
@@ -28,9 +28,9 @@ type IdentitySignPlcOperation_Output struct {
 }
 
 // IdentitySignPlcOperation calls the XRPC method "com.atproto.identity.signPlcOperation".
-func IdentitySignPlcOperation(ctx context.Context, c *xrpc.Client, input *IdentitySignPlcOperation_Input) (*IdentitySignPlcOperation_Output, error) {
+func IdentitySignPlcOperation(ctx context.Context, c util.LexClient, input *IdentitySignPlcOperation_Input) (*IdentitySignPlcOperation_Output, error) {
 	var out IdentitySignPlcOperation_Output
-	if err := c.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.identity.signPlcOperation", nil, input, &out); err != nil {
+	if err := c.LexDo(ctx, util.Procedure, "application/json", "com.atproto.identity.signPlcOperation", nil, input, &out); err != nil {
 		return nil, err
 	}
 

--- a/api/agnostic/identitysubmitPlcOperation.go
+++ b/api/agnostic/identitysubmitPlcOperation.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/bluesky-social/indigo/lex/util"
 )
 
 // IdentitySubmitPlcOperation_Input is the input argument to a com.atproto.identity.submitPlcOperation call.
@@ -17,8 +17,8 @@ type IdentitySubmitPlcOperation_Input struct {
 }
 
 // IdentitySubmitPlcOperation calls the XRPC method "com.atproto.identity.submitPlcOperation".
-func IdentitySubmitPlcOperation(ctx context.Context, c *xrpc.Client, input *IdentitySubmitPlcOperation_Input) error {
-	if err := c.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.identity.submitPlcOperation", nil, input, nil); err != nil {
+func IdentitySubmitPlcOperation(ctx context.Context, c util.LexClient, input *IdentitySubmitPlcOperation_Input) error {
+	if err := c.LexDo(ctx, util.Procedure, "application/json", "com.atproto.identity.submitPlcOperation", nil, input, nil); err != nil {
 		return err
 	}
 

--- a/api/agnostic/repoapplyWrites.go
+++ b/api/agnostic/repoapplyWrites.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"github.com/bluesky-social/indigo/lex/util"
-	"github.com/bluesky-social/indigo/xrpc"
 )
 
 // RepoApplyWrites_Create is a "create" in the com.atproto.repo.applyWrites schema.
@@ -179,9 +178,9 @@ type RepoApplyWrites_UpdateResult struct {
 }
 
 // RepoApplyWrites calls the XRPC method "com.atproto.repo.applyWrites".
-func RepoApplyWrites(ctx context.Context, c *xrpc.Client, input *RepoApplyWrites_Input) (*RepoApplyWrites_Output, error) {
+func RepoApplyWrites(ctx context.Context, c util.LexClient, input *RepoApplyWrites_Input) (*RepoApplyWrites_Output, error) {
 	var out RepoApplyWrites_Output
-	if err := c.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.applyWrites", nil, input, &out); err != nil {
+	if err := c.LexDo(ctx, util.Procedure, "application/json", "com.atproto.repo.applyWrites", nil, input, &out); err != nil {
 		return nil, err
 	}
 

--- a/api/agnostic/repocreateRecord.go
+++ b/api/agnostic/repocreateRecord.go
@@ -7,7 +7,7 @@ package agnostic
 import (
 	"context"
 
-	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/bluesky-social/indigo/lex/util"
 )
 
 // RepoDefs_CommitMeta is a "commitMeta" in the com.atproto.repo.defs schema.
@@ -41,9 +41,9 @@ type RepoCreateRecord_Output struct {
 }
 
 // RepoCreateRecord calls the XRPC method "com.atproto.repo.createRecord".
-func RepoCreateRecord(ctx context.Context, c *xrpc.Client, input *RepoCreateRecord_Input) (*RepoCreateRecord_Output, error) {
+func RepoCreateRecord(ctx context.Context, c util.LexClient, input *RepoCreateRecord_Input) (*RepoCreateRecord_Output, error) {
 	var out RepoCreateRecord_Output
-	if err := c.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.createRecord", nil, input, &out); err != nil {
+	if err := c.LexDo(ctx, util.Procedure, "application/json", "com.atproto.repo.createRecord", nil, input, &out); err != nil {
 		return nil, err
 	}
 

--- a/api/agnostic/repogetRecord.go
+++ b/api/agnostic/repogetRecord.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/bluesky-social/indigo/lex/util"
 )
 
 // RepoGetRecord_Output is the output of a com.atproto.repo.getRecord call.
@@ -25,7 +25,7 @@ type RepoGetRecord_Output struct {
 // collection: The NSID of the record collection.
 // repo: The handle or DID of the repo.
 // rkey: The Record Key.
-func RepoGetRecord(ctx context.Context, c *xrpc.Client, cid string, collection string, repo string, rkey string) (*RepoGetRecord_Output, error) {
+func RepoGetRecord(ctx context.Context, c util.LexClient, cid string, collection string, repo string, rkey string) (*RepoGetRecord_Output, error) {
 	var out RepoGetRecord_Output
 
 	params := map[string]interface{}{
@@ -34,7 +34,7 @@ func RepoGetRecord(ctx context.Context, c *xrpc.Client, cid string, collection s
 		"repo":       repo,
 		"rkey":       rkey,
 	}
-	if err := c.Do(ctx, xrpc.Query, "", "com.atproto.repo.getRecord", params, nil, &out); err != nil {
+	if err := c.LexDo(ctx, util.Query, "", "com.atproto.repo.getRecord", params, nil, &out); err != nil {
 		return nil, err
 	}
 

--- a/api/agnostic/repolistRecords.go
+++ b/api/agnostic/repolistRecords.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/bluesky-social/indigo/lex/util"
 )
 
 // RepoListRecords_Output is the output of a com.atproto.repo.listRecords call.
@@ -31,7 +31,7 @@ type RepoListRecords_Record struct {
 // limit: The number of records to return.
 // repo: The handle or DID of the repo.
 // reverse: Flag to reverse the order of the returned records.
-func RepoListRecords(ctx context.Context, c *xrpc.Client, collection string, cursor string, limit int64, repo string, reverse bool) (*RepoListRecords_Output, error) {
+func RepoListRecords(ctx context.Context, c util.LexClient, collection string, cursor string, limit int64, repo string, reverse bool) (*RepoListRecords_Output, error) {
 	var out RepoListRecords_Output
 
 	params := map[string]interface{}{
@@ -41,7 +41,7 @@ func RepoListRecords(ctx context.Context, c *xrpc.Client, collection string, cur
 		"repo":       repo,
 		"reverse":    reverse,
 	}
-	if err := c.Do(ctx, xrpc.Query, "", "com.atproto.repo.listRecords", params, nil, &out); err != nil {
+	if err := c.LexDo(ctx, util.Query, "", "com.atproto.repo.listRecords", params, nil, &out); err != nil {
 		return nil, err
 	}
 

--- a/api/agnostic/repoputRecord.go
+++ b/api/agnostic/repoputRecord.go
@@ -7,7 +7,7 @@ package agnostic
 import (
 	"context"
 
-	"github.com/bluesky-social/indigo/xrpc"
+	"github.com/bluesky-social/indigo/lex/util"
 )
 
 // RepoPutRecord_Input is the input argument to a com.atproto.repo.putRecord call.
@@ -37,9 +37,9 @@ type RepoPutRecord_Output struct {
 }
 
 // RepoPutRecord calls the XRPC method "com.atproto.repo.putRecord".
-func RepoPutRecord(ctx context.Context, c *xrpc.Client, input *RepoPutRecord_Input) (*RepoPutRecord_Output, error) {
+func RepoPutRecord(ctx context.Context, c util.LexClient, input *RepoPutRecord_Input) (*RepoPutRecord_Output, error) {
 	var out RepoPutRecord_Output
-	if err := c.Do(ctx, xrpc.Procedure, "application/json", "com.atproto.repo.putRecord", nil, input, &out); err != nil {
+	if err := c.LexDo(ctx, util.Procedure, "application/json", "com.atproto.repo.putRecord", nil, input, &out); err != nil {
 		return nil, err
 	}
 

--- a/lex/gen.go
+++ b/lex/gen.go
@@ -135,7 +135,6 @@ func GenCodeForSchema(pkg Package, reqcode bool, s *Schema, packages []Package, 
 	pf("\t\"fmt\"\n")
 	pf("\t\"encoding/json\"\n")
 	pf("\tcbg \"github.com/whyrusleeping/cbor-gen\"\n")
-	pf("\t\"github.com/bluesky-social/indigo/xrpc\"\n")
 	pf("\t\"github.com/bluesky-social/indigo/lex/util\"\n")
 	for _, xpkg := range packages {
 		if xpkg.Prefix != pkg.Prefix {

--- a/lex/type_schema.go
+++ b/lex/type_schema.go
@@ -54,7 +54,7 @@ func (s *TypeSchema) WriteRPC(w io.Writer, typename, inputname string) error {
 	pf := printerf(w)
 	fname := typename
 
-	params := "ctx context.Context, c *xrpc.Client"
+	params := "ctx context.Context, c util.LexClient"
 	inpvar := "nil"
 	inpenc := ""
 
@@ -161,14 +161,14 @@ func (s *TypeSchema) WriteRPC(w io.Writer, typename, inputname string) error {
 	var reqtype string
 	switch s.Type {
 	case "procedure":
-		reqtype = "xrpc.Procedure"
+		reqtype = "util.Procedure"
 	case "query":
-		reqtype = "xrpc.Query"
+		reqtype = "util.Query"
 	default:
 		return fmt.Errorf("can only generate RPC for Query or Procedure (got %s)", s.Type)
 	}
 
-	pf("\tif err := c.Do(ctx, %s, %q, \"%s\", %s, %s, %s); err != nil {\n", reqtype, inpenc, s.id, queryparams, inpvar, outvar)
+	pf("\tif err := c.LexDo(ctx, %s, %q, \"%s\", %s, %s, %s); err != nil {\n", reqtype, inpenc, s.id, queryparams, inpvar, outvar)
 	pf("\t\treturn %s\n", errRet)
 	pf("\t}\n\n")
 	pf("\treturn %s\n", outRet)

--- a/lex/util/client.go
+++ b/lex/util/client.go
@@ -1,0 +1,17 @@
+package util
+
+import (
+	"context"
+)
+
+type XRPCRequestType int
+
+const (
+	Query = XRPCRequestType(iota)
+	Procedure
+)
+
+// API client interface used in lexgen.
+type LexClient interface {
+	LexDo(ctx context.Context, kind XRPCRequestType, inpenc string, method string, params map[string]any, bodyobj any, out any) error
+}


### PR DESCRIPTION
Instead of referring directly to `xrpc.Client` (and the `Do()` method on that type) in lexgen output, define a new client interface with roughly the same function signature. The way this is done, the `xrpc.Client` implementation is basically untouched, so any existing code depending on, including in other git repos, it should not be impacted.

The motivation for this is to allow alternative client implementations. For example, @haileyok has an OAuth client (https://github.com/haileyok/atproto-oauth-golang), and i'm working on a flexible SDK client.

This PR doesn't include an actual lexgen run. There are a bunch of unrelated changes when I do lexgen right now (see https://github.com/bluesky-social/indigo/pull/1069), and it is easier to review without all the (many!) changes). However, everything "Just Works" with both old and new lexgen output. This PR should be mergable as-is.

I did try a lexgen run and everything worked as expected. I also manually updated the "record type agnostic" helper code, which gives a feel for what the full lexgen diff will look like.