### PR TITLE
OAuth client: Surface callback error responses

### DIFF
--- a/atproto/auth/oauth/oauth.go
+++ b/atproto/auth/oauth/oauth.go
@@ -21,26 +21,6 @@ import (
 
 var jwtExpirationDuration = 30 * time.Second
 
-// Returned by [ClientApp.ProcessCallback] if the AS signals an error in the redirect URL parameters, per rfc6749 section 4.1.2.1
-//
-// NOTE: This is untrusted data and should not be e.g. rendered to HTML without appropriate escaping
-type CallbackError struct {
-	code        string
-	description string
-	uri         *syntax.URI
-}
-
-func (e *CallbackError) Error() string {
-	res := "callbackError: " + e.code
-	if e.description != "" {
-		res += ": " + e.description
-	}
-	if e.uri != nil {
-		res += " (" + e.uri.String() + ")"
-	}
-	return res
-}
-
 // Service-level client. Used to establish and refrsh OAuth sessions, but is not itself account or session specific, and can not be used directly to make API calls on behalf of a user.
 type ClientApp struct {
 	Client   *http.Client
@@ -622,7 +602,7 @@ func (app *ClientApp) ProcessCallback(ctx context.Context, params url.Values) (*
 		if err == nil {
 			errorUri = &parsedUri
 		}
-		return nil, &CallbackError{
+		return nil, &ErrCallback{
 			code:        errorCode,
 			description: params.Get("error_description"),
 			uri:         errorUri,

--- a/atproto/auth/oauth/types.go
+++ b/atproto/auth/oauth/types.go
@@ -407,3 +407,23 @@ type TokenResponse struct {
 	// Refresh token, for doing additional token requests to the auth server.
 	RefreshToken string `json:"refresh_token"`
 }
+
+// Returned by [ClientApp.ProcessCallback] if the AS signals an error in the redirect URL parameters, per rfc6749 section 4.1.2.1
+//
+// NOTE: This is untrusted data and should not be e.g. rendered to HTML without appropriate escaping
+type ErrCallback struct {
+	code        string
+	description string
+	uri         *syntax.URI
+}
+
+func (e *ErrCallback) Error() string {
+	res := "callbackError: " + e.code
+	if e.description != "" {
+		res += ": " + e.description
+	}
+	if e.uri != nil {
+		res += " (" + e.uri.String() + ")"
+	}
+	return res
+}

--- a/atproto/auth/oauth/types.go
+++ b/atproto/auth/oauth/types.go
@@ -411,19 +411,19 @@ type TokenResponse struct {
 // Returned by [ClientApp.ProcessCallback] if the AS signals an error in the redirect URL parameters, per rfc6749 section 4.1.2.1
 //
 // NOTE: This is untrusted data and should not be e.g. rendered to HTML without appropriate escaping
-type ErrCallback struct {
-	code        string
-	description string
-	uri         *syntax.URI
+type AuthRequestCallbackError struct {
+	ErrorCode        string
+	ErrorDescription string
+	ErrorURI         *syntax.URI
 }
 
-func (e *ErrCallback) Error() string {
-	res := "callbackError: " + e.code
-	if e.description != "" {
-		res += ": " + e.description
+func (e *AuthRequestCallbackError) Error() string {
+	res := "OAuth request callback error: " + e.ErrorCode
+	if e.ErrorDescription != "" {
+		res += ": " + e.ErrorDescription
 	}
-	if e.uri != nil {
-		res += " (" + e.uri.String() + ")"
+	if e.ErrorURI != nil {
+		res += " (" + e.ErrorURI.String() + ")"
 	}
 	return res
 }


### PR DESCRIPTION
Addresses #1152

This can be tested by initiating a login with the demo client app, but hitting "cancel" on the AS login page (or by refusing to grant the requested scopes).