### PR TITLE
cmd/tap: introduce runPeriodically helper

### DIFF
--- a/cmd/tap/util.go
+++ b/cmd/tap/util.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -80,5 +81,22 @@ func parseOutboxMode(webhookURL string, disableAcks bool) OutboxMode {
 		return OutboxModeFireAndForget
 	} else {
 		return OutboxModeWebsocketAck
+	}
+}
+
+// runPeriodically runs the provided task function at the specified interval until the context is done or an error occurs.
+func runPeriodically(ctx context.Context, interval time.Duration, task func(context.Context) error) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := task(ctx); err != nil {
+				return fmt.Errorf("periodic task failed: %w", err)
+			}
+		}
 	}
 }

--- a/cmd/tap/util_test.go
+++ b/cmd/tap/util_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRunPeriodicallyStopsOnTaskError(t *testing.T) {
+
+	ctx := t.Context()
+
+	var calls atomic.Int32
+	taskErr := errors.New("boom")
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runPeriodically(ctx, 5*time.Millisecond, func(context.Context) error {
+			calls.Add(1)
+			return taskErr
+		})
+	}()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, taskErr) {
+			t.Fatalf("expected error to wrap task error, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "periodic task failed") {
+			t.Fatalf("expected wrapped error message, got %v", err)
+		}
+		if calls.Load() != 1 {
+			t.Fatalf("expected task to be called once, got %d", calls.Load())
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("runPeriodically did not return on task error")
+	}
+}
+
+func TestRunPeriodicallyReturnsOnContextCancel(t *testing.T) {
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var calls atomic.Int32
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runPeriodically(ctx, 5*time.Millisecond, func(context.Context) error {
+			if calls.Add(1) >= 2 {
+				cancel()
+			}
+			return nil
+		})
+	}()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation, got %v", err)
+		}
+		if calls.Load() < 2 {
+			t.Fatalf("expected at least two task executions, got %d", calls.Load())
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("runPeriodically did not return on context cancel")
+	}
+}


### PR DESCRIPTION
There is a common pattern that a component wants to run a periodic operation until being cancelled via context. This PR extracts that pattern into a helper and as a proof of concept refactors RunCursorSaver to use it.