### PR TITLE
bump relay integration test timeout from 3s to 10s

### DIFF
--- a/cmd/relay/testing/consumer.go
+++ b/cmd/relay/testing/consumer.go
@@ -27,7 +27,7 @@ type Consumer struct {
 func NewConsumer(host string) *Consumer {
 	c := Consumer{
 		Host:    host,
-		Timeout: time.Second * 3,
+		Timeout: time.Second * 10,
 	}
 	return &c
 }


### PR DESCRIPTION
Trying to reduce the frequency of flakey test failures in github actions CI. Suspect this is due to over-utilized test runners.

This should not impact "happy path" (tests passing), but makes working on the tests a bit annoying. Might be possible to check env vars to see if the test is running in CI and have a different timeout for that situation.