### PR TITLE
crypto: add Multibase() method to PrivateKeyExportable interface

### DIFF
--- a/atproto/crypto/keys.go
+++ b/atproto/crypto/keys.go
@@ -30,7 +30,8 @@ type PrivateKeyExportable interface {
 	// No ASN.1 or other enclosing structure is applied to the bytes.
 	Bytes() []byte
 
-	// NOTE: should Multibase() (string, error) be part of this interface? Probably.
+	// String serialization of the key bytes in "Multibase" format.
+	Multibase() string
 }
 
 // Common interface for all the supported atproto cryptographic systems.

--- a/atproto/crypto/keys_test.go
+++ b/atproto/crypto/keys_test.go
@@ -166,9 +166,11 @@ func TestParsePrivateMultibase(t *testing.T) {
 	assert.NoError(err)
 	_, ok := privP256FromMB.(*PrivateKeyP256)
 	assert.True(ok)
+	assert.Equal(privP256MB, privP256FromMB.Multibase())
 
 	privK256FromMB, err := ParsePrivateMultibase(privK256MB)
 	assert.NoError(err)
 	_, ok = privK256FromMB.(*PrivateKeyK256)
 	assert.True(ok)
+	assert.Equal(privK256MB, privK256FromMB.Multibase())
 }


### PR DESCRIPTION
Pretty simple one: actually add `Multibase()` output encoding to `PrivateKeyExportable` interface, as foreshadowed by an earlier comment.

Adds a round-trip test for the two current curve types supported.