### PR TITLE
oauth: store auth req scopes same way as auth session (array of strings)

### DIFF
--- a/atproto/auth/oauth/types.go
+++ b/atproto/auth/oauth/types.go
@@ -330,8 +330,8 @@ type AuthRequestData struct {
 	// If the flow started with an account identifier (DID or handle), it should be persisted, to verify against the initial token response.
 	AccountDID *syntax.DID `json:"account_did,omitempty"`
 
-	// OAuth scope string (space-separated list)
-	Scope string `json:"scope"`
+	// OAuth scope strings
+	Scopes []string `json:"scopes"`
 
 	// unique token in URI format, which will be used by the client in the auth flow redirect
 	RequestURI string `json:"request_uri"`


### PR DESCRIPTION
This is a breaking change, and could impact database schemas or even stored data for already-deployed code relying on this package.

On the other hand, it makes things consistent, and I think easier to work with.

I'll try to do a quick scan for projects already building on this (new) package.