### PR TITLE
add a 1ms delay between re-subscribing to PDS instances

### DIFF
--- a/cmd/relay/relay/crawl.go
+++ b/cmd/relay/relay/crawl.go
@@ -73,7 +73,7 @@ func (r *Relay) ResubscribeAllHosts(ctx context.Context) error {
 			logger.Warn("failed to re-subscribe to host", "err", err)
 		}
 		// sleep for a very short period, so we don't open tons of sockets at the same time
-		time.Sleep(1 * time.Milisecond)
+		time.Sleep(1 * time.Millisecond)
 	}
 	return nil
 }


### PR DESCRIPTION
Assuming 5k active PDS instances, this spreads things out over 5 seconds. had been seeing burst of errors when restarting relay, which I suspect is related to too many sockets (and DNS lookups) at the same time.