### PR TITLE
.golangci.yaml: warn if go.mod/go.sum is dirty

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,6 @@
 version: "2"
-
+run:
+  modules-download-mode: readonly
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0


### PR DESCRIPTION
Setting modules-download-mode: readonly causes the linter to complain, rather than silently letting the tooling fix things up behind the scenes. This is a good belt and suspenders check to ensure whats in the commit is what is built at that commit.