### PR TITLE
prevent HTTP 500 responses for listRepos when one account has no account_repo

### DIFF
--- a/cmd/relay/handlers.go
+++ b/cmd/relay/handlers.go
@@ -151,16 +151,26 @@ func (s *Service) handleComAtprotoSyncListRepos(c echo.Context, cursor int64, li
 	// TODO: would be much more efficient to do a join and have Relay.ListAccounts return these repos with the account info
 	for i, acc := range accounts {
 		repo, err := s.relay.GetAccountRepo(ctx, acc.UID)
-		if err != nil {
+		if err != nil && !errors.Is(err, relay.ErrAccountRepoNotFound) {
 			s.logger.Error("failed to get repo root", "err", err, "did", acc.DID)
 			return nil, echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to get repo root for (%s): %v", acc.DID, err.Error()))
+		}
+		// note: repo can be nil beyond this point!
+
+		// TODO: empty strings here may not be spec-compliant
+		// need to determine correct handling when there is no account_repo entry
+		// see https://github.com/bluesky-social/indigo/issues/1143
+		var cid, rev string
+		if repo != nil {
+			cid = repo.CommitCID
+			rev = repo.Rev
 		}
 
 		active := acc.IsActive()
 		resp.Repos[i] = &comatproto.SyncListRepos_Repo{
 			Did:    acc.DID,
-			Head:   repo.CommitCID,
-			Rev:    repo.Rev,
+			Head:   cid,
+			Rev:    rev,
 			Active: &active,
 			Status: acc.StatusField(),
 		}


### PR DESCRIPTION
Accounts sometimes don't have an entry in their account_repo extension table. This change handles that case for listRepos by including them in the response but with empty strings for the "Rev" and "Head" fields.

...which probably isn't ultimately correct, but is at least more usable for clients than missing an entire page of repos because one of them was affected by this.

placeholder improvement directly related to https://github.com/bluesky-social/indigo/issues/1143

basically the same as #1142 but that PR only addressed getRepoStatus

---

for what it's worth, the sql join `TODO` suggested in the code here would have hidden (fixed?) this problem by omitting the affected accounts, assuming inner-join