### PR TITLE
Tap: restore nextID counter on restart to prevent unique constraint errors

### DIFF
--- a/cmd/tap/event_manager.go
+++ b/cmd/tap/event_manager.go
@@ -140,6 +140,9 @@ func (em *EventManager) loadEventPage(ctx context.Context, lastID int) (int, err
 	eventCacheSize.Set(float64(len(em.cache)))
 	em.cacheLk.Unlock()
 
+	maxID := dbEvts[len(dbEvts)-1].ID
+	em.nextID.Store(uint64(maxID + 1))
+
 	for i := range dbEvts {
 		em.pendingIDs <- dbEvts[i].ID
 	}


### PR DESCRIPTION
When Tap restarts, the EventManager loads existing events from the database but doesn't initialize the nextID counter. This causes new events to be assigned IDs starting from 0, which collide with existing database records.

The fix restores the nextID counter as events are loaded, ensuring new IDs are always greater than any existing database IDs.

Fixes #1253