### PR TITLE
lex/util: fix dropped test error

### DIFF
--- a/lex/util/lex_types_test.go
+++ b/lex/util/lex_types_test.go
@@ -27,6 +27,7 @@ func TestBlobParse(t *testing.T) {
 		}
 	}`
 	cidOne, err := cid.Decode("bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a")
+	assert.NoError(err)
 	goObj := blobSchema{
 		A: "abc",
 		B: LexBlob{


### PR DESCRIPTION
This picks up a dropped test error in `lex/util`.