### PR TITLE
Add warning counter for non-active accounts in event processing

### DIFF
--- a/cmd/relay/relay/ingest.go
+++ b/cmd/relay/relay/ingest.go
@@ -99,7 +99,7 @@ func (r *Relay) processCommitEvent(ctx context.Context, evt *comatproto.SyncSubs
 	}
 
 	if !acc.IsActive() {
-		logger.Info("dropping commit message for non-active account", "status", acc.Status, "upstreamStatus", acc.UpstreamStatus)
+		logger.Info("dropping commit message for inactive-active account", "status", acc.Status, "upstreamStatus", acc.UpstreamStatus)
 		eventsWarningsCounter.WithLabelValues(hostname, "inactive-account").Add(1)
 		return nil
 	}
@@ -159,7 +159,7 @@ func (r *Relay) processSyncEvent(ctx context.Context, evt *comatproto.SyncSubscr
 	}
 
 	if !acc.IsActive() {
-		logger.Info("dropping sync message for non-active account", "status", acc.Status, "upstreamStatus", acc.UpstreamStatus)
+		logger.Info("dropping sync message for inactive-active account", "status", acc.Status, "upstreamStatus", acc.UpstreamStatus)
 		eventsWarningsCounter.WithLabelValues(hostname, "inactive-account").Add(1)
 		return nil
 	}


### PR DESCRIPTION
I was trying to follow dropped events, and realised this metric is not being written.   