### PR TITLE
collectiondir: use base64url encoding for cursor param

### DIFF
--- a/cmd/collectiondir/pebble.go
+++ b/cmd/collectiondir/pebble.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -194,7 +195,12 @@ func (pcd *PebbleCollectionDirectory) ReadCollection(ctx context.Context, collec
 		return nil, "", fmt.Errorf("collection id err, %w", err)
 	}
 	if cursor != "" {
-		lower, err = base64.RawURLEncoding.DecodeString(cursor)
+		if strings.ContainsAny(cursor, "+/=") {
+			// NOTE(2025-12-05): this is a temporary flexibility to not break clients using "old" cursor encoding
+			lower, err = base64.StdEncoding.DecodeString(cursor)
+		} else {
+			lower, err = base64.RawURLEncoding.DecodeString(cursor)
+		}
 		if err != nil {
 			return nil, "", fmt.Errorf("could not decode cursor, %w", err)
 		}


### PR DESCRIPTION
This should fix a corner-case bug with query param encoding with Swift.

Will need a deploy.

Closes: https://github.com/bluesky-social/indigo/issues/1084