### PR TITLE
basic permission-set support in lexicon package

### DIFF
--- a/atproto/lexicon/catalog.go
+++ b/atproto/lexicon/catalog.go
@@ -65,7 +65,7 @@ func (c *BaseCatalog) AddSchemaFile(sf SchemaFile) error {
 		}
 		// "A file can have at most one definition with one of the "primary" types. Primary types should always have the name main. It is possible for main to describe a non-primary type."
 		switch s := def.Inner.(type) {
-		case SchemaRecord, SchemaQuery, SchemaProcedure, SchemaSubscription:
+		case SchemaRecord, SchemaQuery, SchemaProcedure, SchemaSubscription, SchemaPermissionSet:
 			if frag != "main" {
 				return fmt.Errorf("record, query, procedure, and subscription types must be 'main', not: %s", frag)
 			}

--- a/atproto/lexicon/testdata/catalog/permission-set.json
+++ b/atproto/lexicon/testdata/catalog/permission-set.json
@@ -1,0 +1,58 @@
+{
+  "lexicon": 1,
+  "id": "example.lexicon.permissionset",
+  "description": "exercizes many lexicon features for the permission-set type",
+  "defs": {
+    "main": {
+      "type": "permission-set",
+      "permissions": [
+        {
+          "type": "permission",
+          "resource": "blob",
+          "accept": [
+            "image/*"
+          ]
+        },
+        {
+          "type": "permission",
+          "resource": "repo",
+          "collection": [
+            "com.example.calendar.event",
+            "com.example.calendar.rsvp"
+          ],
+          "action": [
+            "delete",
+            "create"
+          ]
+        },
+        {
+          "type": "permission",
+          "resource": "repo",
+          "collection": [
+            "com.example.calendar.event",
+            "app.bsky.feed.post"
+          ],
+          "action": [
+            "create",
+            "update",
+            "delete"
+          ]
+        },
+        {
+        	"type": "permission",
+        	"resource": "rpc",
+        	"aud": "did:web:example.com#foo",
+        	"lxm": ["com.example.calendar.listEvents"]
+        },
+        {
+          "type": "permission",
+          "resource": "rpc",
+          "inheritAud": true,
+          "lxm": [
+            "com.example.calendar.listEvents"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
I should probably add parsing helpers to the atproto/syntax package for MIME type glob patterns, and for "service refs".

This isn't super rigorous yet, and it doesn't support pass-through of extra fields on `permission` types. But it would catch early/initial syntax issues, and could be used with `goat` for publishing and resolving lexicons (eg, basic devex for permission-sets feature).