### PR TITLE
atproto/identity: unexport MockDirectory internals

### DIFF
--- a/atproto/identity/mock_directory.go
+++ b/atproto/identity/mock_directory.go
@@ -12,8 +12,8 @@ import (
 // A fake identity directory, for use in tests
 type MockDirectory struct {
 	mu         sync.RWMutex
-	Handles    map[syntax.Handle]syntax.DID
-	Identities map[syntax.DID]Identity
+	handles    map[syntax.Handle]syntax.DID
+	identities map[syntax.DID]Identity
 }
 
 var _ Directory = (*MockDirectory)(nil)
@@ -21,8 +21,8 @@ var _ Resolver = (*MockDirectory)(nil)
 
 func NewMockDirectory() MockDirectory {
 	return MockDirectory{
-		Handles:    make(map[syntax.Handle]syntax.DID),
-		Identities: make(map[syntax.DID]Identity),
+		handles:    make(map[syntax.Handle]syntax.DID),
+		identities: make(map[syntax.DID]Identity),
 	}
 }
 
@@ -31,9 +31,9 @@ func (d *MockDirectory) Insert(ident Identity) {
 	defer d.mu.Unlock()
 
 	if !ident.Handle.IsInvalidHandle() {
-		d.Handles[ident.Handle.Normalize()] = ident.DID
+		d.handles[ident.Handle.Normalize()] = ident.DID
 	}
-	d.Identities[ident.DID] = ident
+	d.identities[ident.DID] = ident
 }
 
 func (d *MockDirectory) LookupHandle(ctx context.Context, h syntax.Handle) (*Identity, error) {
@@ -41,11 +41,11 @@ func (d *MockDirectory) LookupHandle(ctx context.Context, h syntax.Handle) (*Ide
 	defer d.mu.RUnlock()
 
 	h = h.Normalize()
-	did, ok := d.Handles[h]
+	did, ok := d.handles[h]
 	if !ok {
 		return nil, ErrHandleNotFound
 	}
-	ident, ok := d.Identities[did]
+	ident, ok := d.identities[did]
 	if !ok {
 		return nil, ErrDIDNotFound
 	}
@@ -56,7 +56,7 @@ func (d *MockDirectory) LookupDID(ctx context.Context, did syntax.DID) (*Identit
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	ident, ok := d.Identities[did]
+	ident, ok := d.identities[did]
 	if !ok {
 		return nil, ErrDIDNotFound
 	}
@@ -83,7 +83,7 @@ func (d *MockDirectory) ResolveHandle(ctx context.Context, h syntax.Handle) (syn
 	defer d.mu.RUnlock()
 
 	h = h.Normalize()
-	did, ok := d.Handles[h]
+	did, ok := d.handles[h]
 	if !ok {
 		return "", ErrHandleNotFound
 	}
@@ -94,7 +94,7 @@ func (d *MockDirectory) ResolveDID(ctx context.Context, did syntax.DID) (*DIDDoc
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	ident, ok := d.Identities[did]
+	ident, ok := d.identities[did]
 	if !ok {
 		return nil, ErrDIDNotFound
 	}
@@ -106,7 +106,7 @@ func (d *MockDirectory) ResolveDIDRaw(ctx context.Context, did syntax.DID) (json
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	ident, ok := d.Identities[did]
+	ident, ok := d.identities[did]
 	if !ok {
 		return nil, ErrDIDNotFound
 	}


### PR DESCRIPTION
MockDirectory.mu was not exported, by Handles and Indentities were. While I was not able to find any examples of this in indigo, this arrangement could permit a caller of MockDirectory to violate the lock invariant and reach into Handles/Identities directly.

Unexporting these two fields showed no breaks in any of the tests, which is excellent. If it was necessary to probe the internals of the MockDirectory, that could be done with additional methods exposed via a type asserting from Directory to *MockDirectory.