### PR TITLE
subscribeRepos Client Reconnects

### DIFF
--- a/events/consumer.go
+++ b/events/consumer.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"


### PR DESCRIPTION
We've been seeing periodic cases where firehose subscribers get booted off because they [fail to keep up](https://github.com/bluesky-social/indigo/blob/9c19d0c438ef38657dff9f2f55caa167271287c4/cmd/relay/stream/eventmgr/event_manager.go#L70-L94). Thus far, we've seen this during network turbulence events with one of our ISPs.

The candidate solution here is to add some number of retries on websocket closures now that the firehose will properly clean up network conns if the consumer is too slow (#1066).

I was looking at splitter.go's [subscribeWithRedialer](https://github.com/bluesky-social/indigo/blob/9c19d0c438ef38657dff9f2f55caa167271287c4/splitter/splitter.go#L354) as prior art, but I wanted to specifically check for certain retry-able errors and not infinite loop.

I hemmed and hawed about the look of this API as well as the function name for a while as well since there are a lot of options being passed in, and I eventually opted for a struct with a default function. IMO it's the simplest API to use, and it provides reasonable defaults. If there's a better pattern, I'm 100% game for that though.