### PR TITLE
carstore: don't ignore the first record in sqlite

### DIFF
--- a/carstore/sqlite_store.go
+++ b/carstore/sqlite_store.go
@@ -6,11 +6,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"go.opentelemetry.io/otel/attribute"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+
+	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/bluesky-social/indigo/models"
 	blockformat "github.com/ipfs/go-block-format"
@@ -470,7 +471,11 @@ func (sqs *SQLiteStore) getBlock(ctx context.Context, user models.Uid, bcid cid.
 		if err != nil {
 			return nil, fmt.Errorf("getb bad scan, %w", err)
 		}
-		return blocks.NewBlock(blockb), nil
+		blk, err := blocks.NewBlockWithCid(blockb, bcid)
+		if err != nil {
+			return nil, fmt.Errorf("getb bad block, %w", err)
+		}
+		return blk, nil
 	}
 	return nil, ErrNothingThere
 }


### PR DESCRIPTION
Small fix to the SQLite carstore -- the first record in the cache will have ID 0, there's no reason to ignore it. Naturally, this case happens a lot in testing and stuff 'cause the first attempt to get a revision on an empty database will fail