### PR TITLE
Relay:Fix flag type initial-seq-number

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -103,13 +103,13 @@ func run(args []string) error {
 					Sources: cli.EnvVars("RELAY_HOST_CONCURRENCY", "RELAY_CONCURRENCY_PER_PDS"),
 					Value:   40,
 				},
-				&cli.IntFlag{
+				&cli.Int64Flag{
 					Name:    "default-account-limit",
 					Value:   100,
 					Usage:   "max number of active accounts for new upstream hosts",
 					Sources: cli.EnvVars("RELAY_DEFAULT_ACCOUNT_LIMIT", "RELAY_DEFAULT_REPO_LIMIT"),
 				},
-				&cli.IntFlag{
+				&cli.Int64Flag{
 					Name:    "new-hosts-per-day-limit",
 					Value:   50,
 					Usage:   "max number of new upstream hosts subscribed per day via public requestCrawl",


### PR DESCRIPTION
Relay is not starting because initial-seq-number is always 0, resulting from typecast from int to int64 fails. Changed flag type of initial-seq-number fom int to Int64.

default-account-limit and new-hosts-per-day-limit had the same issue

fixes #1176 