### PR TITLE
workflows: use go.mod as source of truth for the Go version to use

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Set up Go tooling
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - name: Build
         run: make build
       - name: Test
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Set up Go tooling
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version-file: go.mod
       - name: Lint
         run: make lint


### PR DESCRIPTION
Rather than mentioning the Go version in several places, actions/setup-go can source the correct version from the go.mod file, removing one place where they can get out of sync.

I wasn't sure if the go-version-file syntax is available with setup-go v4, so I went ahead and bumped up the checkout and setup actions to their latest versions. I use these versions on several projects as they are what dependabot will upgrade you too by default, so feel pretty confident this is a safe change.