### PR TITLE
bump to go v1.24

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go tooling
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.24"
       - name: Build
         run: make build
       - name: Test
@@ -32,6 +32,6 @@ jobs:
       - name: Set up Go tooling
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.24"
       - name: Lint
         run: make lint

--- a/cmd/beemo/Dockerfile
+++ b/cmd/beemo/Dockerfile
@@ -3,7 +3,7 @@
 #   podman build -f ./cmd/beemo/Dockerfile -t beemo .
 
 ### Compile stage
-FROM golang:1.23-alpine3.20 AS build-env
+FROM golang:1.24-alpine3.22 AS build-env
 RUN apk add --no-cache build-base make git
 
 ADD . /dockerbuild
@@ -15,7 +15,7 @@ RUN GIT_VERSION=$(git describe --tags --long --always) && \
     go build -tags timetzdata -o /beemo ./cmd/beemo
 
 ### Run stage
-FROM alpine:3.20
+FROM alpine:3.22
 
 RUN apk add --no-cache --update dumb-init ca-certificates runit
 ENTRYPOINT ["dumb-init", "--"]

--- a/cmd/bigsky/Dockerfile
+++ b/cmd/bigsky/Dockerfile
@@ -3,7 +3,7 @@
 #   podman build -f ./cmd/bigsky/Dockerfile -t bigsky .
 
 ### Compile stage
-FROM golang:1.23-alpine3.20 AS build-env
+FROM golang:1.24-alpine3.22 AS build-env
 RUN apk add --no-cache build-base make git
 
 ADD . /dockerbuild
@@ -28,7 +28,7 @@ RUN yarn install --frozen-lockfile
 RUN yarn build
 
 ### Run stage
-FROM alpine:3.20
+FROM alpine:3.22
 
 RUN apk add --no-cache --update dumb-init ca-certificates runit
 ENTRYPOINT ["dumb-init", "--"]

--- a/cmd/bluepages/Dockerfile
+++ b/cmd/bluepages/Dockerfile
@@ -3,7 +3,7 @@
 #   podman build -f ./cmd/bluepages/Dockerfile -t bluepages .
 
 ### Compile stage
-FROM golang:1.23-alpine3.20 AS build-env
+FROM golang:1.24-alpine3.22 AS build-env
 RUN apk add --no-cache build-base make git
 
 ADD . /dockerbuild
@@ -15,7 +15,7 @@ RUN GIT_VERSION=$(git describe --tags --long --always) && \
     go build -tags timetzdata -o /bluepages ./cmd/bluepages
 
 ### Run stage
-FROM alpine:3.20
+FROM alpine:3.22
 
 RUN apk add --no-cache --update dumb-init ca-certificates runit
 

--- a/cmd/collectiondir/Dockerfile
+++ b/cmd/collectiondir/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine3.22 AS build-env
+FROM golang:1.24-bullseye AS build-env
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC

--- a/cmd/collectiondir/Dockerfile
+++ b/cmd/collectiondir/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bullseye AS build-env
+FROM golang:1.24-alpine3.22 AS build-env
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC

--- a/cmd/goat/util.go
+++ b/cmd/goat/util.go
@@ -72,6 +72,6 @@ func configLogger(cctx *cli.Context, writer io.Writer) *slog.Logger {
 
 // returns a pointer because that is what xrpc.Client expects
 func userAgent() *string {
-	s := fmt.Sprintf("goat/" + versioninfo.Short())
+	s := fmt.Sprintf("goat/%s", versioninfo.Short())
 	return &s
 }

--- a/cmd/hepa/Dockerfile
+++ b/cmd/hepa/Dockerfile
@@ -3,7 +3,7 @@
 #   podman build -f ./cmd/hepa/Dockerfile -t hepa .
 
 ### Compile stage
-FROM golang:1.23-alpine3.20 AS build-env
+FROM golang:1.24-alpine3.22 AS build-env
 RUN apk add --no-cache build-base make git
 
 ADD . /dockerbuild
@@ -15,7 +15,7 @@ RUN GIT_VERSION=$(git describe --tags --long --always) && \
     go build -tags timetzdata -o /hepa ./cmd/hepa
 
 ### Run stage
-FROM alpine:3.20
+FROM alpine:3.22
 
 RUN apk add --no-cache --update dumb-init ca-certificates runit
 ENTRYPOINT ["dumb-init", "--"]

--- a/cmd/palomar/Dockerfile
+++ b/cmd/palomar/Dockerfile
@@ -3,7 +3,7 @@
 #   podman build -f ./cmd/palomar/Dockerfile -t palomar .
 
 ### Compile stage
-FROM golang:1.23-alpine3.20 AS build-env
+FROM golang:1.24-alpine3.22 AS build-env
 RUN apk add --no-cache build-base make git
 
 ADD . /dockerbuild
@@ -15,7 +15,7 @@ RUN GIT_VERSION=$(git describe --tags --long --always) && \
     go build -tags timetzdata -o /palomar ./cmd/palomar
 
 ### Run stage
-FROM alpine:3.20
+FROM alpine:3.22
 
 RUN apk add --no-cache --update dumb-init ca-certificates runit
 ENTRYPOINT ["dumb-init", "--"]

--- a/cmd/rainbow/Dockerfile
+++ b/cmd/rainbow/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bullseye AS build-env
+FROM golang:1.24-bullseye AS build-env
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC

--- a/cmd/relay/Dockerfile
+++ b/cmd/relay/Dockerfile
@@ -3,7 +3,7 @@
 #   podman build -f ./cmd/relay/Dockerfile -t relay .
 
 ### Compile stage
-FROM golang:1.23-alpine3.20 AS build-env
+FROM golang:1.24-alpine3.22 AS build-env
 RUN apk add --no-cache build-base make git
 
 ADD . /dockerbuild
@@ -26,7 +26,7 @@ RUN yarn install --frozen-lockfile
 RUN yarn build
 
 ### Run stage
-FROM alpine:3.20
+FROM alpine:3.22
 
 RUN apk add --no-cache --update dumb-init ca-certificates runit
 ENTRYPOINT ["dumb-init", "--"]

--- a/cmd/sonar/Dockerfile
+++ b/cmd/sonar/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go binary
-FROM golang:1.23-alpine3.20 AS builder
+FROM golang:1.24-alpine3.22 AS build-env
 
 # Install SSL ca certificates.
 RUN apk update && apk add --no-cache ca-certificates && update-ca-certificates

--- a/cmd/supercollider/Dockerfile
+++ b/cmd/supercollider/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go binary
-FROM golang:1.23-alpine3.20 AS builder
+FROM golang:1.24-alpine3.22 AS build-env
 
 # Create a directory for the application
 WORKDIR /app
@@ -23,7 +23,7 @@ FROM debian:stable-slim
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Copy the binary from the first stage.
-COPY --from=builder /supercollider /supercollider
+COPY --from=build-env /supercollider /supercollider
 
 # Set the startup command to run the binary
 CMD ["/supercollider"]

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/bluesky-social/indigo
 
-go 1.23
+go 1.24
 
-toolchain go1.23.8
+toolchain go1.24.1
 
 require (
 	github.com/PuerkitoBio/purell v1.2.1

--- a/mst/mst_test.go
+++ b/mst/mst_test.go
@@ -13,7 +13,8 @@ import (
 	"testing"
 
 	"github.com/bluesky-social/indigo/util"
-	cid "github.com/ipfs/go-cid"
+
+	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/ipld/go-car/v2"
@@ -32,16 +33,16 @@ func randCid() cid.Cid {
 }
 
 func TestBasicMst(t *testing.T) {
-	rand.Seed(6123123)
 
 	ctx := context.Background()
 	cst := util.CborStore(blockstore.NewBlockstore(datastore.NewMapDatastore()))
 	mst := createMST(cst, cid.Undef, []nodeEntry{}, -1)
 
+	// NOTE: these were previously generated randomly, but the random seed behavior changed
 	vals := map[string]cid.Cid{
-		"cats/cats":  randCid(),
-		"dogs/dogs":  randCid(),
-		"cats/bears": randCid(),
+		"cats/cats":  mustCid(t, "bafkreicwamkg77pijyudfbdmskelsnuztr6gp62lqfjv3e3urbs3gxnv2m"),
+		"dogs/dogs":  mustCid(t, "bafkreihwoet2mghoduxannw3uqsq44a3if37i5omnlqmjcfuhcdegzpyn4"),
+		"cats/bears": mustCid(t, "bafkreiealwcgkpqxmr75a2vubzdertnbrip65nclv6gbsss4w7ef7fh6oy"),
 	}
 
 	for k, v := range vals {


### PR DESCRIPTION
Don't have any specific burning need for this, just keeping up with releases.

Go 1.25 is expected in August; we'll probably wait until at least v1.25.1 and an Alpine release to upgrade.