### PR TITLE
adds a CLI flag that toggles SSRF protection

### DIFF
--- a/.github/workflows/container-relay-dockerhub.yaml
+++ b/.github/workflows/container-relay-dockerhub.yaml
@@ -1,0 +1,51 @@
+name: container-relay-dockerhub
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: withtwoemms/indigo
+
+jobs:
+  container-relay-dockerhub:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,enable=true,priority=100,prefix=relay-,suffix=,format=long
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./cmd/relay/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -132,6 +132,11 @@ func run(args []string) error {
 					Sources: cli.EnvVars("RELAY_ALLOW_INSECURE_HOSTS"),
 				},
 				&cli.BoolFlag{
+					Name:    "skip-host-check",
+					Usage:   "skip SSRF protections and account-host validation (for testing with private/Docker networks)",
+					Sources: cli.EnvVars("RELAY_SKIP_HOST_CHECK"),
+				},
+				&cli.BoolFlag{
 					Name:    "lenient-sync-validation",
 					Usage:   "when messages fail atproto 'Sync 1.1' validation, just log, don't drop",
 					Sources: cli.EnvVars("RELAY_LENIENT_SYNC_VALIDATION"),
@@ -257,6 +262,7 @@ func runRelay(ctx context.Context, cmd *cli.Command) error {
 	relayConfig.HostPerDayLimit = cmd.Int64("new-hosts-per-day-limit")
 	relayConfig.TrustedDomains = cmd.StringSlice("trusted-domains")
 	relayConfig.LenientSyncValidation = cmd.Bool("lenient-sync-validation")
+	relayConfig.SkipAccountHostCheck = cmd.Bool("skip-host-check")
 
 	svcConfig := DefaultServiceConfig()
 	svcConfig.AllowInsecureHosts = cmd.Bool("allow-insecure-hosts")

--- a/cmd/relay/relay/host_checker.go
+++ b/cmd/relay/relay/host_checker.go
@@ -43,6 +43,22 @@ func NewHostClient(userAgent string) *HostClient {
 	}
 }
 
+// NewHostClientUnsafe creates a HostClient without SSRF protections,
+// allowing connections to private/Docker network IPs and non-standard ports.
+// Only use for testing environments.
+func NewHostClientUnsafe(userAgent string) *HostClient {
+	if userAgent == "" {
+		userAgent = "indigo-relay (atproto-relay)"
+	}
+	c := http.Client{
+		Timeout: 5 * time.Second,
+	}
+	return &HostClient{
+		Client:    &c,
+		UserAgent: userAgent,
+	}
+}
+
 func (hc *HostClient) apiClient(host string) *atclient.APIClient {
 	client := atclient.APIClient{
 		Client: hc.Client,

--- a/cmd/relay/relay/relay.go
+++ b/cmd/relay/relay/relay.go
@@ -69,7 +69,12 @@ func NewRelay(db *gorm.DB, evtman *eventmgr.EventManager, dir identity.Directory
 
 	uc, _ := lru.New[string, *models.Account](2_000_000)
 
-	hc := NewHostClient(config.UserAgent)
+	var hc *HostClient
+	if config.SkipAccountHostCheck {
+		hc = NewHostClientUnsafe(config.UserAgent)
+	} else {
+		hc = NewHostClient(config.UserAgent)
+	}
 
 	// NOTE: discarded second argument is not an `error` type
 


### PR DESCRIPTION
Expose SkipAccountHostCheck as a CLI flag (`--skip-host-check`) and environment variable (`RELAY_SKIP_HOST_CHECK`) for the relay serve command. When enabled, the relay uses an HTTP client without SSRF protections and skips account-host validation, allowing it to crawl PDS instances on private/Docker networks. This config was already used internally by the relay's test suite but had no external configuration surface.

Also adds a GH Actions workflow to build and push the relay image to Docker Hub.