### PR TITLE
Catch Panics in EventManager.broadcastEvent

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -68,6 +68,12 @@ func (em *EventManager) Shutdown(ctx context.Context) error {
 }
 
 func (em *EventManager) broadcastEvent(evt *XRPCStreamEvent) {
+	defer func() {
+		if r := recover(); r != nil {
+			em.log.Error("caught panic in broadcastEvent", "recover", r)
+		}
+	}()
+
 	// the main thing we do is send it out, so MarshalCBOR once
 	if err := evt.Preserialize(); err != nil {
 		em.log.Error("broadcast serialize failed", "err", err)


### PR DESCRIPTION
Seeing lots of crashes in rainbow due to us sending to `s.outgoing` even though it's already been closed.

This is clearly a bandaid, but we need a fix ASAP, and this should probably be in there anyways

<img width="1608" height="823" alt="image" src="https://github.com/user-attachments/assets/ce0ba2d3-b9a4-4564-9de9-3b69070ef67b" />

^ note that large recent missing data blip was me cutting the rainbow process over to a new management system. Had a bit of downtime (sorry!)