### PR TITLE
OAuth client SDK: Support token revocation via Logout helper

### DIFF
--- a/atproto/auth/oauth/cmd/oauth-web-demo/main.go
+++ b/atproto/auth/oauth/cmd/oauth-web-demo/main.go
@@ -288,10 +288,10 @@ func (s *Server) OAuthRefresh(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) OAuthLogout(w http.ResponseWriter, r *http.Request) {
 
-	// delete session from auth store
+	// revoke tokens and delete session from auth store
 	did, sessionID := s.currentSessionDID(r)
 	if did != nil {
-		if err := s.OAuth.Store.DeleteSession(r.Context(), *did, sessionID); err != nil {
+		if err := s.OAuth.Logout(r.Context(), *did, sessionID); err != nil {
 			slog.Error("failed to delete session", "did", did, "err", err)
 		}
 	}

--- a/atproto/auth/oauth/doc.go
+++ b/atproto/auth/oauth/doc.go
@@ -122,9 +122,9 @@ Sessions can be resumed and used to make authenticated API calls to the user's h
 
 The [ClientSession] will handle nonce updates and token refreshes, and persist the results in the [ClientAuthStore].
 
-To log out a user, delete their session from the [ClientAuthStore]:
+To log out a user, use the [ClientApp.Logout] helper method, which revokes their tokens (if supported by the AS) and deletes their session from the [ClientAuthStore]:
 
-	if err := oauthApp.Store.DeleteSession(r.Context(), did, sessionID); err != nil {
+	if err := oauthApp.Logout(r.Context(), did, sessionID); err != nil {
 		return err
 	}
 

--- a/atproto/auth/oauth/oauth.go
+++ b/atproto/auth/oauth/oauth.go
@@ -668,8 +668,15 @@ func (app *ClientApp) Logout(ctx context.Context, did syntax.DID, sessionID stri
 		return err
 	}
 
-	// Tell the AS to revoke the tokens
-	sess.RevokeSession(ctx)
+	// Tell the AS to revoke the tokens, if supported
+	if sess.Data.AuthServerRevocationEndpoint == "" {
+		slog.Info("AS does not support token revocation, skipping RevokeSession")
+	} else {
+		err = sess.RevokeSession(ctx)
+		if err != nil {
+			slog.Warn("error during session revocation", "err", err)
+		}
+	}
 
 	// Delete from our own session store
 	err = app.Store.DeleteSession(ctx, did, sessionID)

--- a/atproto/auth/oauth/oauth.go
+++ b/atproto/auth/oauth/oauth.go
@@ -664,16 +664,12 @@ func (app *ClientApp) ProcessCallback(ctx context.Context, params url.Values) (*
 // High-level helper to delete a session, including revoking access/refresh tokens if supported by the AS
 func (app *ClientApp) Logout(ctx context.Context, did syntax.DID, sessionID string) error {
 	sess, err := app.ResumeSession(ctx, did, sessionID)
-	// TODO: Should this be idempotent? i.e. logging out of a session that does not exist does nothing and succeeds?
 	if err != nil {
 		return err
 	}
 
 	// Tell the AS to revoke the tokens
-	err = sess.RevokeSession(ctx)
-	if err != nil {
-		return err
-	}
+	sess.RevokeSession(ctx)
 
 	// Delete from our own session store
 	err = app.Store.DeleteSession(ctx, did, sessionID)

--- a/atproto/auth/oauth/types.go
+++ b/atproto/auth/oauth/types.go
@@ -415,6 +415,8 @@ type TokenResponse struct {
 }
 
 // The fields which are included in a token revocation request. These HTTP POST bodies are form-encoded, so use URL encoding syntax, not JSON.
+//
+// Per https://datatracker.ietf.org/doc/html/rfc7009#section-2.1
 type RevocationRequest struct {
 	// Client ID, aka client metadata URL
 	ClientID string `url:"client_id"`

--- a/atproto/auth/oauth/types.go
+++ b/atproto/auth/oauth/types.go
@@ -197,6 +197,9 @@ type AuthServerMetadata struct {
 
 	// must be true
 	ClientIDMetadataDocumentSupported bool `json:"client_id_metadata_document_supported"`
+
+	// optional, used to explicitly revoke access/refresh tokens on logout, if present
+	RevocationEndpoint string `json:"revocation_endpoint,omitempty"`
 }
 
 func (m *AuthServerMetadata) Validate(serverURL string) error {
@@ -339,6 +342,9 @@ type AuthRequestData struct {
 	// Full token endpoint URL
 	AuthServerTokenEndpoint string `json:"authserver_token_endpoint"`
 
+	// Full revocation endpoint, if it exists
+	AuthServerRevocationEndpoint string `json:"authserver_revocation_endpoint,omitempty"`
+
 	// The secret token/nonce which a code challenge was generated from
 	PKCEVerifier string `json:"pkce_verifier"`
 
@@ -406,4 +412,22 @@ type TokenResponse struct {
 
 	// Refresh token, for doing additional token requests to the auth server.
 	RefreshToken string `json:"refresh_token"`
+}
+
+// The fields which are included in a token revocation request. These HTTP POST bodies are form-encoded, so use URL encoding syntax, not JSON.
+type RevocationRequest struct {
+	// Client ID, aka client metadata URL
+	ClientID string `url:"client_id"`
+
+	// The token to revoke
+	Token string `url:"token"`
+
+	// Either "access_token" or "refresh_token"
+	TokenTypeHint string `url:"token_type_hint"`
+
+	// For confidential clients, must be "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+	ClientAssertionType *string `url:"client_assertion_type"`
+
+	// For confidential clients, the signed client assertion JWT
+	ClientAssertion *string `url:"client_assertion"`
 }


### PR DESCRIPTION
Addresses #1135

Revocation has similar properties to session refresh, so I implemented it in `ClientSession` alongside `RefreshTokens`.

A high-level `Logout` helper has been added to `ClientApp` which both revokes the tokens against the AS and deletes the session from the app's session store.

Due to aforementioned similarity between refresh and revocation, I created the `ClientSession.postToAuthServer` helper to reduce duplicated logic. (Note that "DPoP retry" logic is still duplicated elsewhere, I couldn't think of any elegant way to eliminate it)