### PR TITLE
Make repo fetch timeout configurable in `sync-tool`

### DIFF
--- a/cmd/nexus/README.md
+++ b/cmd/nexus/README.md
@@ -60,6 +60,7 @@ Environment variables or CLI flags:
 - `NEXUS_FIREHOSE_PARALLELISM`: concurrent firehose event processors (default: `10`)
 - `NEXUS_RESYNC_PARALLELISM`: concurrent resync workers (default: `5`)
 - `NEXUS_CURSOR_SAVE_INTERVAL`: how often to save cursor (default: `5s`, set to `0` to disable)
+- `NEXUS_REPO_FETCH_TIMEOUT`: timeout for fetching repo CARs from PDS (Go duration syntax, e.g. `180s`)
 - `NEXUS_FULL_NETWORK_MODE`: track all repos on the network (default: `false`)
 - `NEXUS_SIGNAL_COLLECTION`: track all repos with at least one record in this collection (e.g. `app.bsky.actor.profile`)
 - `NEXUS_COLLECTION_FILTERS`: comma-separated collection filters, wildcards accepted (e.g., `app.bsky.feed.post,app.bsky.graph.*`)

--- a/cmd/nexus/main.go
+++ b/cmd/nexus/main.go
@@ -87,6 +87,12 @@ func run(args []string) error {
 			Value:   0,
 			EnvVars: []string{"NEXUS_CURSOR_SAVE_INTERVAL"},
 		},
+		&cli.DurationFlag{
+			Name:    "repo-fetch-timeout",
+			Usage:   "timeout when fetching repo CARs from PDS (e.g. 180s for slow hosts)",
+			Value:   30 * time.Second,
+			EnvVars: []string{"NEXUS_REPO_FETCH_TIMEOUT"},
+		},
 		&cli.BoolFlag{
 			Name:    "full-network-mode",
 			Usage:   "enumerate and sync all repos on the network",
@@ -149,6 +155,7 @@ func runNexus(cctx *cli.Context) error {
 		FirehoseParallelism:        cctx.Int("firehose-parallelism"),
 		ResyncParallelism:          cctx.Int("resync-parallelism"),
 		FirehoseCursorSaveInterval: cctx.Duration("cursor-save-interval"),
+		RepoFetchTimeout:           cctx.Duration("repo-fetch-timeout"),
 		FullNetworkMode:            cctx.Bool("full-network-mode"),
 		SignalCollection:           cctx.String("signal-collection"),
 		DisableAcks:                cctx.Bool("disable-acks"),

--- a/cmd/nexus/nexus.go
+++ b/cmd/nexus/nexus.go
@@ -49,6 +49,7 @@ type NexusConfig struct {
 	FirehoseParallelism        int
 	ResyncParallelism          int
 	FirehoseCursorSaveInterval time.Duration
+	RepoFetchTimeout           time.Duration
 	FullNetworkMode            bool
 	SignalCollection           string
 	DisableAcks                bool

--- a/cmd/nexus/resync.go
+++ b/cmd/nexus/resync.go
@@ -119,8 +119,12 @@ func (n *Nexus) doResync(ctx context.Context, did string) (bool, error) {
 	n.logger.Info("fetching repo from PDS", "did", did, "pds", pdsURL)
 
 	client := atclient.NewAPIClient(pdsURL)
+	timeout := n.config.RepoFetchTimeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
 	client.Client = &http.Client{
-		Timeout: 30 * time.Second,
+		Timeout: timeout,
 	}
 
 	repoBytes, err := comatproto.SyncGetRepo(ctx, client, did, "")


### PR DESCRIPTION
Some big repos take more than 30 seconds to fetch as I have learned the hard way.