### PR TITLE
atproto/atclient: password auth refresh should use method post

### DIFF
--- a/atproto/atclient/password_auth.go
+++ b/atproto/atclient/password_auth.go
@@ -144,7 +144,7 @@ func (a *PasswordAuth) Refresh(ctx context.Context, c *http.Client, priorRefresh
 	}
 
 	u := a.Session.Host + "/xrpc/com.atproto.server.refreshSession"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix `PasswordAuth#Refresh` using the wrong method.