### PR TITLE
Client assertion jwt missing exp ( expiresat ) claim

### DIFF
--- a/atproto/auth/oauth/oauth.go
+++ b/atproto/auth/oauth/oauth.go
@@ -247,7 +247,7 @@ func (cfg *ClientConfig) NewClientAssertion(authURL string) (string, error) {
 			Audience:  []string{authURL},
 			ID:        secureRandomBase64(16),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute * 5)),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute * 1)),
 		},
 	}
 

--- a/atproto/auth/oauth/oauth.go
+++ b/atproto/auth/oauth/oauth.go
@@ -242,11 +242,12 @@ func (cfg *ClientConfig) NewClientAssertion(authURL string) (string, error) {
 	}
 	claims := clientAssertionClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
-			Issuer:   cfg.ClientID,
-			Subject:  cfg.ClientID,
-			Audience: []string{authURL},
-			ID:       secureRandomBase64(16),
-			IssuedAt: jwt.NewNumericDate(time.Now()),
+			Issuer:    cfg.ClientID,
+			Subject:   cfg.ClientID,
+			Audience:  []string{authURL},
+			ID:        secureRandomBase64(16),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute * 5)),
 		},
 	}
 

--- a/atproto/auth/oauth/oauth.go
+++ b/atproto/auth/oauth/oauth.go
@@ -247,7 +247,7 @@ func (cfg *ClientConfig) NewClientAssertion(authURL string) (string, error) {
 			Audience:  []string{authURL},
 			ID:        secureRandomBase64(16),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute * 1)),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(jwtExpirationDuration)),
 		},
 	}
 


### PR DESCRIPTION
According to [rfc7523](https://datatracker.ietf.org/doc/html/rfc7523#page-6) a client assertion jwt MUST have an exp ( expiresat ) claim. This could also be a issue with the assertion verification in the reference PDS code ( seems to accepts assertions without the exp claim)  and [python-oauth-web-app](https://github.com/bluesky-social/cookbook/tree/main/python-oauth-web-app) not sending the exp claim either