### PR TITLE
goat: Create service auth token via locally-held signing key

### DIFF
--- a/cmd/goat/account.go
+++ b/cmd/goat/account.go
@@ -416,6 +416,7 @@ func runAccountServiceAuthOffline(cctx *cli.Context) error {
 	}
 
 	issString := cctx.String("iss")
+	// TODO: support fragment identifiers
 	iss, err := syntax.ParseDID(issString)
 	if err != nil {
 		return fmt.Errorf("iss argument must be a valid DID: %w", err)


### PR DESCRIPTION
This is needed as part of the "adversarial PDS migration" flow, because the existing `goat account service-auth` command requires the origin PDS to create the token.

```
NAME:
   goat account service-auth-offline - create service auth token via locally-held signing key

USAGE:
   goat account service-auth-offline [command options] [arguments...]

OPTIONS:
   --atproto-signing-key value    private key used to sign the token (multibase syntax) [$ATPROTO_SIGNING_KEY]
   --iss value                    the DID of the account issuing the token
   --endpoint value, --lxm value  restrict token to API endpoint (NSID, optional)
   --audience value, --aud value  DID of service that will receive and validate token
   --duration-sec value           validity time window of token (seconds) (default: 0)
   --help, -h                     show help
```