### PR TITLE
lexgen empty union

### DIFF
--- a/lex/type_schema.go
+++ b/lex/type_schema.go
@@ -552,7 +552,7 @@ func (s *TypeSchema) typeNameForField(name, k string, v TypeSchema) (string, err
 		return "string", nil
 	case "unknown":
 		// NOTE: sometimes a record, for which we want LexiconTypeDecoder, sometimes any object
-		if k == "didDoc" || k == "plcOp" {
+		if k == "didDoc" || k == "plcOp" || k == "meta" {
 			return "interface{}", nil
 		} else {
 			return "*util.LexiconTypeDecoder", nil

--- a/lex/type_schema.go
+++ b/lex/type_schema.go
@@ -558,7 +558,12 @@ func (s *TypeSchema) typeNameForField(name, k string, v TypeSchema) (string, err
 			return "*util.LexiconTypeDecoder", nil
 		}
 	case "union":
-		return "*" + name + "_" + strings.Title(k), nil
+		if len(v.Refs) > 0 {
+			return "*" + name + "_" + strings.Title(k), nil
+		} else {
+			// an empty union is effectively an 'unknown', but with mandatory type indicator
+			return "*util.LexiconTypeDecoder", nil
+		}
 	case "blob":
 		return "*util.LexBlob", nil
 	case "array":


### PR DESCRIPTION
This fixes lexgen for empty unions (which it now treats similarly to `unknown`).

Also handles the special "meta" unknown field in `tools.ozone.moderation.defs#modTool`, which is a "true" unknown (aka, it will not have `$type`, similar to plc ops and did docs).

I tested running against atproto main, and the API part worked, but current lexgen adds yet more params to queryEvents which breaks things.