### PR TITLE
Tap: fix nil pointer err on prevData

### DIFF
--- a/cmd/tap/firehose.go
+++ b/cmd/tap/firehose.go
@@ -178,11 +178,14 @@ func (fp *FirehoseProcessor) validateCommitAndFilterOps(ctx context.Context, evt
 	}
 
 	commit := &Commit{
-		Did:      evt.Repo,
-		Rev:      repoCommit.Rev,
-		DataCid:  repoCommit.Data.String(),
-		PrevData: evt.PrevData.String(),
-		Ops:      parsedOps,
+		Did:     evt.Repo,
+		Rev:     repoCommit.Rev,
+		DataCid: repoCommit.Data.String(),
+		Ops:     parsedOps,
+	}
+
+	if evt.PrevData != nil {
+		commit.PrevData = evt.PrevData.String()
 	}
 
 	return commit, nil

--- a/cmd/tap/resyncer.go
+++ b/cmd/tap/resyncer.go
@@ -370,7 +370,8 @@ func (r *Resyncer) drainResyncBuffer(ctx context.Context, did string) error {
 		}
 
 		// if this commit doesn't stack neatly on current state of tracked repo then we skip
-		if commit.PrevData != curr.PrevData {
+		// NOTE: the check against the empty string can be eliminated after we start refusing legacy commit events
+		if commit.PrevData != "" && commit.PrevData != curr.PrevData {
 			continue
 		}
 


### PR DESCRIPTION
Prev data can be nil in the case of legacy (non sync1.1) commits, causing a nil pointer error.