### PR TITLE
oauth docs: replace transitional OAuth scope

### DIFF
--- a/atproto/auth/oauth/doc.go
+++ b/atproto/auth/oauth/doc.go
@@ -20,7 +20,7 @@ Create a single [ClientApp] instance during service setup that will be used (con
 	config := oauth.NewPublicConfig(
 		"https://app.example.com/client-metadata.json",
 		"https://app.example.com/oauth/callback",
-		[]string{"atproto", "transition:generic"},
+		[]string{"atproto", "repo:app.bsky.feed.post?action=create"},
 	)
 
 	// clients are "public" by default, but if they have secure access to a secret attestation key can be "confidential"


### PR DESCRIPTION
I think this is the last place we use `transition:generic` in doc examples.

We could consider switching these to `include:app.bsky.authCreatePosts`, but I think it is fine either way.