### PR TITLE
Latest Lexgen

### DIFF
--- a/api/bsky/feeddefs.go
+++ b/api/bsky/feeddefs.go
@@ -35,6 +35,8 @@ type FeedDefs_FeedViewPost struct {
 	Post        *FeedDefs_PostView            `json:"post" cborgen:"post"`
 	Reason      *FeedDefs_FeedViewPost_Reason `json:"reason,omitempty" cborgen:"reason,omitempty"`
 	Reply       *FeedDefs_ReplyRef            `json:"reply,omitempty" cborgen:"reply,omitempty"`
+	// reqId: Unique identifier per request that may be passed back alongside interactions.
+	ReqId *string `json:"reqId,omitempty" cborgen:"reqId,omitempty"`
 }
 
 type FeedDefs_FeedViewPost_Reason struct {
@@ -104,6 +106,8 @@ type FeedDefs_Interaction struct {
 	// feedContext: Context on a feed item that was originally supplied by the feed generator on getFeedSkeleton.
 	FeedContext *string `json:"feedContext,omitempty" cborgen:"feedContext,omitempty"`
 	Item        *string `json:"item,omitempty" cborgen:"item,omitempty"`
+	// reqId: Unique identifier per request that may be passed back alongside interactions.
+	ReqId *string `json:"reqId,omitempty" cborgen:"reqId,omitempty"`
 }
 
 // FeedDefs_NotFoundPost is a "notFoundPost" in the app.bsky.feed.defs schema.
@@ -207,7 +211,9 @@ type FeedDefs_ReasonPin struct {
 type FeedDefs_ReasonRepost struct {
 	LexiconTypeID string                      `json:"$type,const=app.bsky.feed.defs#reasonRepost" cborgen:"$type,const=app.bsky.feed.defs#reasonRepost"`
 	By            *ActorDefs_ProfileViewBasic `json:"by" cborgen:"by"`
+	Cid           *string                     `json:"cid,omitempty" cborgen:"cid,omitempty"`
 	IndexedAt     string                      `json:"indexedAt" cborgen:"indexedAt"`
+	Uri           *string                     `json:"uri,omitempty" cborgen:"uri,omitempty"`
 }
 
 // FeedDefs_ReplyRef is a "replyRef" in the app.bsky.feed.defs schema.

--- a/api/bsky/feedgetFeedSkeleton.go
+++ b/api/bsky/feedgetFeedSkeleton.go
@@ -14,6 +14,8 @@ import (
 type FeedGetFeedSkeleton_Output struct {
 	Cursor *string                      `json:"cursor,omitempty" cborgen:"cursor,omitempty"`
 	Feed   []*FeedDefs_SkeletonFeedPost `json:"feed" cborgen:"feed"`
+	// reqId: Unique identifier per request that may be passed back alongside interactions.
+	ReqId *string `json:"reqId,omitempty" cborgen:"reqId,omitempty"`
 }
 
 // FeedGetFeedSkeleton calls the XRPC method "app.bsky.feed.getFeedSkeleton".

--- a/api/bsky/feedlike.go
+++ b/api/bsky/feedlike.go
@@ -17,4 +17,5 @@ type FeedLike struct {
 	LexiconTypeID string                         `json:"$type,const=app.bsky.feed.like" cborgen:"$type,const=app.bsky.feed.like"`
 	CreatedAt     string                         `json:"createdAt" cborgen:"createdAt"`
 	Subject       *comatprototypes.RepoStrongRef `json:"subject" cborgen:"subject"`
+	Via           *comatprototypes.RepoStrongRef `json:"via,omitempty" cborgen:"via,omitempty"`
 }

--- a/api/bsky/feedrepost.go
+++ b/api/bsky/feedrepost.go
@@ -17,4 +17,5 @@ type FeedRepost struct {
 	LexiconTypeID string                         `json:"$type,const=app.bsky.feed.repost" cborgen:"$type,const=app.bsky.feed.repost"`
 	CreatedAt     string                         `json:"createdAt" cborgen:"createdAt"`
 	Subject       *comatprototypes.RepoStrongRef `json:"subject" cborgen:"subject"`
+	Via           *comatprototypes.RepoStrongRef `json:"via,omitempty" cborgen:"via,omitempty"`
 }

--- a/api/bsky/notificationlistNotifications.go
+++ b/api/bsky/notificationlistNotifications.go
@@ -19,7 +19,7 @@ type NotificationListNotifications_Notification struct {
 	IndexedAt string                             `json:"indexedAt" cborgen:"indexedAt"`
 	IsRead    bool                               `json:"isRead" cborgen:"isRead"`
 	Labels    []*comatprototypes.LabelDefs_Label `json:"labels,omitempty" cborgen:"labels,omitempty"`
-	// reason: Expected values are 'like', 'repost', 'follow', 'mention', 'reply', 'quote', 'starterpack-joined', 'verified', and 'unverified'.
+	// reason: The reason why this notification was delivered - e.g. your post was liked, or you received a new follower.
 	Reason        string                   `json:"reason" cborgen:"reason"`
 	ReasonSubject *string                  `json:"reasonSubject,omitempty" cborgen:"reasonSubject,omitempty"`
 	Record        *util.LexiconTypeDecoder `json:"record" cborgen:"record"`


### PR DESCRIPTION
This is to pull in the latest requirement changes via https://github.com/bluesky-social/atproto/pull/3882, specifically the "via repost" changes.

After running `make lexgen`, there were several other changes that were deprecated, so I did not commit those. Happy to add them back if that's the preferred way of doing things, but doing so led to some lexgen weirdness, so I decided to leave them off for now to continue making progress.