### PR TITLE
Tap: allow custom plc directory

### DIFF
--- a/cmd/tap/README.md
+++ b/cmd/tap/README.md
@@ -59,6 +59,7 @@ Environment variables or CLI flags:
 - `TAP_DATABASE_URL`: database connection string, SQLite or PostgreSQL (default: `sqlite://./tap.db`)
 - `TAP_MAX_DB_CONNS`: maximum number of database connections (default: `32`)
 - `TAP_BIND`: HTTP server address (default: `:2480`)
+- `TAP_PLC_URL`: PLC directory HTTP/HTTPS URL (default: `https://plc.directory`)
 - `TAP_RELAY_URL`: AT Protocol relay HTTP/HTTPS URL (default: `https://relay1.us-east.bsky.network`)
 - `TAP_FIREHOSE_PARALLELISM`: concurrent firehose event processors (default: `10`)
 - `TAP_RESYNC_PARALLELISM`: concurrent resync workers (default: `5`)

--- a/cmd/tap/main.go
+++ b/cmd/tap/main.go
@@ -60,6 +60,12 @@ func run(args []string) error {
 						Sources: cli.EnvVars("TAP_BIND"),
 					},
 					&cli.StringFlag{
+						Name:    "plc-url",
+						Usage:   "PLC registry HTTP/HTTPS url",
+						Value:   "https://plc.directory",
+						Sources: cli.EnvVars("TAP_PLC_URL", "ATP_PLC_HOST"),
+					},
+					&cli.StringFlag{
 						Name:    "relay-url",
 						Usage:   "AT Protocol relay HTTP/HTTPS url",
 						Value:   "https://relay1.us-east.bsky.network",
@@ -181,9 +187,16 @@ func runTap(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("relay-url must start with http:// or https://")
 	}
 
+	// fail early if plc url is not http/https
+	plcUrl := cmd.String("plc-url")
+	if !strings.HasPrefix(plcUrl, "http://") && !strings.HasPrefix(plcUrl, "https://") {
+		return fmt.Errorf("plc-url must start with http:// or https://")
+	}
+
 	config := TapConfig{
 		DatabaseURL:                cmd.String("db-url"),
 		DBMaxConns:                 int(cmd.Int("max-db-conn")),
+		PLCURL:                     plcUrl,
 		RelayUrl:                   relayUrl,
 		FirehoseParallelism:        int(cmd.Int("firehose-parallelism")),
 		ResyncParallelism:          int(cmd.Int("resync-parallelism")),

--- a/cmd/tap/tap.go
+++ b/cmd/tap/tap.go
@@ -36,6 +36,7 @@ type Tap struct {
 type TapConfig struct {
 	DatabaseURL                string
 	DBMaxConns                 int
+	PLCURL                     string
 	RelayUrl                   string
 	FirehoseParallelism        int
 	ResyncParallelism          int
@@ -61,6 +62,7 @@ func NewTap(config TapConfig) (*Tap, error) {
 	}
 
 	bdir := identity.BaseDirectory{
+		PLCURL:                config.PLCURL,
 		TryAuthoritativeDNS:   false,
 		SkipDNSDomainSuffixes: []string{".bsky.social"},
 	}


### PR DESCRIPTION
One might need custom plc directory endpoint other than <https://plc.directory> for testing purposes or for plc mirrors.

As tap supports full network backfill, it would be better to test that on sandboxed atproto infra than public infra with ~40M repos.

So I added a `plc-url` flag and `TAP_PLC_URL` env var.
Same as relay, `ATP_PLC_HOST` env var can also be used instead.