### PR TITLE
lexicon: more granular account and identity parsing

### DIFF
--- a/atproto/lexicon/testdata/catalog/permission-set.json
+++ b/atproto/lexicon/testdata/catalog/permission-set.json
@@ -88,6 +88,28 @@
           "lxm": [
             "com.example.calendar.listEvents"
           ]
+        },
+        {
+          "type": "permission",
+          "resource": "account",
+          "attr": "email"
+        },
+        {
+          "type": "permission",
+          "resource": "account",
+          "attr": "repo",
+          "action": "manage"
+        },
+        {
+          "type": "permission",
+          "resource": "identity",
+          "attr": "*"
+        },
+        {
+          "type": "permission",
+          "resource": "identity",
+          "attr": "handle",
+          "action": "submit"
         }
       ]
     }

--- a/atproto/lexicon/testdata/lexicon-valid.json
+++ b/atproto/lexicon/testdata/lexicon-valid.json
@@ -10,5 +10,60 @@
         }
       }
     }
+  },
+  {
+    "name": "permission action round-trip",
+    "lexicon": {
+      "lexicon": 1,
+      "id": "example.lexicon.perms",
+      "defs": {
+        "main": {
+          "type": "permission-set",
+          "title": "test case",
+          "permissions": [
+            {
+              "type": "permission",
+              "resource": "repo",
+              "collection": [
+                "com.example.calendar.event"
+              ],
+              "action": [
+                "delete",
+                "create"
+              ]
+            },
+            {
+              "type": "permission",
+              "resource": "repo",
+              "collection": [
+                "com.example.calendar.rsvp"
+              ]
+            },
+            {
+              "type": "permission",
+              "resource": "account",
+              "attr": "email"
+            },
+            {
+              "type": "permission",
+              "resource": "account",
+              "attr": "repo",
+              "action": "manage"
+            },
+            {
+              "type": "permission",
+              "resource": "identity",
+              "attr": "*"
+            },
+            {
+              "type": "permission",
+              "resource": "identity",
+              "attr": "handle",
+              "action": "submit"
+            }
+          ]
+        }
+      }
+    }
   }
 ]


### PR DESCRIPTION
There is maybe an open question here around how strict the validation should be when parsing a schema file, versus parsing permissions.

Eg, should `CheckSchema()` on an overall schemafile actually fail for unsupported permission resource types? What about additional account/identity `attr`? We definitely want linting to flag this sort of thing, this comes down to parsing `permission-set` declarations.

I think being strict to start here is fine. Auth scope string parsing will be separate, and we can revisit when adding specific SDK support for permissions.