### PR TITLE
fix nil pointer deref for ErrAccountRepoNotFound

### DIFF
--- a/cmd/relay/handlers.go
+++ b/cmd/relay/handlers.go
@@ -197,8 +197,11 @@ func (s *Service) handleComAtprotoSyncGetRepoStatus(c echo.Context, did syntax.D
 	if err != nil && !errors.Is(err, relay.ErrAccountRepoNotFound) {
 		return nil, err
 	}
+	// ^^ only returns for non-ErrAccountRepoNotFound: repo can be nil after this!
 
-	out.Rev = &repo.Rev
+	if repo != nil {
+		out.Rev = &repo.Rev
+	}
 
 	return out, nil
 }


### PR DESCRIPTION
this change just makes sure `repo` is not nil before we try to pull a `Rev` out of it.

assigning the Rev from the repo follows what's *almost* a boilerplate golang error handler, but is sneakily not handling `relay.ErrAccountRepoNotFound` -- seems the intent is to provide a happy-path response for a common error case.

unfortunately the Rev assignment tried to dereference that from `repo` unconditionally, so it panicked in the allowed-error path.


(still need to test and will verify on my relays)