### PR TITLE
Revert "Adds `recId` to `getSuggestUsers`"

### DIFF
--- a/api/bsky/unspeccedgetSuggestedUsers.go
+++ b/api/bsky/unspeccedgetSuggestedUsers.go
@@ -13,8 +13,6 @@ import (
 // UnspeccedGetSuggestedUsers_Output is the output of a app.bsky.unspecced.getSuggestedUsers call.
 type UnspeccedGetSuggestedUsers_Output struct {
 	Actors []*ActorDefs_ProfileView `json:"actors" cborgen:"actors"`
-	// recId: Snowflake for this recommendation, use when submitting recommendation events.
-	RecId *int64 `json:"recId,omitempty" cborgen:"recId,omitempty"`
 }
 
 // UnspeccedGetSuggestedUsers calls the XRPC method "app.bsky.unspecced.getSuggestedUsers".

--- a/api/bsky/unspeccedgetSuggestedUsersSkeleton.go
+++ b/api/bsky/unspeccedgetSuggestedUsersSkeleton.go
@@ -13,8 +13,6 @@ import (
 // UnspeccedGetSuggestedUsersSkeleton_Output is the output of a app.bsky.unspecced.getSuggestedUsersSkeleton call.
 type UnspeccedGetSuggestedUsersSkeleton_Output struct {
 	Dids []string `json:"dids" cborgen:"dids"`
-	// recId: Snowflake for this recommendation, use when submitting recommendation events.
-	RecId *int64 `json:"recId,omitempty" cborgen:"recId,omitempty"`
 }
 
 // UnspeccedGetSuggestedUsersSkeleton calls the XRPC method "app.bsky.unspecced.getSuggestedUsersSkeleton".

--- a/lexicons/app/bsky/unspecced/getSuggestedUsers.json
+++ b/lexicons/app/bsky/unspecced/getSuggestedUsers.json
@@ -32,10 +32,6 @@
                 "type": "ref",
                 "ref": "app.bsky.actor.defs#profileView"
               }
-            },
-            "recId": {
-              "type": "integer",
-              "description": "Snowflake for this recommendation, use when submitting recommendation events."
             }
           }
         }

--- a/lexicons/app/bsky/unspecced/getSuggestedUsersSkeleton.json
+++ b/lexicons/app/bsky/unspecced/getSuggestedUsersSkeleton.json
@@ -37,10 +37,6 @@
                 "type": "string",
                 "format": "did"
               }
-            },
-            "recId": {
-              "type": "integer",
-              "description": "Snowflake for this recommendation, use when submitting recommendation events."
             }
           }
         }


### PR DESCRIPTION
This reverts commit 2c00289a95bd0f6b06ae08e0ac7b80fbbc8b367d.


We need to remove this field here and from `@atproto/bsky`, deploy the lexicon without it, and then re-add it as string.

Long story short: `recId` is an `int64` and TS/JS cannot get the machine ID out of it because it can't handle big integers unless with explicity `BigInt` — which is not the case in our stack. So we're gonna pass it ias string instead.

Related PRs:

* bluesky-social/atproto#4440
* #1263
* bluesky-social/seeemore#155 
* bluesky-social/seeemore#158