### PR TITLE
set account did if ident

### DIFF
--- a/atproto/auth/oauth/oauth.go
+++ b/atproto/auth/oauth/oauth.go
@@ -535,6 +535,7 @@ func (app *ClientApp) StartAuthFlow(ctx context.Context, identifier string) (str
 		if err != nil {
 			return "", fmt.Errorf("failed to resolve username (%s): %w", identifier, err)
 		}
+		accountDID = ident.DID
 		host := ident.PDSEndpoint()
 		if host == "" {
 			return "", fmt.Errorf("identity does not link to an atproto host (PDS)")


### PR DESCRIPTION
I believe that we need to set the accountDID to ident.DID so we can set info.DID later on if we are not given an auth server url