### PR TITLE
automod: limit blob processing concurrency per record

### DIFF
--- a/automod/engine/engine.go
+++ b/automod/engine/engine.go
@@ -61,6 +61,9 @@ type EngineConfig struct {
 	IdentityEventTimeout time.Duration
 	// timeout for event processing (total, including all setup, rules, and teardown)
 	OzoneEventTimeout time.Duration
+
+	// number of blobs fetched and processed concurrently per record (there may be many records processed in parallel). If zero, a sane default is used (`DEFAULT_BLOB_PROCESSING_CONCURRENCY`). If negative, no limit.
+	BlobProcessingConcurrency int
 }
 
 // Entrypoint for external code pushing #identity events in to the engine.

--- a/automod/engine/ruleset.go
+++ b/automod/engine/ruleset.go
@@ -3,11 +3,14 @@ package engine
 import (
 	"bytes"
 	"fmt"
-	"sync"
 
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	lexutil "github.com/bluesky-social/indigo/lex/util"
+
+	"golang.org/x/sync/errgroup"
 )
+
+var DEFAULT_BLOB_PROCESSING_CONCURRENCY = 8
 
 // Holds configuration of which rules of various types should be run, and helps dispatch events to those rules.
 type RuleSet struct {
@@ -121,60 +124,36 @@ func (r *RuleSet) fetchAndProcessBlobs(c *RecordContext) error {
 		return nil
 	}
 
-	errChan := make(chan error, len(blobs))
-	var wg sync.WaitGroup
+	concurrency := c.engine.Config.BlobProcessingConcurrency
+	if concurrency == 0 {
+		concurrency = DEFAULT_BLOB_PROCESSING_CONCURRENCY
+	}
+
+	var wg errgroup.Group
+	wg.SetLimit(concurrency)
 	for _, blob := range blobs {
-		wg.Add(1)
-		go func(blob lexutil.LexBlob) {
-			defer wg.Done()
+		blob := blob
+		wg.Go(func() error {
 			data, err := c.fetchBlob(blob)
 			if err != nil {
-				errChan <- err
-				return
+				return err
 			}
-			err = r.processBlob(c, blob, data)
-			if err != nil {
-				errChan <- err
-				return
-			}
-		}(blob)
-
+			return r.processBlob(c, blob, data)
+		})
 	}
-	wg.Wait()
-	close(errChan)
-
-	// check for errors
-	for err := range errChan {
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return wg.Wait()
 }
 
 func (r *RuleSet) processBlob(c *RecordContext, blob lexutil.LexBlob, data []byte) error {
-	errChan := make(chan error, len(r.BlobRules))
-	var wg sync.WaitGroup
-	for _, f := range r.BlobRules {
-		wg.Add(1)
-		go func(brf BlobRuleFunc) {
-			defer wg.Done()
-			err := brf(c, blob, data)
-			if err != nil {
-				errChan <- err
-				return
-			}
-		}(f)
+
+	// note that this errgroup.Group is *not* bounded: it runs all blob rules in parallel
+	var wg errgroup.Group
+	for _, brf := range r.BlobRules {
+		brf := brf
+		wg.Go(func() error {
+			return brf(c, blob, data)
+		})
 	}
 
-	wg.Wait()
-	close(errChan)
-
-	// check for errors
-	for err := range errChan {
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return wg.Wait()
 }


### PR DESCRIPTION
The motivation is that we are looking at doing a "gallery" embed type on bsky posts, and want to constrain the increase in concurrent goroutines. In particular, the number of concurrent HTTP requests being made by automod to PDS instances to download the blobs: we don't want automod to get rate-limited if it is doing dozens of concurrent blob requests to a small/simple PDS due to a single record; or to DDoS that type of PDS instance if it does not have limits on concurrent requests in place.

Note that this patch does *not* add concurrency limits on processing rules for individual blobs. If an automod process had 20 blob rules, and concurrent blob processing of 8x, it might start 160 processing goroutines at the same time. This is expected to be fine because blob rules are usually "per service", and these requests would be going to separate backend services. The best way to constrain concurrency there is to limit the overall number of worker queues.

Note that i'm not using `errgroup.WithContext` (doesn't seem needed), and that i'm doing the old-fashioned `blob := blob` variable re-assignment in the for-loops out of habit, even though loop vars were fixed in Go 1.22.

Mostly requesting review from Rafael, but also tagging Jim for review (if he has time) just for idiomatic Go concurrency patterns.