### PR TITLE
Make MockDirectory Thread Safe

### DIFF
--- a/atproto/identity/mock_directory.go
+++ b/atproto/identity/mock_directory.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
 )
 
 // A fake identity directory, for use in tests
 type MockDirectory struct {
+	mu         *sync.RWMutex
 	Handles    map[syntax.Handle]syntax.DID
 	Identities map[syntax.DID]Identity
 }
@@ -19,12 +21,16 @@ var _ Resolver = (*MockDirectory)(nil)
 
 func NewMockDirectory() MockDirectory {
 	return MockDirectory{
+		mu:         &sync.RWMutex{},
 		Handles:    make(map[syntax.Handle]syntax.DID),
 		Identities: make(map[syntax.DID]Identity),
 	}
 }
 
 func (d *MockDirectory) Insert(ident Identity) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	if !ident.Handle.IsInvalidHandle() {
 		d.Handles[ident.Handle.Normalize()] = ident.DID
 	}
@@ -32,6 +38,9 @@ func (d *MockDirectory) Insert(ident Identity) {
 }
 
 func (d *MockDirectory) LookupHandle(ctx context.Context, h syntax.Handle) (*Identity, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
 	h = h.Normalize()
 	did, ok := d.Handles[h]
 	if !ok {
@@ -45,6 +54,9 @@ func (d *MockDirectory) LookupHandle(ctx context.Context, h syntax.Handle) (*Ide
 }
 
 func (d *MockDirectory) LookupDID(ctx context.Context, did syntax.DID) (*Identity, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
 	ident, ok := d.Identities[did]
 	if !ok {
 		return nil, ErrDIDNotFound
@@ -53,6 +65,9 @@ func (d *MockDirectory) LookupDID(ctx context.Context, did syntax.DID) (*Identit
 }
 
 func (d *MockDirectory) Lookup(ctx context.Context, a syntax.AtIdentifier) (*Identity, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
 	handle, err := a.AsHandle()
 	if nil == err { // if not an error, is a Handle
 		return d.LookupHandle(ctx, handle)
@@ -65,6 +80,9 @@ func (d *MockDirectory) Lookup(ctx context.Context, a syntax.AtIdentifier) (*Ide
 }
 
 func (d *MockDirectory) ResolveHandle(ctx context.Context, h syntax.Handle) (syntax.DID, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
 	h = h.Normalize()
 	did, ok := d.Handles[h]
 	if !ok {
@@ -74,6 +92,9 @@ func (d *MockDirectory) ResolveHandle(ctx context.Context, h syntax.Handle) (syn
 }
 
 func (d *MockDirectory) ResolveDID(ctx context.Context, did syntax.DID) (*DIDDocument, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
 	ident, ok := d.Identities[did]
 	if !ok {
 		return nil, ErrDIDNotFound
@@ -83,6 +104,9 @@ func (d *MockDirectory) ResolveDID(ctx context.Context, did syntax.DID) (*DIDDoc
 }
 
 func (d *MockDirectory) ResolveDIDRaw(ctx context.Context, did syntax.DID) (json.RawMessage, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
 	ident, ok := d.Identities[did]
 	if !ok {
 		return nil, ErrDIDNotFound
@@ -92,5 +116,8 @@ func (d *MockDirectory) ResolveDIDRaw(ctx context.Context, did syntax.DID) (json
 }
 
 func (d *MockDirectory) Purge(ctx context.Context, a syntax.AtIdentifier) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	return nil
 }


### PR DESCRIPTION
I've wanted this when writing tests that use the mock directory from multiple goroutines.