### PR TITLE
use legally registered name for company

### DIFF
--- a/LICENSE-DUAL
+++ b/LICENSE-DUAL
@@ -2,7 +2,7 @@ Except as otherwise noted in individual files, this software is licensed under t
 
 Downstream projects and end users may chose either license individually, or both together, at their discretion. The motivation for this dual-licensing is the additional software patent assurance provided by Apache 2.0.
 
-Copyright (c) 2022-2025 Bluesky PBC, @whyrusleeping, and Contributors
+Copyright (c) 2022-2025 Bluesky Social PBC, @whyrusleeping, and Contributors
 
 MIT: https://www.opensource.org/licenses/mit
 Apache-2.0: https://www.apache.org/licenses/LICENSE-2.0

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The [HACKING](./HACKING.md) file has a list of commands and packages in this rep
 
 _not to be confused with the [AT command set](https://en.wikipedia.org/wiki/Hayes_command_set) or [Adenosine triphosphate](https://en.wikipedia.org/wiki/Adenosine_triphosphate)_
 
-The Authenticated Transfer Protocol ("ATP" or "atproto") is a decentralized social media protocol, developed by [Bluesky PBC](https://bsky.social). Learn more at:
+The Authenticated Transfer Protocol ("ATP" or "atproto") is a decentralized social media protocol, developed by [Bluesky Social PBC](https://bsky.social). Learn more at:
 
 - [Overview and Guides](https://atproto.com/guides/overview) 👈 Best starting point
 - [Github Discussions](https://github.com/bluesky-social/atproto/discussions) 👈 Great place to ask questions


### PR DESCRIPTION
I had this wrong previously; the formal company name does include "Social".