### PR TITLE
atclient: allow pw auth to inactive account

### DIFF
--- a/atproto/atclient/password_auth.go
+++ b/atproto/atclient/password_auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -266,7 +267,7 @@ func LoginWithPasswordHost(ctx context.Context, host, username, password, authTo
 	}
 
 	if out.Active != nil && *out.Active == false {
-		return nil, fmt.Errorf("account is disabled: %v", out.Status)
+		slog.Info("password login to inactive account", "status", *out.Status, "username", username)
 	}
 
 	did, err := syntax.ParseDID(out.Did)


### PR DESCRIPTION
This check was overly aggressive. There are a lot of situations where an account needs to authenticate in "deactivated" state.

I'm not even sure if a log line is necessary here, but figure this is a change in SDK behavior so it should at least be a bit vocal.

This also fixes a bug where a pointer to the status string was printed, instead of the status string itself.