### PR TITLE
identity SDK: match spec better w/r/t handle normalization and extraction from DID doc alsoKnownAs

### DIFF
--- a/atproto/identity/apidir/apidir.go
+++ b/atproto/identity/apidir/apidir.go
@@ -153,6 +153,7 @@ func (dir *APIDirectory) ResolveDID(ctx context.Context, did syntax.DID) (*ident
 }
 
 func (dir *APIDirectory) ResolveHandle(ctx context.Context, handle syntax.Handle) (syntax.DID, error) {
+	handle = handle.Normalize()
 	var body handleBody
 	u := dir.Host + "/xrpc/com.atproto.identity.resolveHandle?handle=" + handle.String()
 

--- a/atproto/identity/base_directory.go
+++ b/atproto/identity/base_directory.go
@@ -55,6 +55,7 @@ func (d *BaseDirectory) LookupHandle(ctx context.Context, h syntax.Handle) (*Ide
 	if err != nil {
 		return nil, fmt.Errorf("could not verify handle/DID match: %w", err)
 	}
+	// NOTE: DeclaredHandle() returns a normalized handle, and we already normalized 'h' above
 	if declared != h {
 		return nil, fmt.Errorf("%w: %s != %s", ErrHandleMismatch, declared, h)
 	}

--- a/atproto/identity/cache_directory.go
+++ b/atproto/identity/cache_directory.go
@@ -93,6 +93,7 @@ func (d *CacheDirectory) updateHandle(ctx context.Context, h syntax.Handle) Hand
 }
 
 func (d *CacheDirectory) ResolveHandle(ctx context.Context, h syntax.Handle) (syntax.DID, error) {
+	h = h.Normalize()
 	if h.IsInvalidHandle() {
 		return "", fmt.Errorf("can not resolve handle: %w", ErrInvalidHandle)
 	}
@@ -251,6 +252,7 @@ func (d *CacheDirectory) LookupHandleWithCacheState(ctx context.Context, h synta
 	if err != nil {
 		return nil, hit, fmt.Errorf("could not verify handle/DID mapping: %w", err)
 	}
+	// NOTE: DeclaredHandle() returns a normalized handle, and we already normalized 'h' above
 	if declared != h {
 		return nil, hit, fmt.Errorf("%w: %s != %s", ErrHandleMismatch, declared, h)
 	}

--- a/atproto/identity/handle.go
+++ b/atproto/identity/handle.go
@@ -177,6 +177,8 @@ func (d *BaseDirectory) ResolveHandle(ctx context.Context, handle syntax.Handle)
 	var dnsErr error
 	var did syntax.DID
 
+	handle = handle.Normalize()
+
 	if handle.IsInvalidHandle() {
 		return "", fmt.Errorf("can not resolve handle: %w", ErrInvalidHandle)
 	}

--- a/atproto/identity/identity.go
+++ b/atproto/identity/identity.go
@@ -196,7 +196,11 @@ func (i *Identity) GetServiceEndpoint(id string) string {
 func (i *Identity) DeclaredHandle() (syntax.Handle, error) {
 	for _, u := range i.AlsoKnownAs {
 		if strings.HasPrefix(u, "at://") && len(u) > len("at://") {
-			return syntax.ParseHandle(u[5:])
+			hdl, err := syntax.ParseHandle(u[5:])
+			if err != nil {
+				continue
+			}
+			return hdl.Normalize(), nil
 		}
 	}
 	return "", ErrHandleNotDeclared

--- a/atproto/identity/identity_test.go
+++ b/atproto/identity/identity_test.go
@@ -1,0 +1,70 @@
+package identity
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests parsing and normalizing handles from DID documents
+func TestHandleExtraction(t *testing.T) {
+	assert := assert.New(t)
+	f, err := os.Open("testdata/did_plc_doc.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	docBytes, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var doc DIDDocument
+	err = json.Unmarshal(docBytes, &doc)
+	assert.NoError(err)
+
+	{
+		ident := ParseIdentity(&doc)
+		hdl, err := ident.DeclaredHandle()
+		assert.NoError(err)
+		assert.Equal("atproto.com", hdl.String())
+	}
+
+	{
+		doc.AlsoKnownAs = []string{
+			"at://BLAH.com",
+			"at://other.org",
+		}
+		ident := ParseIdentity(&doc)
+		hdl, err := ident.DeclaredHandle()
+		assert.NoError(err)
+		assert.Equal("blah.com", hdl.String())
+	}
+
+	{
+		doc.AlsoKnownAs = []string{
+			"https://http.example.com",
+			"at://under_example_com",
+			"at://correct.EXAMPLE.com",
+			"at://other.example.com",
+		}
+		ident := ParseIdentity(&doc)
+		hdl, err := ident.DeclaredHandle()
+		assert.NoError(err)
+		assert.Equal("correct.example.com", hdl.String())
+	}
+
+	{
+		doc.AlsoKnownAs = []string{
+			"https://http.example.com",
+		}
+		ident := ParseIdentity(&doc)
+		_, err := ident.DeclaredHandle()
+		assert.Error(err)
+		assert.Equal("handle.invalid", ident.Handle.String())
+	}
+}

--- a/atproto/identity/mock_directory.go
+++ b/atproto/identity/mock_directory.go
@@ -26,7 +26,7 @@ func NewMockDirectory() MockDirectory {
 
 func (d *MockDirectory) Insert(ident Identity) {
 	if !ident.Handle.IsInvalidHandle() {
-		d.Handles[ident.Handle] = ident.DID
+		d.Handles[ident.Handle.Normalize()] = ident.DID
 	}
 	d.Identities[ident.DID] = ident
 }

--- a/atproto/identity/mock_directory_test.go
+++ b/atproto/identity/mock_directory_test.go
@@ -65,4 +65,9 @@ func TestMockDirectory(t *testing.T) {
 
 	_, err = c.ResolveDID(ctx, syntax.DID("did:plc:abc999"))
 	assert.ErrorIs(err, ErrDIDNotFound)
+
+	// handle lookups should be case-insensitive
+	_, err = c.ResolveHandle(ctx, syntax.Handle("handle.EXAMPLE.com"))
+	assert.NoError(err)
+	assert.Equal(id1.DID, did)
 }

--- a/atproto/identity/redisdir/redis_directory.go
+++ b/atproto/identity/redisdir/redis_directory.go
@@ -156,6 +156,7 @@ func (d *RedisDirectory) updateHandle(ctx context.Context, h syntax.Handle) hand
 
 func (d *RedisDirectory) ResolveHandle(ctx context.Context, h syntax.Handle) (syntax.DID, error) {
 	start := time.Now()
+	h = h.Normalize()
 	if h.IsInvalidHandle() {
 		return "", fmt.Errorf("can not resolve handle: %w", identity.ErrInvalidHandle)
 	}
@@ -359,6 +360,7 @@ func (d *RedisDirectory) LookupHandleWithCacheState(ctx context.Context, h synta
 	if err != nil {
 		return nil, hit, err
 	}
+	// NOTE: DeclaredHandle() returns a normalized handle, and we already normalized 'h' above
 	if declared != h {
 		return nil, hit, identity.ErrHandleMismatch
 	}

--- a/cmd/bluepages/handlers.go
+++ b/cmd/bluepages/handlers.go
@@ -74,6 +74,8 @@ func (srv *Server) ResolveDid(c echo.Context) error {
 func (srv *Server) resolveIdentityFromHandle(c echo.Context, handle syntax.Handle) error {
 	ctx := c.Request().Context()
 
+	handle = handle.Normalize()
+
 	did, err := srv.dir.ResolveHandle(ctx, handle)
 	if err != nil && errors.Is(err, identity.ErrHandleNotFound) {
 		return c.JSON(404, GenericError{
@@ -110,6 +112,7 @@ func (srv *Server) resolveIdentityFromHandle(c echo.Context, handle syntax.Handl
 	}
 
 	ident := identity.ParseIdentity(&doc)
+	// NOTE: 'handle' was resolved above, and 'DeclaredHandle()' returns a normalized handle
 	declHandle, err := ident.DeclaredHandle()
 	if err != nil || declHandle != handle {
 		return c.JSON(400, GenericError{


### PR DESCRIPTION
- tries harder to find a valid handle in alsoKnownAs list (doesn't stop at the first `at://` if it was not a valid handle)
- normalizes handles when extracting from DID docs / identities
- ensures that bi-directional handle comparisons are done with normalized handles
- ensures that caching is done with normalized version of handles
- adds some tests for all this