### PR TITLE
relay: hint PG for perf on listRepos

### DIFF
--- a/cmd/relay/relay/account.go
+++ b/cmd/relay/relay/account.go
@@ -299,10 +299,10 @@ func (r *Relay) ListAccountsDetailed(ctx context.Context, cursor int64, limit in
 		       account_repo.rev, account_repo.commit_cid, account_repo.commit_data_cid
 		FROM account
 		INNER JOIN account_repo ON account.uid = account_repo.uid
-		WHERE account.uid > ? AND account.status = 'active' AND account.upstream_status = 'active'
+		WHERE account.uid > ? AND account_repo.uid > ? AND account.status = 'active' AND account.upstream_status = 'active'
 		ORDER BY account.uid
 		LIMIT ?
-	`, cursor, limit).Scan(&accounts).Error; err != nil {
+	`, cursor, cursor, limit).Scan(&accounts).Error; err != nil {
 		return nil, err
 	}
 	return accounts, nil

--- a/cmd/relay/relay/models/models.go
+++ b/cmd/relay/relay/models/models.go
@@ -89,6 +89,7 @@ func (Account) TableName() string {
 // This is a small extension table to `Account`, which holds fast-changing fields updated on every firehose event.
 type AccountRepo struct {
 	// references Account.UID, but not set up as a foreign key
+	// TODO: it might help the query planner to add the foreign key relationship to the 'account' table.
 	UID uint64 `gorm:"column:uid;primarykey" json:"uid"`
 	Rev string `gorm:"column:rev;not null" json:"rev"`
 


### PR DESCRIPTION
As indicated in the comment, adding an actual foreign key relationship would probably help with this. But doing it as a query tweak is a simpler change to deploy (no schema change).

I have tested this in prod and it helped a bunch with perf. I have not tested even locally with an actual call to listRepos, should do that before merging+deploying.

closes: https://github.com/bluesky-social/indigo/issues/1236