### PR TITLE
goat: improve PLC-related error messages

### DIFF
--- a/cmd/goat/plc.go
+++ b/cmd/goat/plc.go
@@ -517,7 +517,7 @@ func runPLCSign(cctx *cli.Context) error {
 
 	privStr := cctx.String("plc-signing-key")
 	if privStr == "" {
-		return fmt.Errorf("private key must be provided")
+		return fmt.Errorf("private key must be provided (HINT: use `goat account plc` if your PDS holds the keys)")
 	}
 
 	inputReader, err := getFileOrStdin(s)
@@ -587,7 +587,7 @@ func runPLCSubmit(cctx *cli.Context) error {
 
 	var enum didplc.OpEnum
 	if err := json.Unmarshal(inBytes, &enum); err != nil {
-		return err
+		return fmt.Errorf("failed decoding PLC op JSON: %w", err)
 	}
 	op := enum.AsOperation()
 


### PR DESCRIPTION
Addresses #1128 and also adds some "hints" to error messages regarding when to use `goat plc` vs `goat account plc`. There's perhaps still room for improvement on the command help texts though.

Note: I haven't fully tested a PLC update via `goat account plc submit` with these changes, yet