### PR TITLE
lexgen: add --external-lexicons

### DIFF
--- a/cmd/lexgen/main.go
+++ b/cmd/lexgen/main.go
@@ -64,9 +64,6 @@ func main() {
 		&cli.StringFlag{
 			Name: "outdir",
 		},
-		&cli.StringFlag{
-			Name: "prefix",
-		},
 		&cli.BoolFlag{
 			Name: "gen-server",
 		},

--- a/lex/gen.go
+++ b/lex/gen.go
@@ -468,8 +468,8 @@ func ParsePackages(jsonBytes []byte) ([]Package, error) {
 	return packages, nil
 }
 
-func Run(schemas []*Schema, packages []Package) error {
-	defmap := BuildExtDefMap(schemas, packages)
+func Run(schemas []*Schema, externalSchemas []*Schema, packages []Package) error {
+	defmap := BuildExtDefMap(append(schemas, externalSchemas...), packages)
 
 	for _, pkg := range packages {
 		prefix := pkg.Prefix


### PR DESCRIPTION
`cmd/lexgen` is unprepared for a world where it's not generating schemas for everything in `atproto`! Both type generation and server stub generation generate types/stubs for every specified lexicon; this causes generated code to be somewhere between "challenging" and "unusable" for external projects — we'd prefer to have codegen that creates types for our Go program while still being able to externally reference `com.atproto` and `app.bsky` schema

This change introduces an `--external-lexicons` flag that can take multiple directories. It functions the same way as the positional lexicon arguments, those lexicons are all loaded into the code and can be referenced, but their types/stubs are not  included as part of the generated output. This yields the following command for Streamplace; this generates types for Streamplace lexicons without generating atproto code:

```shell
lexgen \
		-outdir ./pkg/spxrpc \
		--build-file util/lexgen-types.json \
		--external-lexicons ../atproto/lexicons \
		lexicons/place/stream \
		lexicons/app/bsky

```

And this does the same thing for generating server stubs:
```
lexgen \
		--gen-server \
		--types-import place.stream:stream.place/streamplace/pkg/streamplace \
		--types-import app.bsky:github.com/bluesky-social/indigo/api/bsky \
		--types-import com.atproto:github.com/bluesky-social/indigo/api/atproto \
		--types-import chat.bsky:github.com/bluesky-social/indigo/api/chat \
		--types-import tools.ozone:github.com/bluesky-social/indigo/api/ozone \
		-outdir ./pkg/spxrpc \
		--build-file util/lexgen-types.json \
		--external-lexicons ../atproto/lexicons \
		--package spxrpc \
		lexicons/place/stream \
		lexicons/app/bsky
```

`lexgen-types.json` looks like this:
```json
[
  {
    "package": "bsky",
    "prefix": "app.bsky",
    "outdir": "api/bsky",
    "import": "github.com/bluesky-social/indigo/api/bsky"
  },
  {
    "package": "atproto",
    "prefix": "com.atproto",
    "outdir": "api/atproto",
    "import": "github.com/bluesky-social/indigo/api/atproto"
  },
  {
    "package": "chat",
    "prefix": "chat.bsky",
    "outdir": "api/chat",
    "import": "github.com/bluesky-social/indigo/api/chat"
  },
  {
    "package": "ozone",
    "prefix": "tools.ozone",
    "outdir": "api/ozone",
    "import": "github.com/bluesky-social/indigo/api/ozone"
  },
  {
    "package": "streamplace",
    "prefix": "place.stream",
    "outdir": "./pkg/streamplace",
    "import": "stream.place/streamplace"
  }
]
```

This is a great tool, makes writing Go XRPC handlers really easy, let's get it usable by the community!

EDIT: Oh also I removed `--prefix` which was referenced by nobody and did nothing.