### PR TITLE
cmd/tap: move component initalisation into constructor fns

### DIFF
--- a/cmd/tap/event_manager.go
+++ b/cmd/tap/event_manager.go
@@ -28,6 +28,16 @@ type EventManager struct {
 	pendingIDs chan uint
 }
 
+func NewEventManager(logger *slog.Logger, db *gorm.DB, config *TapConfig) *EventManager {
+	return &EventManager{
+		logger:     logger.With("component", "event_manager"),
+		db:         db,
+		cacheSize:  config.EventCacheSize,
+		cache:      make(map[uint]*OutboxEvt),
+		pendingIDs: make(chan uint, config.EventCacheSize*2), // give us some buffer room in channel since we can overshoot
+	}
+}
+
 type DBCallback = func(tx *gorm.DB) error
 
 func (em *EventManager) IsFull() bool {

--- a/cmd/tap/main.go
+++ b/cmd/tap/main.go
@@ -224,7 +224,7 @@ func runTap(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	if !config.OutboxOnly {
-		go tap.Crawler.Run(ctx)
+		go tap.crawler.Run(ctx)
 	}
 
 	svcErr := make(chan error, 1)
@@ -232,7 +232,7 @@ func runTap(ctx context.Context, cmd *cli.Command) error {
 	if !config.OutboxOnly {
 		go func() {
 			logger.Info("starting firehose consumer")
-			if err := tap.Firehose.Run(ctx); err != nil {
+			if err := tap.firehose.Run(ctx); err != nil {
 				svcErr <- err
 			}
 		}()
@@ -242,7 +242,7 @@ func runTap(ctx context.Context, cmd *cli.Command) error {
 
 	go func() {
 		logger.Info("starting HTTP server", "addr", cmd.String("bind"))
-		if err := tap.Server.Start(cmd.String("bind")); err != nil {
+		if err := tap.server.Start(cmd.String("bind")); err != nil {
 			svcErr <- err
 		}
 	}()
@@ -273,7 +273,7 @@ func runTap(ctx context.Context, cmd *cli.Command) error {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()
 
-	if err := tap.Server.Shutdown(shutdownCtx); err != nil {
+	if err := tap.server.Shutdown(shutdownCtx); err != nil {
 		logger.Error("error during shutdown", "error", err)
 		return err
 	}

--- a/cmd/tap/outbox.go
+++ b/cmd/tap/outbox.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log/slog"
+	"net/http"
 	"sync"
 	"time"
 
@@ -41,6 +42,27 @@ type Outbox struct {
 	outgoing chan *OutboxEvt
 
 	ctx context.Context
+}
+
+func NewOutbox(logger *slog.Logger, events *EventManager, config *TapConfig) *Outbox {
+	return &Outbox{
+		logger:       logger.With("component", "outbox"),
+		mode:         parseOutboxMode(config.WebhookURL, config.DisableAcks),
+		parallelism:  config.OutboxParallelism,
+		retryTimeout: config.RetryTimeout,
+		webhook: &WebhookClient{
+			logger:        logger.With("component", "webhook_client"),
+			webhookURL:    config.WebhookURL,
+			adminPassword: config.AdminPassword,
+			httpClient: &http.Client{
+				Timeout: 30 * time.Second,
+			},
+		},
+		events:     events,
+		didWorkers: xsync.NewMap[string, *DIDWorker](),
+		acks:       make(chan uint, config.OutboxParallelism*10000),
+		outgoing:   make(chan *OutboxEvt, config.OutboxParallelism*10000),
+	}
 }
 
 // Run starts the outbox workers for event delivery and cleanup.

--- a/cmd/tap/repo_manager.go
+++ b/cmd/tap/repo_manager.go
@@ -13,8 +13,17 @@ import (
 type RepoManager struct {
 	logger *slog.Logger
 	db     *gorm.DB
-	IdDir  identity.Directory
+	idDir  identity.Directory
 	events *EventManager
+}
+
+func NewRepoManager(logger *slog.Logger, db *gorm.DB, events *EventManager, idDir identity.Directory) *RepoManager {
+	return &RepoManager{
+		logger: logger.With("component", "repo_manager"),
+		db:     db,
+		idDir:  idDir,
+		events: events,
+	}
 }
 
 func (rm *RepoManager) GetRepoState(ctx context.Context, did string) (*models.Repo, error) {
@@ -39,11 +48,11 @@ func (rm *RepoManager) RefreshIdentity(ctx context.Context, did string) error {
 	ctx, span := tracer.Start(ctx, "RefreshIdentity")
 	defer span.End()
 
-	if err := rm.IdDir.Purge(ctx, syntax.DID(did).AtIdentifier()); err != nil {
+	if err := rm.idDir.Purge(ctx, syntax.DID(did).AtIdentifier()); err != nil {
 		rm.logger.Error("failed to purge identity cache", "did", did, "error", err)
 	}
 
-	id, err := rm.IdDir.LookupDID(ctx, syntax.DID(did))
+	id, err := rm.idDir.LookupDID(ctx, syntax.DID(did))
 	if err != nil {
 		return err
 	}

--- a/cmd/tap/server.go
+++ b/cmd/tap/server.go
@@ -27,6 +27,18 @@ type TapServer struct {
 	crawler       *Crawler
 }
 
+func NewTapServer(logger *slog.Logger, db *gorm.DB, outbox *Outbox, idDir identity.Directory, firehose *FirehoseProcessor, crawler *Crawler, config *TapConfig) *TapServer {
+	return &TapServer{
+		logger:        logger.With("component", "server"),
+		db:            db,
+		outbox:        outbox,
+		adminPassword: config.AdminPassword,
+		idDir:         idDir,
+		firehose:      firehose,
+		crawler:       crawler,
+	}
+}
+
 func (ts *TapServer) Start(address string) error {
 	ts.echo = echo.New()
 	ts.echo.HideBanner = true


### PR DESCRIPTION
This PR moves the declaration of the various tap components from runTap to various constructor functions. Along the way I also took the liberty of unexporting various fields, and plumbed the outboxOnly mode down to main.Tap rather than the whole config object.

There is no functional change, just breaking out the initalisation for each component so in tests we can use the same logic as in runTap.