### PR TITLE
atproto/identity: return *CacheDirectory from constructor

### DIFF
--- a/atproto/identity/cache_directory.go
+++ b/atproto/identity/cache_directory.go
@@ -37,8 +37,8 @@ type identityEntry struct {
 var _ Directory = (*CacheDirectory)(nil)
 
 // Capacity of zero means unlimited size. Similarly, ttl of zero means unlimited duration.
-func NewCacheDirectory(inner Directory, capacity int, hitTTL, errTTL, invalidHandleTTL time.Duration) CacheDirectory {
-	return CacheDirectory{
+func NewCacheDirectory(inner Directory, capacity int, hitTTL, errTTL, invalidHandleTTL time.Duration) *CacheDirectory {
+	return &CacheDirectory{
 		ErrTTL:           errTTL,
 		InvalidHandleTTL: invalidHandleTTL,
 		Inner:            inner,

--- a/atproto/identity/directory.go
+++ b/atproto/identity/directory.go
@@ -85,6 +85,5 @@ func DefaultDirectory() Directory {
 		SkipDNSDomainSuffixes: []string{".bsky.social"},
 		UserAgent:             "indigo-identity/" + versioninfo.Short(),
 	}
-	cached := NewCacheDirectory(&base, 250_000, time.Hour*24, time.Minute*2, time.Minute*5)
-	return &cached
+	return NewCacheDirectory(&base, 250_000, time.Hour*24, time.Minute*2, time.Minute*5)
 }

--- a/atproto/identity/live_test.go
+++ b/atproto/identity/live_test.go
@@ -66,7 +66,7 @@ func TestCacheDirectory(t *testing.T) {
 	inner := BaseDirectory{}
 	d := NewCacheDirectory(&inner, 1000, time.Hour*1, time.Hour*1, time.Hour*1)
 	for i := 0; i < 3; i = i + 1 {
-		testDirectoryLive(t, &d)
+		testDirectoryLive(t, d)
 	}
 }
 

--- a/cmd/hepa/main.go
+++ b/cmd/hepa/main.go
@@ -12,8 +12,9 @@ import (
 	"strings"
 	"time"
 
-	_ "github.com/joho/godotenv/autoload"
 	_ "net/http/pprof"
+
+	_ "github.com/joho/godotenv/autoload"
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/identity/redisdir"
@@ -222,8 +223,7 @@ func configDirectory(cmd *cli.Command) (identity.Directory, error) {
 		}
 		dir = rdir
 	} else {
-		cdir := identity.NewCacheDirectory(&baseDir, 1_500_000, time.Hour*24, time.Minute*2, time.Minute*5)
-		dir = &cdir
+		dir = identity.NewCacheDirectory(&baseDir, 1_500_000, time.Hour*24, time.Minute*2, time.Minute*5)
 	}
 	return dir, nil
 }

--- a/cmd/palomar/main.go
+++ b/cmd/palomar/main.go
@@ -267,7 +267,7 @@ var runCmd = &cli.Command{
 			PostIndex:    cmd.String("es-post-index"),
 		}
 
-		srv, err := search.NewServer(escli, &dir, apiConfig)
+		srv, err := search.NewServer(escli, dir, apiConfig)
 		if err != nil {
 			return err
 		}
@@ -290,7 +290,7 @@ var runCmd = &cli.Command{
 				IndexingRateLimit:   cmd.Int("indexing-rate-limit"),
 			}
 
-			idx, err := search.NewIndexer(db, escli, &dir, indexerConfig)
+			idx, err := search.NewIndexer(db, escli, dir, indexerConfig)
 			if err != nil {
 				return fmt.Errorf("failed to set up indexer: %w", err)
 			}

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -278,7 +278,7 @@ func runRelay(ctx context.Context, cmd *cli.Command) error {
 	evtman := eventmgr.NewEventManager(persister)
 
 	logger.Info("constructing relay service")
-	r, err := relay.NewRelay(db, evtman, &dir, relayConfig)
+	r, err := relay.NewRelay(db, evtman, dir, relayConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/tap/tap.go
+++ b/cmd/tap/tap.go
@@ -81,7 +81,7 @@ func NewTap(config TapConfig) (*Tap, error) {
 	repoMngr := &RepoManager{
 		logger: logger.With("component", "server"),
 		db:     db,
-		IdDir:  &cdir,
+		IdDir:  cdir,
 		events: evtMngr,
 	}
 


### PR DESCRIPTION
This PR is sadly a breaking change, but probably one that is valuable to make. NewCacheDirectory was returning CacheDirectory, the value, not *CacheDirectory, the reference. This is problematic because CacheDirectory includes two sync.Map fields which should not be copied.

I'm not sure why returning the CacheDirectory from NewCacheDirectory by value did not trigger a linter warning -- returning a value is the same as passing a parameter, its a copy -- it could be a special case, but the result is the value return from NewCacheDirectory is tricky to use correctly.

Firstly it forces anyone who wants to use the result to take its address, because that is what satisfies the interface. Also, not taking the address and passing it as a parameter or assinging the result will trigger the lint warning
```
sync.Map contains sync.noCopy (govet)
```
I cannot find a defensible reason that NewCacheDirectory should continue to return a value, so I have updated it to return a pointer type which resolves a number of places which were complicated by not being able to take the address of a return value without first assinging it.

However, this remains a breaking change, and probably one that will be visible to downstream indigo users. I suspect they will welcome it, as I believe it is the correct thing to do, but never the less, this is not a transparent change.