### PR TITLE
Adds custom logger to `backfill`

### DIFF
--- a/backfill/backfill.go
+++ b/backfill/backfill.go
@@ -202,6 +202,9 @@ func NewBackfiller(
 func (b *Backfiller) StartWithLogger(log *slog.Logger) {
 	ctx := context.Background()
 
+	if log == nil {
+		log = slog.Default()
+	}
 	b.log = log.With("source", "backfiller", "name", b.Name)
 	b.log.Info("starting backfill processor")
 

--- a/backfill/backfill.go
+++ b/backfill/backfill.go
@@ -94,6 +94,8 @@ type Backfiller struct {
 
 	stop chan chan struct{}
 
+	log *slog.Logger
+
 	Directory identity.Directory
 }
 
@@ -200,15 +202,15 @@ func NewBackfiller(
 func (b *Backfiller) StartWithLogger(log *slog.Logger) {
 	ctx := context.Background()
 
-	log = log.With("source", "backfiller", "name", b.Name)
-	log.Info("starting backfill processor")
+	b.log = log.With("source", "backfiller", "name", b.Name)
+	b.log.Info("starting backfill processor")
 
 	sem := semaphore.NewWeighted(int64(b.ParallelBackfills))
 
 	for {
 		select {
 		case stopped := <-b.stop:
-			log.Info("stopping backfill processor")
+			b.log.Info("stopping backfill processor")
 			sem.Acquire(ctx, int64(b.ParallelBackfills))
 			close(stopped)
 			return
@@ -219,7 +221,7 @@ func (b *Backfiller) StartWithLogger(log *slog.Logger) {
 		dequeueStart := time.Now()
 		job, err := b.Store.GetNextEnqueuedJob(ctx)
 		if err != nil {
-			log.Error("failed to get next enqueued job", "error", err)
+			b.log.Error("failed to get next enqueued job", "error", err)
 			time.Sleep(1 * time.Second)
 			continue
 		} else if job == nil {
@@ -228,7 +230,7 @@ func (b *Backfiller) StartWithLogger(log *slog.Logger) {
 		}
 		backfillDispatchSeconds.WithLabelValues(b.Name, "dequeue").Observe(time.Since(dequeueStart).Seconds())
 
-		log := log.With("repo", job.Repo())
+		log := b.log.With("repo", job.Repo())
 
 		// Mark the backfill as "in progress"
 		setStateStart := time.Now()
@@ -272,13 +274,16 @@ func (b *Backfiller) Start() {
 
 // Stop stops the backfill processor
 func (b *Backfiller) Stop(ctx context.Context) error {
-	log := slog.With("source", "backfiller", "name", b.Name)
-	log.Info("stopping backfill processor")
+	if b.log != nil {
+		b.log.Info("stopping backfill processor")
+	}
 	stopped := make(chan struct{})
 	b.stop <- stopped
 	select {
 	case <-stopped:
-		log.Info("backfill processor stopped")
+		if b.log != nil {
+			b.log.Info("backfill processor stopped")
+		}
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/backfill/backfill.go
+++ b/backfill/backfill.go
@@ -196,11 +196,11 @@ func NewBackfiller(
 	}
 }
 
-// Start starts the backfill processor routine
-func (b *Backfiller) Start() {
+// StartWithLogger starts the backfill processor routine with a custom logger
+func (b *Backfiller) StartWithLogger(log *slog.Logger) {
 	ctx := context.Background()
 
-	log := slog.With("source", "backfiller", "name", b.Name)
+	log = log.With("source", "backfiller", "name", b.Name)
 	log.Info("starting backfill processor")
 
 	sem := semaphore.NewWeighted(int64(b.ParallelBackfills))
@@ -263,6 +263,11 @@ func (b *Backfiller) Start() {
 			backfillJobsProcessed.WithLabelValues(b.Name).Inc()
 		}(job)
 	}
+}
+
+// Start starts the backfill processor routine
+func (b *Backfiller) Start() {
+	b.StartWithLogger(slog.Default())
 }
 
 // Stop stops the backfill processor
@@ -351,7 +356,7 @@ type FetchRepoError struct {
 }
 
 func (e *FetchRepoError) Error() string {
-	reason := "unknown error"
+	var reason string
 	if e.StatusCode == http.StatusBadRequest {
 		reason = "repo not found"
 	} else {

--- a/backfill/gormstore.go
+++ b/backfill/gormstore.go
@@ -71,7 +71,7 @@ func (s *Gormstore) loadJobs(ctx context.Context, limit int) error {
 	retryableIndexClause := ""
 
 	// If the DB is a SQLite DB, we can use INDEXED BY to speed up the query
-	if s.db.Dialector.Name() == "sqlite" {
+	if s.db.Name() == "sqlite" {
 		enqueuedIndexClause = "INDEXED BY enqueued_job_idx"
 		retryableIndexClause = "INDEXED BY retryable_job_idx"
 	}


### PR DESCRIPTION
Adds a **non-breaking change** to `backfill` package.

* With `.Start()` it would use the default logger
* This PR adds `StartWithLogger(*slog.Logger)` so the user can use a custom logger
* Now `Start()` just wraps the default logger in a `StartWithLogger` call (so, not breaking the API)

(the two other minor changes are from the linter)