### PR TITLE
cmd/tap: quash Echo's cheery http server started on [::]:2480 msg

### DIFF
--- a/cmd/tap/server.go
+++ b/cmd/tap/server.go
@@ -31,6 +31,7 @@ type TapServer struct {
 func (ts *TapServer) Start(address string) error {
 	ts.echo = echo.New()
 	ts.echo.HideBanner = true
+	ts.echo.HidePort = true // silence http server started on [::]:port log line
 	ts.echo.Use(middleware.LoggerWithConfig(middleware.DefaultLoggerConfig))
 
 	// Apply admin auth middleware if configured


### PR DESCRIPTION
_Almost_ every log line from tap goes slog in json format, so one can pipe it through jq. Except for echo, which helpfully poops

```
⇨ http server started on [::]:2480
```

to stdout and breaks jq parsing.

This PR silences the annoucement as we have already slog'd the same information.