### PR TITLE
identity SDK tweaks

### DIFF
--- a/atproto/auth/http_test.go
+++ b/atproto/auth/http_test.go
@@ -86,8 +86,8 @@ func TestServiceAuthMiddleware(t *testing.T) {
 	dir := identity.NewMockDirectory()
 	dir.Insert(identity.Identity{
 		DID: iss,
-		Keys: map[string]identity.Key{
-			"atproto": identity.Key{
+		Keys: map[string]identity.IdentityKey{
+			"atproto": {
 				Type:               "Multikey",
 				PublicKeyMultibase: pub.Multibase(),
 			},

--- a/atproto/auth/http_test.go
+++ b/atproto/auth/http_test.go
@@ -86,7 +86,7 @@ func TestServiceAuthMiddleware(t *testing.T) {
 	dir := identity.NewMockDirectory()
 	dir.Insert(identity.Identity{
 		DID: iss,
-		Keys: map[string]identity.IdentityKey{
+		Keys: map[string]identity.VerificationMethod{
 			"atproto": {
 				Type:               "Multikey",
 				PublicKeyMultibase: pub.Multibase(),

--- a/atproto/auth/jwt_test.go
+++ b/atproto/auth/jwt_test.go
@@ -100,8 +100,8 @@ func testSigningValidation(t *testing.T, priv crypto.PrivateKey) {
 	dir := identity.NewMockDirectory()
 	dir.Insert(identity.Identity{
 		DID: iss,
-		Keys: map[string]identity.Key{
-			"atproto": identity.Key{
+		Keys: map[string]identity.IdentityKey{
+			"atproto": {
 				Type:               "Multikey",
 				PublicKeyMultibase: pub.Multibase(),
 			},

--- a/atproto/auth/jwt_test.go
+++ b/atproto/auth/jwt_test.go
@@ -100,7 +100,7 @@ func testSigningValidation(t *testing.T, priv crypto.PrivateKey) {
 	dir := identity.NewMockDirectory()
 	dir.Insert(identity.Identity{
 		DID: iss,
-		Keys: map[string]identity.IdentityKey{
+		Keys: map[string]identity.VerificationMethod{
 			"atproto": {
 				Type:               "Multikey",
 				PublicKeyMultibase: pub.Multibase(),

--- a/atproto/client/password_auth_test.go
+++ b/atproto/client/password_auth_test.go
@@ -121,7 +121,7 @@ func TestPasswordAuth(t *testing.T) {
 	dir.Insert(identity.Identity{
 		DID:    "did:web:account.example.com",
 		Handle: "user1.example.com",
-		Services: map[string]identity.Service{
+		Services: map[string]identity.ServiceEndpoint{
 			"atproto_pds": {
 				Type: "AtprotoPersonalDataServer",
 				URL:  srv.URL,

--- a/atproto/identity/identity.go
+++ b/atproto/identity/identity.go
@@ -20,16 +20,16 @@ type Identity struct {
 
 	// These fields represent a parsed subset of a DID document. They are all nullable. Note that the services and keys maps do not preserve order, so they don't exactly round-trip DID documents.
 	AlsoKnownAs []string
-	Services    map[string]Service
-	Keys        map[string]Key
+	Services    map[string]ServiceEndpoint
+	Keys        map[string]IdentityKey
 }
 
-type Key struct {
+type IdentityKey struct {
 	Type               string
 	PublicKeyMultibase string
 }
 
-type Service struct {
+type ServiceEndpoint struct {
 	Type string
 	URL  string
 }
@@ -38,7 +38,7 @@ type Service struct {
 //
 // Always returns an invalid Handle field; calling code should only populate that field if it has been bi-directionally verified.
 func ParseIdentity(doc *DIDDocument) Identity {
-	keys := make(map[string]Key, len(doc.VerificationMethod))
+	keys := make(map[string]IdentityKey, len(doc.VerificationMethod))
 	for _, vm := range doc.VerificationMethod {
 		parts := strings.SplitN(vm.ID, "#", 2)
 		if len(parts) < 2 {
@@ -53,12 +53,12 @@ func ParseIdentity(doc *DIDDocument) Identity {
 			continue
 		}
 		// TODO: verify that ID and type match for atproto-specific services?
-		keys[parts[1]] = Key{
+		keys[parts[1]] = IdentityKey{
 			Type:               vm.Type,
 			PublicKeyMultibase: vm.PublicKeyMultibase,
 		}
 	}
-	svc := make(map[string]Service, len(doc.Service))
+	svc := make(map[string]ServiceEndpoint, len(doc.Service))
 	for _, s := range doc.Service {
 		parts := strings.SplitN(s.ID, "#", 2)
 		if len(parts) < 2 {
@@ -69,7 +69,7 @@ func ParseIdentity(doc *DIDDocument) Identity {
 			continue
 		}
 		// TODO: verify that ID and type match for atproto-specific services?
-		svc[parts[1]] = Service{
+		svc[parts[1]] = ServiceEndpoint{
 			Type: s.Type,
 			URL:  s.ServiceEndpoint,
 		}

--- a/atproto/identity/identity.go
+++ b/atproto/identity/identity.go
@@ -21,14 +21,16 @@ type Identity struct {
 	// These fields represent a parsed subset of a DID document. They are all nullable. Note that the services and keys maps do not preserve order, so they don't exactly round-trip DID documents.
 	AlsoKnownAs []string
 	Services    map[string]ServiceEndpoint
-	Keys        map[string]IdentityKey
+	Keys        map[string]VerificationMethod
 }
 
-type IdentityKey struct {
+// Sub-field type for [Identity], representing a crytographic public key declared as a "verificationMethod" in the DID document.
+type VerificationMethod struct {
 	Type               string
 	PublicKeyMultibase string
 }
 
+// Sub-field type for [Identity], representing a service endpoint URL declared in the DID document.
 type ServiceEndpoint struct {
 	Type string
 	URL  string
@@ -38,7 +40,7 @@ type ServiceEndpoint struct {
 //
 // Always returns an invalid Handle field; calling code should only populate that field if it has been bi-directionally verified.
 func ParseIdentity(doc *DIDDocument) Identity {
-	keys := make(map[string]IdentityKey, len(doc.VerificationMethod))
+	keys := make(map[string]VerificationMethod, len(doc.VerificationMethod))
 	for _, vm := range doc.VerificationMethod {
 		parts := strings.SplitN(vm.ID, "#", 2)
 		if len(parts) < 2 {
@@ -53,7 +55,7 @@ func ParseIdentity(doc *DIDDocument) Identity {
 			continue
 		}
 		// TODO: verify that ID and type match for atproto-specific services?
-		keys[parts[1]] = IdentityKey{
+		keys[parts[1]] = VerificationMethod{
 			Type:               vm.Type,
 			PublicKeyMultibase: vm.PublicKeyMultibase,
 		}

--- a/atproto/identity/redisdir/redis_directory.go
+++ b/atproto/identity/redisdir/redis_directory.go
@@ -273,11 +273,11 @@ func (d *RedisDirectory) updateDID(ctx context.Context, did syntax.DID) identity
 }
 
 func (d *RedisDirectory) LookupDID(ctx context.Context, did syntax.DID) (*identity.Identity, error) {
-	id, _, err := d.LookupDIDWithCacheState(ctx, did)
+	id, _, err := d.lookupDIDWithCacheState(ctx, did)
 	return id, err
 }
 
-func (d *RedisDirectory) LookupDIDWithCacheState(ctx context.Context, did syntax.DID) (*identity.Identity, bool, error) {
+func (d *RedisDirectory) lookupDIDWithCacheState(ctx context.Context, did syntax.DID) (*identity.Identity, bool, error) {
 	start := time.Now()
 	var entry identityEntry
 	err := d.identityCache.Get(ctx, redisDirPrefix+did.String(), &entry)
@@ -340,17 +340,17 @@ func (d *RedisDirectory) LookupDIDWithCacheState(ctx context.Context, did syntax
 }
 
 func (d *RedisDirectory) LookupHandle(ctx context.Context, h syntax.Handle) (*identity.Identity, error) {
-	ident, _, err := d.LookupHandleWithCacheState(ctx, h)
+	ident, _, err := d.lookupHandleWithCacheState(ctx, h)
 	return ident, err
 }
 
-func (d *RedisDirectory) LookupHandleWithCacheState(ctx context.Context, h syntax.Handle) (*identity.Identity, bool, error) {
+func (d *RedisDirectory) lookupHandleWithCacheState(ctx context.Context, h syntax.Handle) (*identity.Identity, bool, error) {
 	h = h.Normalize()
 	did, err := d.ResolveHandle(ctx, h)
 	if err != nil {
 		return nil, false, err
 	}
-	ident, hit, err := d.LookupDIDWithCacheState(ctx, did)
+	ident, hit, err := d.lookupDIDWithCacheState(ctx, did)
 	if err != nil {
 		return nil, hit, err
 	}


### PR DESCRIPTION
Making a couple internal methods and types private, and gave a couple sub-types better names.

These are technically API breaking changes, but i'm pretty confident the internal bits are not being used outside this repo. And the renames should also not be particularly disruptive (if at all), and best done sooner than later (eg, before more folks start building on this API surface).