### PR TITLE
Changed error handling during blob export command in goat to help with account migration

### DIFF
--- a/cmd/goat/blob.go
+++ b/cmd/goat/blob.go
@@ -113,7 +113,8 @@ func runBlobExport(cctx *cli.Context) error {
 			}
 			blobBytes, err := comatproto.SyncGetBlob(ctx, &xrpcc, cidStr, ident.DID.String())
 			if err != nil {
-				return err
+				fmt.Printf("%s\tnot found\n", blobPath)
+
 			}
 			if err := os.WriteFile(blobPath, blobBytes, 0666); err != nil {
 				return err

--- a/cmd/goat/blob.go
+++ b/cmd/goat/blob.go
@@ -119,7 +119,9 @@ func runBlobExport(cctx *cli.Context) error {
 			if err := os.WriteFile(blobPath, blobBytes, 0666); err != nil {
 				return err
 			}
-			fmt.Printf("%s\tdownloaded\n", blobPath)
+			if err == nil {
+				fmt.Printf("%s\tdownloaded\n", blobPath)
+			}
 		}
 		if resp.Cursor != nil && *resp.Cursor != "" {
 			cursor = *resp.Cursor

--- a/cmd/goat/blob.go
+++ b/cmd/goat/blob.go
@@ -113,7 +113,7 @@ func runBlobExport(cctx *cli.Context) error {
 			}
 			blobBytes, err := comatproto.SyncGetBlob(ctx, &xrpcc, cidStr, ident.DID.String())
 			if err != nil {
-				fmt.Printf("%s\tnot found\n", blobPath)
+				fmt.Printf("%s\tfailed %s\n", blobPath, err)
 				continue
 			}
 			if err := os.WriteFile(blobPath, blobBytes, 0666); err != nil {

--- a/cmd/goat/blob.go
+++ b/cmd/goat/blob.go
@@ -114,14 +114,12 @@ func runBlobExport(cctx *cli.Context) error {
 			blobBytes, err := comatproto.SyncGetBlob(ctx, &xrpcc, cidStr, ident.DID.String())
 			if err != nil {
 				fmt.Printf("%s\tnot found\n", blobPath)
-
+				continue
 			}
 			if err := os.WriteFile(blobPath, blobBytes, 0666); err != nil {
 				return err
 			}
-			if err == nil {
-				fmt.Printf("%s\tdownloaded\n", blobPath)
-			}
+			fmt.Printf("%s\tdownloaded\n", blobPath)
 		}
 		if resp.Cursor != nil && *resp.Cursor != "" {
 			cursor = *resp.Cursor


### PR DESCRIPTION
Prints the error and continues rather than bailing entirely during blob export. Slightly worse in the "i have a connection problem" scenario, but means repository exports where some blobs are missing actually work now rather than getting stuck.

Was trying to migrate my main to my own PDS and ran into it, and figured addressing it would be both simple enough and useful to others trying to do the same.