### PR TITLE
Tap: fix repo commit metadata tracking

### DIFF
--- a/cmd/tap/firehose.go
+++ b/cmd/tap/firehose.go
@@ -178,10 +178,11 @@ func (fp *FirehoseProcessor) validateCommitAndFilterOps(ctx context.Context, evt
 	}
 
 	commit := &Commit{
-		Did:     evt.Repo,
-		Rev:     repoCommit.Rev,
-		DataCid: repoCommit.Data.String(),
-		Ops:     parsedOps,
+		Did:      evt.Repo,
+		Rev:      repoCommit.Rev,
+		DataCid:  repoCommit.Data.String(),
+		PrevData: evt.PrevData.String(),
+		Ops:      parsedOps,
 	}
 
 	return commit, nil

--- a/cmd/tap/types.go
+++ b/cmd/tap/types.go
@@ -15,10 +15,11 @@ const (
 )
 
 type Commit struct {
-	Did     string     `json:"did"`
-	Rev     string     `json:"rev"`
-	DataCid string     `json:"data_cid"`
-	Ops     []CommitOp `json:"ops"`
+	Did      string     `json:"did"`
+	Rev      string     `json:"rev"`
+	DataCid  string     `json:"data_cid"`
+	PrevData string     `json:"prev_data"`
+	Ops      []CommitOp `json:"ops"`
 }
 
 type CommitOp struct {


### PR DESCRIPTION
Fixes a few issues in Tap. The most important is that we were not updating prev data & rev when we didn't need to process any ops from a commit. This would cause commits to appear as disjunctions in commit history.

This also rearranges some logic in `ProcessCommit` which would cause us to mark a repo "desynced" if an event came in while resyncing rather than adding that event to the resync buffer.

For events that we add to the resync buffer, we hold off checking that they play neatly on the current state of the repo (through prevData) until we actually go to play them back.