### PR TITLE
cmd/tap: move metrics and pprof endpoint management to runTap

### DIFF
--- a/cmd/tap/server.go
+++ b/cmd/tap/server.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -58,12 +57,6 @@ func (ts *TapServer) Start(address string) error {
 // Shutdown gracefully shuts down the HTTP server.
 func (ts *TapServer) Shutdown(ctx context.Context) error {
 	return ts.echo.Shutdown(ctx)
-}
-
-// RunMetrics starts the metrics and pprof server on a separate port.
-func (ts *TapServer) RunMetrics(listen string) error {
-	http.Handle("/metrics", promhttp.Handler())
-	return http.ListenAndServe(listen, nil)
 }
 
 func (ts *TapServer) handleHealthcheck(c echo.Context) error {


### PR DESCRIPTION
TapServer's RunMetrics method didn't really belong on TapServer. It was for a different HTTP server, with a different lifecycle. Extracting it to main.runTap makes this a little clearer.