### PR TITLE
Add lightrail support for multi signal collection backfill

### DIFF
--- a/cmd/tap/README.md
+++ b/cmd/tap/README.md
@@ -50,6 +50,7 @@ Tips:
 - **Set `--no-replay`**: Always connect to the firehose head on restart instead of replaying from a stale cursor. Repos that fell behind will resync when their next firehose event arrives. This flag is incompatible with `--full-network` and is not recommended for production.
 - **Don't use `--full-network`**: Full network mode tracks every repo on the network and takes days to backfill. Instead, add specific DIDs with `/repos/add`.
 - **Use `--disable-acks` until you setup webhooks or event acks**: Use a simple WebSocket client like `websocat` to inspect events.
+- **Use `--light-rail-url` and `--light-rail-signal-collections` to enumerate repos by multiple collections like `--light-rail-url https://lightrail.microcosm.blue --light-rail-signal-collections community.lexicon.calendar.rsvp,community.lexicon.calendar.event`
 
 ## HTTP API
 
@@ -76,6 +77,7 @@ Environment variables or CLI flags:
 - `TAP_BIND`: HTTP server address (default: `:2480`)
 - `TAP_PLC_URL`: PLC directory HTTP/HTTPS URL (default: `https://plc.directory`)
 - `TAP_RELAY_URL`: AT Protocol relay HTTP/HTTPS URL (default: `https://relay1.us-east.bsky.network`)
+- `TAP_LIGHT_RAIL_URL`: Light Rail HTTP/HTTPS URL (default: ``, but `https://lightrail.microcosm.blue` is a instance you can use)
 - `TAP_FIREHOSE_PARALLELISM`: concurrent firehose event processors (default: `10`)
 - `TAP_RESYNC_PARALLELISM`: concurrent resync workers (default: `5`)
 - `TAP_OUTBOX_PARALLELISM`: concurrent outbox workers (default: `1`)
@@ -86,6 +88,7 @@ Environment variables or CLI flags:
 - `TAP_OUTBOX_CAPACITY`: rough size of outbox before back pressure is applied (default: `100000`)
 - `TAP_FULL_NETWORK`: track all repos on the network (default: `false`)
 - `TAP_SIGNAL_COLLECTION`: track all repos with at least one record in this collection (e.g. `app.bsky.actor.profile`)
+- `TAP_LIGHT_RAIL_SIGNAL_COLLECTIONS`: track all repos with at least one record in these collections. Can not be used with `TAP_SIGNAL_COLLECTION` (e.g. `community.lexicon.calendar.rsvp,community.lexicon.calendar.event`)
 - `TAP_COLLECTION_FILTERS`: comma-separated collection filters, wildcards accepted (e.g., `app.bsky.feed.post,app.bsky.graph.*`)
 - `TAP_DISABLE_ACKS`: fire-and-forget mode, no client acks (default: `false`)
 - `TAP_WEBHOOK_URL`: webhook URL for event delivery (disables WebSocket mode)

--- a/cmd/tap/crawler.go
+++ b/cmd/tap/crawler.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
+
+	lexutil "github.com/bluesky-social/indigo/lex/util"
 
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/atproto/atclient"
@@ -19,18 +22,25 @@ type Crawler struct {
 	db     *gorm.DB
 	logger *slog.Logger
 
-	fullNetworkMode  bool
-	relayUrl         string
-	signalCollection string
+	fullNetworkMode            bool
+	relayUrl                   string
+	lightRailUrl               string
+	lightRailMode              bool
+	signalCollection           string
+	lightRailSignalCollections []string
 }
 
 func NewCrawler(logger *slog.Logger, db *gorm.DB, config *TapConfig) *Crawler {
+
 	return &Crawler{
-		logger:           logger.With("component", "crawler"),
-		db:               db,
-		fullNetworkMode:  config.FullNetworkMode,
-		relayUrl:         config.RelayUrl,
-		signalCollection: config.SignalCollection,
+		logger:                     logger.With("component", "crawler"),
+		db:                         db,
+		fullNetworkMode:            config.FullNetworkMode,
+		relayUrl:                   config.RelayUrl,
+		signalCollection:           config.SignalCollection,
+		lightRailMode:              config.LightRailUrl != "",
+		lightRailUrl:               config.LightRailUrl,
+		lightRailSignalCollections: config.LightRailSignalCollections,
 	}
 }
 
@@ -38,7 +48,9 @@ func (c *Crawler) Run(ctx context.Context) {
 	for {
 		var err error
 		if c.signalCollection != "" {
-			err = c.EnumerateNetworkByCollection(ctx, c.signalCollection)
+			err = c.EnumerateNetworkByCollection(ctx)
+		} else if len(c.lightRailSignalCollections) > 0 {
+			err = c.EnumerateNetworkByCollection(ctx)
 		} else if c.fullNetworkMode {
 			err = c.EnumerateNetwork(ctx)
 		}
@@ -150,17 +162,28 @@ func (c *Crawler) getListReposCursor(ctx context.Context) (string, error) {
 }
 
 // EnumerateNetworkByCollection discovers repositories that have records in the specified collection.
-func (c *Crawler) EnumerateNetworkByCollection(ctx context.Context, collection string) error {
+func (c *Crawler) EnumerateNetworkByCollection(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "EnumerateNetworkByCollection")
-	span.SetAttributes(attribute.String("collection", collection))
+	var collectionCursor string
+	if c.lightRailMode {
+		collectionCursor = strings.Join(c.lightRailSignalCollections, ",")
+	} else {
+		collectionCursor = c.signalCollection
+	}
+	span.SetAttributes(attribute.String("collection", collectionCursor))
 	defer span.End()
 
-	cursor, err := c.getCollectionCursor(ctx, collection)
+	cursor, err := c.getCollectionCursor(ctx, collectionCursor)
 	if err != nil {
 		return err
 	}
-
-	client := atclient.NewAPIClient(c.relayUrl)
+	var client *atclient.APIClient
+	if c.lightRailMode {
+		c.logger.Info("using light rail client", "url", c.lightRailUrl)
+		client = atclient.NewAPIClient(c.lightRailUrl)
+	} else {
+		client = atclient.NewAPIClient(c.relayUrl)
+	}
 	client.Headers.Set("User-Agent", userAgent())
 	client.Client = &http.Client{
 		Timeout: 30 * time.Second,
@@ -172,8 +195,12 @@ func (c *Crawler) EnumerateNetworkByCollection(ctx context.Context, collection s
 			return ctx.Err()
 		default:
 		}
-
-		repoList, err := comatproto.SyncListReposByCollection(ctx, client, collection, cursor, 1000)
+		var repoList *comatproto.SyncListReposByCollection_Output
+		if c.lightRailMode {
+			repoList, err = LightRailSyncListReposByCollection(ctx, client, c.lightRailSignalCollections, cursor, 1000)
+		} else {
+			repoList, err = comatproto.SyncListReposByCollection(ctx, client, c.signalCollection, cursor, 1000)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to list repos by collection: %w", err)
 		}
@@ -192,12 +219,12 @@ func (c *Crawler) EnumerateNetworkByCollection(ctx context.Context, collection s
 		}
 
 		if err := c.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(&repos).Error; err != nil {
-			c.logger.Error("failed to save repos batch", "error", err, "collection", collection, "count", len(repos))
+			c.logger.Error("failed to save repos batch", "error", err, "collection", collectionCursor, "count", len(repos))
 			return err
 		}
 
 		crawlerReposDiscovered.Add(float64(len(repos)))
-		c.logger.Info("enumerated repos by collection batch", "collection", collection, "count", len(repos))
+		c.logger.Info("enumerated repos by collection batch", "collection", collectionCursor, "count", len(repos))
 
 		if repoList.Cursor == nil || *repoList.Cursor == "" {
 			break
@@ -206,14 +233,14 @@ func (c *Crawler) EnumerateNetworkByCollection(ctx context.Context, collection s
 
 		if err := c.db.WithContext(ctx).Save(&models.CollectionCursor{
 			Url:        c.relayUrl,
-			Collection: collection,
+			Collection: collectionCursor,
 			Cursor:     cursor,
 		}).Error; err != nil {
 			c.logger.Error("failed to save collection cursor", "error", err)
 		}
 	}
 
-	c.logger.Info("collection enumeration complete", "collection", collection)
+	c.logger.Info("collection enumeration complete", "collection", collectionCursor)
 	return nil
 }
 
@@ -227,4 +254,25 @@ func (c *Crawler) getCollectionCursor(ctx context.Context, collection string) (s
 		return "", nil
 	}
 	return dbCursor.Cursor, nil
+}
+
+// LightRailSyncListReposByCollection calls the XRPC method "com.atproto.sync.listReposByCollection" on a lightrail service that supports multiple collections
+//
+// limit: Maximum size of response set. Recommend setting a large maximum (1000+) when enumerating large DID lists.
+func LightRailSyncListReposByCollection(ctx context.Context, c lexutil.LexClient, collection []string, cursor string, limit int64) (*comatproto.SyncListReposByCollection_Output, error) {
+	var out comatproto.SyncListReposByCollection_Output
+
+	params := map[string]interface{}{}
+	params["collection"] = collection
+	if cursor != "" {
+		params["cursor"] = cursor
+	}
+	if limit != 0 {
+		params["limit"] = limit
+	}
+	if err := c.LexDo(ctx, lexutil.Query, "", "com.atproto.sync.listReposByCollection", params, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
 }

--- a/cmd/tap/crawler.go
+++ b/cmd/tap/crawler.go
@@ -24,18 +24,14 @@ type Crawler struct {
 
 	fullNetworkMode            bool
 	listCollectionService      string
-	lightRailUrl               string
-	lightRailMode              bool
 	signalCollection           string
 	lightRailSignalCollections []string
 }
 
 func NewCrawler(logger *slog.Logger, db *gorm.DB, config *TapConfig) *Crawler {
-	var url string
+	url := config.RelayUrl
 	if config.LightRailUrl != "" {
 		url = config.LightRailUrl
-	} else {
-		url = config.RelayUrl
 	}
 
 	return &Crawler{
@@ -44,7 +40,6 @@ func NewCrawler(logger *slog.Logger, db *gorm.DB, config *TapConfig) *Crawler {
 		fullNetworkMode:            config.FullNetworkMode,
 		listCollectionService:      url,
 		signalCollection:           config.SignalCollection,
-		lightRailMode:              config.LightRailUrl != "",
 		lightRailSignalCollections: config.LightRailSignalCollections,
 	}
 }
@@ -79,6 +74,8 @@ func (c *Crawler) Run(ctx context.Context) {
 func (c *Crawler) GetCursor(ctx context.Context) (string, error) {
 	if c.signalCollection != "" {
 		return c.getCollectionCursor(ctx, c.signalCollection)
+	} else if len(c.lightRailSignalCollections) > 0 {
+		return c.getCollectionCursor(ctx, strings.Join(c.lightRailSignalCollections, ","))
 	} else if c.fullNetworkMode {
 		return c.getListReposCursor(ctx)
 	}
@@ -169,8 +166,9 @@ func (c *Crawler) getListReposCursor(ctx context.Context) (string, error) {
 // EnumerateNetworkByCollection discovers repositories that have records in the specified collection.
 func (c *Crawler) EnumerateNetworkByCollection(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "EnumerateNetworkByCollection")
+	lightRail := len(c.lightRailSignalCollections) > 0
 	var collectionCursor string
-	if c.lightRailMode {
+	if lightRail {
 		collectionCursor = strings.Join(c.lightRailSignalCollections, ",")
 	} else {
 		collectionCursor = c.signalCollection
@@ -196,7 +194,7 @@ func (c *Crawler) EnumerateNetworkByCollection(ctx context.Context) error {
 		default:
 		}
 		var repoList *comatproto.SyncListReposByCollection_Output
-		if c.lightRailMode {
+		if lightRail {
 			repoList, err = LightRailSyncListReposByCollection(ctx, client, c.lightRailSignalCollections, cursor, 1000)
 		} else {
 			repoList, err = comatproto.SyncListReposByCollection(ctx, client, c.signalCollection, cursor, 1000)

--- a/cmd/tap/crawler.go
+++ b/cmd/tap/crawler.go
@@ -23,7 +23,7 @@ type Crawler struct {
 	logger *slog.Logger
 
 	fullNetworkMode            bool
-	relayUrl                   string
+	listCollectionService      string
 	lightRailUrl               string
 	lightRailMode              bool
 	signalCollection           string
@@ -31,15 +31,20 @@ type Crawler struct {
 }
 
 func NewCrawler(logger *slog.Logger, db *gorm.DB, config *TapConfig) *Crawler {
+	var url string
+	if config.LightRailUrl != "" {
+		url = config.LightRailUrl
+	} else {
+		url = config.RelayUrl
+	}
 
 	return &Crawler{
 		logger:                     logger.With("component", "crawler"),
 		db:                         db,
 		fullNetworkMode:            config.FullNetworkMode,
-		relayUrl:                   config.RelayUrl,
+		listCollectionService:      url,
 		signalCollection:           config.SignalCollection,
 		lightRailMode:              config.LightRailUrl != "",
-		lightRailUrl:               config.LightRailUrl,
 		lightRailSignalCollections: config.LightRailSignalCollections,
 	}
 }
@@ -90,7 +95,7 @@ func (c *Crawler) EnumerateNetwork(ctx context.Context) error {
 		return err
 	}
 
-	client := atclient.NewAPIClient(c.relayUrl)
+	client := atclient.NewAPIClient(c.listCollectionService)
 	client.Headers.Set("User-Agent", userAgent())
 	client.Client = &http.Client{
 		Timeout: 30 * time.Second,
@@ -138,7 +143,7 @@ func (c *Crawler) EnumerateNetwork(ctx context.Context) error {
 		cursor = *repoList.Cursor
 
 		if err := c.db.WithContext(ctx).Save(&models.ListReposCursor{
-			Url:    c.relayUrl,
+			Url:    c.listCollectionService,
 			Cursor: cursor,
 		}).Error; err != nil {
 			c.logger.Error("failed to save list repos cursor", "error", err)
@@ -151,7 +156,7 @@ func (c *Crawler) EnumerateNetwork(ctx context.Context) error {
 
 func (c *Crawler) getListReposCursor(ctx context.Context) (string, error) {
 	var dbCursor models.ListReposCursor
-	err := c.db.WithContext(ctx).Where("url = ?", c.relayUrl).First(&dbCursor).Error
+	err := c.db.WithContext(ctx).Where("url = ?", c.listCollectionService).First(&dbCursor).Error
 	if err != nil {
 		if err != gorm.ErrRecordNotFound {
 			return "", fmt.Errorf("failed to read list repos cursor: %w", err)
@@ -177,13 +182,8 @@ func (c *Crawler) EnumerateNetworkByCollection(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	var client *atclient.APIClient
-	if c.lightRailMode {
-		c.logger.Info("using light rail client", "url", c.lightRailUrl)
-		client = atclient.NewAPIClient(c.lightRailUrl)
-	} else {
-		client = atclient.NewAPIClient(c.relayUrl)
-	}
+
+	client := atclient.NewAPIClient(c.listCollectionService)
 	client.Headers.Set("User-Agent", userAgent())
 	client.Client = &http.Client{
 		Timeout: 30 * time.Second,
@@ -232,7 +232,7 @@ func (c *Crawler) EnumerateNetworkByCollection(ctx context.Context) error {
 		cursor = *repoList.Cursor
 
 		if err := c.db.WithContext(ctx).Save(&models.CollectionCursor{
-			Url:        c.relayUrl,
+			Url:        c.listCollectionService,
 			Collection: collectionCursor,
 			Cursor:     cursor,
 		}).Error; err != nil {
@@ -246,7 +246,7 @@ func (c *Crawler) EnumerateNetworkByCollection(ctx context.Context) error {
 
 func (c *Crawler) getCollectionCursor(ctx context.Context, collection string) (string, error) {
 	var dbCursor models.CollectionCursor
-	err := c.db.WithContext(ctx).Where("url = ? AND collection = ?", c.relayUrl, collection).First(&dbCursor).Error
+	err := c.db.WithContext(ctx).Where("url = ? AND collection = ?", c.listCollectionService, collection).First(&dbCursor).Error
 	if err != nil {
 		if err != gorm.ErrRecordNotFound {
 			return "", fmt.Errorf("failed to read collection cursor: %w", err)

--- a/cmd/tap/firehose.go
+++ b/cmd/tap/firehose.go
@@ -31,7 +31,9 @@ type FirehoseProcessor struct {
 	repos  *RepoManager
 
 	relayUrl           string
+	lightRailUrl       string
 	fullNetworkMode    bool
+	lightRailMode      bool
 	signalCollection   string
 	collectionFilters  []string
 	parallelism        int
@@ -48,7 +50,9 @@ func NewFirehoseProcessor(logger *slog.Logger, db *gorm.DB, events *EventManager
 		events:             events,
 		repos:              repos,
 		relayUrl:           config.RelayUrl,
+		lightRailUrl:       config.LightRailUrl,
 		fullNetworkMode:    config.FullNetworkMode,
+		lightRailMode:      config.LightRailUrl != "",
 		signalCollection:   config.SignalCollection,
 		collectionFilters:  config.CollectionFilters,
 		parallelism:        config.FirehoseParallelism,

--- a/cmd/tap/firehose.go
+++ b/cmd/tap/firehose.go
@@ -31,9 +31,7 @@ type FirehoseProcessor struct {
 	repos  *RepoManager
 
 	relayUrl                   string
-	lightRailUrl               string
 	fullNetworkMode            bool
-	lightRailMode              bool
 	signalCollection           string
 	lightRailSignalCollections []string
 	collectionFilters          []string
@@ -51,9 +49,7 @@ func NewFirehoseProcessor(logger *slog.Logger, db *gorm.DB, events *EventManager
 		events:                     events,
 		repos:                      repos,
 		relayUrl:                   config.RelayUrl,
-		lightRailUrl:               config.LightRailUrl,
 		fullNetworkMode:            config.FullNetworkMode,
-		lightRailMode:              config.LightRailUrl != "",
 		signalCollection:           config.SignalCollection,
 		lightRailSignalCollections: config.LightRailSignalCollections,
 		collectionFilters:          config.CollectionFilters,
@@ -88,7 +84,7 @@ func (fp *FirehoseProcessor) ProcessCommit(ctx context.Context, evt *comatproto.
 	if err != nil {
 		return err
 	} else if curr == nil {
-		shouldTrack := fp.fullNetworkMode || (fp.signalCollection != "" && evtHasSignalCollection(evt, fp.signalCollection)) || (fp.lightRailMode && evtHasLightRailSignalCollection(evt, fp.lightRailSignalCollections))
+		shouldTrack := fp.fullNetworkMode || (fp.signalCollection != "" && evtHasSignalCollection(evt, fp.signalCollection)) || (len(fp.lightRailSignalCollections) > 0 && evtHasLightRailSignalCollection(evt, fp.lightRailSignalCollections))
 		if shouldTrack {
 			if err := fp.repos.EnsureRepo(ctx, evt.Repo); err != nil {
 				fp.logger.Error("failed to auto-track repo", "did", evt.Repo, "error", err)

--- a/cmd/tap/firehose.go
+++ b/cmd/tap/firehose.go
@@ -30,34 +30,36 @@ type FirehoseProcessor struct {
 	events *EventManager
 	repos  *RepoManager
 
-	relayUrl           string
-	lightRailUrl       string
-	fullNetworkMode    bool
-	lightRailMode      bool
-	signalCollection   string
-	collectionFilters  []string
-	parallelism        int
-	cursorSaveInterval time.Duration
-	noReplay           bool
+	relayUrl                   string
+	lightRailUrl               string
+	fullNetworkMode            bool
+	lightRailMode              bool
+	signalCollection           string
+	lightRailSignalCollections []string
+	collectionFilters          []string
+	parallelism                int
+	cursorSaveInterval         time.Duration
+	noReplay                   bool
 
 	lastSeq atomic.Int64
 }
 
 func NewFirehoseProcessor(logger *slog.Logger, db *gorm.DB, events *EventManager, repos *RepoManager, config *TapConfig) *FirehoseProcessor {
 	return &FirehoseProcessor{
-		logger:             logger.With("component", "firehose"),
-		db:                 db,
-		events:             events,
-		repos:              repos,
-		relayUrl:           config.RelayUrl,
-		lightRailUrl:       config.LightRailUrl,
-		fullNetworkMode:    config.FullNetworkMode,
-		lightRailMode:      config.LightRailUrl != "",
-		signalCollection:   config.SignalCollection,
-		collectionFilters:  config.CollectionFilters,
-		parallelism:        config.FirehoseParallelism,
-		cursorSaveInterval: config.FirehoseCursorSaveInterval,
-		noReplay:           config.NoReplay,
+		logger:                     logger.With("component", "firehose"),
+		db:                         db,
+		events:                     events,
+		repos:                      repos,
+		relayUrl:                   config.RelayUrl,
+		lightRailUrl:               config.LightRailUrl,
+		fullNetworkMode:            config.FullNetworkMode,
+		lightRailMode:              config.LightRailUrl != "",
+		signalCollection:           config.SignalCollection,
+		lightRailSignalCollections: config.LightRailSignalCollections,
+		collectionFilters:          config.CollectionFilters,
+		parallelism:                config.FirehoseParallelism,
+		cursorSaveInterval:         config.FirehoseCursorSaveInterval,
+		noReplay:                   config.NoReplay,
 	}
 }
 
@@ -86,7 +88,7 @@ func (fp *FirehoseProcessor) ProcessCommit(ctx context.Context, evt *comatproto.
 	if err != nil {
 		return err
 	} else if curr == nil {
-		shouldTrack := fp.fullNetworkMode || (fp.signalCollection != "" && evtHasSignalCollection(evt, fp.signalCollection))
+		shouldTrack := fp.fullNetworkMode || (fp.signalCollection != "" && evtHasSignalCollection(evt, fp.signalCollection)) || (fp.lightRailMode && evtHasLightRailSignalCollection(evt, fp.lightRailSignalCollections))
 		if shouldTrack {
 			if err := fp.repos.EnsureRepo(ctx, evt.Repo); err != nil {
 				fp.logger.Error("failed to auto-track repo", "did", evt.Repo, "error", err)

--- a/cmd/tap/main.go
+++ b/cmd/tap/main.go
@@ -76,6 +76,17 @@ func run(args []string) error {
 						Value:   "https://relay1.us-east.bsky.network",
 						Sources: cli.EnvVars("TAP_RELAY_URL"),
 					},
+					&cli.StringFlag{
+						Name:    "light-rail-url",
+						Usage:   "Microcosm Lightrail HTTP/HTTPS url",
+						Value:   "",
+						Sources: cli.EnvVars("TAP_LIGHT_RAIL_URL"),
+					},
+					&cli.StringFlag{
+						Name:    "jetstream-url",
+						Usage:   "JetStream HTTP/HTTPS url",
+						Sources: cli.EnvVars("TAP_JETSTREAM_URL"),
+					},
 					&cli.IntFlag{
 						Name:    "firehose-parallelism",
 						Usage:   "number of parallel firehose event processors",
@@ -132,6 +143,11 @@ func run(args []string) error {
 						Name:    "signal-collection",
 						Usage:   "enumerate repos by collection (exact NSID)",
 						Sources: cli.EnvVars("TAP_SIGNAL_COLLECTION"),
+					},
+					&cli.StringSliceFlag{
+						Name:    "light-rail-signal-collections",
+						Usage:   "enumerate repos by collections (exact NSIDs)",
+						Sources: cli.EnvVars("TAP_LIGHT_RAIL_SIGNAL_COLLECTIONS"),
 					},
 					&cli.BoolFlag{
 						Name:    "disable-acks",
@@ -194,6 +210,12 @@ func runTap(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("relay-url must start with http:// or https://")
 	}
 
+	// fail early if lightrail url is not http/https
+	lightRailUrl := cmd.String("light-rail-url")
+	if lightRailUrl != "" && !strings.HasPrefix(lightRailUrl, "http://") && !strings.HasPrefix(lightRailUrl, "https://") {
+		return fmt.Errorf("lightrail-url must start with http:// or https://")
+	}
+
 	// fail early if plc url is not http/https
 	plcUrl := cmd.String("plc-url")
 	if !strings.HasPrefix(plcUrl, "http://") && !strings.HasPrefix(plcUrl, "https://") {
@@ -203,12 +225,14 @@ func runTap(ctx context.Context, cmd *cli.Command) error {
 	if cmd.Bool("no-replay") && cmd.Bool("full-network") {
 		return fmt.Errorf("--no-replay cannot be used with --full-network")
 	}
-
+	test := cmd.StringSlice("light-rail-signal-collections")
+	fmt.Printf("light-rail-signal-collections: %v\n", test)
 	config := TapConfig{
 		DatabaseURL:                cmd.String("db-url"),
 		DBMaxConns:                 int(cmd.Int("max-db-conn")),
 		PLCURL:                     plcUrl,
 		RelayUrl:                   relayUrl,
+		LightRailUrl:               lightRailUrl,
 		FirehoseParallelism:        int(cmd.Int("firehose-parallelism")),
 		ResyncParallelism:          int(cmd.Int("resync-parallelism")),
 		OutboxParallelism:          int(cmd.Int("outbox-parallelism")),
@@ -219,6 +243,7 @@ func runTap(ctx context.Context, cmd *cli.Command) error {
 		EventCacheSize:             int(cmd.Int("outbox-capacity")),
 		FullNetworkMode:            cmd.Bool("full-network"),
 		SignalCollection:           cmd.String("signal-collection"),
+		LightRailSignalCollections: cmd.StringSlice("light-rail-signal-collections"),
 		DisableAcks:                cmd.Bool("disable-acks"),
 		WebhookURL:                 cmd.String("webhook-url"),
 		CollectionFilters:          cmd.StringSlice("collection-filters"),

--- a/cmd/tap/main.go
+++ b/cmd/tap/main.go
@@ -225,8 +225,7 @@ func runTap(ctx context.Context, cmd *cli.Command) error {
 	if cmd.Bool("no-replay") && cmd.Bool("full-network") {
 		return fmt.Errorf("--no-replay cannot be used with --full-network")
 	}
-	test := cmd.StringSlice("light-rail-signal-collections")
-	fmt.Printf("light-rail-signal-collections: %v\n", test)
+
 	config := TapConfig{
 		DatabaseURL:                cmd.String("db-url"),
 		DBMaxConns:                 int(cmd.Int("max-db-conn")),

--- a/cmd/tap/main.go
+++ b/cmd/tap/main.go
@@ -82,11 +82,6 @@ func run(args []string) error {
 						Value:   "",
 						Sources: cli.EnvVars("TAP_LIGHT_RAIL_URL"),
 					},
-					&cli.StringFlag{
-						Name:    "jetstream-url",
-						Usage:   "JetStream HTTP/HTTPS url",
-						Sources: cli.EnvVars("TAP_JETSTREAM_URL"),
-					},
 					&cli.IntFlag{
 						Name:    "firehose-parallelism",
 						Usage:   "number of parallel firehose event processors",
@@ -226,6 +221,17 @@ func runTap(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("--no-replay cannot be used with --full-network")
 	}
 
+	// light-rail enumeration requires both the URL and the collections
+	lightRailCollections := cmd.StringSlice("light-rail-signal-collections")
+	if (lightRailUrl != "") != (len(lightRailCollections) > 0) {
+		return fmt.Errorf("--light-rail-url and --light-rail-signal-collections must be set together")
+	}
+	// light-rail is its own enumeration mode and cannot be combined with the
+	// relay-based --signal-collection / --full-network modes.
+	if lightRailUrl != "" && (cmd.String("signal-collection") != "" || cmd.Bool("full-network")) {
+		return fmt.Errorf("--light-rail-url cannot be used with --signal-collection or --full-network")
+	}
+
 	config := TapConfig{
 		DatabaseURL:                cmd.String("db-url"),
 		DBMaxConns:                 int(cmd.Int("max-db-conn")),
@@ -242,7 +248,7 @@ func runTap(ctx context.Context, cmd *cli.Command) error {
 		EventCacheSize:             int(cmd.Int("outbox-capacity")),
 		FullNetworkMode:            cmd.Bool("full-network"),
 		SignalCollection:           cmd.String("signal-collection"),
-		LightRailSignalCollections: cmd.StringSlice("light-rail-signal-collections"),
+		LightRailSignalCollections: lightRailCollections,
 		DisableAcks:                cmd.Bool("disable-acks"),
 		WebhookURL:                 cmd.String("webhook-url"),
 		CollectionFilters:          cmd.StringSlice("collection-filters"),

--- a/cmd/tap/tap.go
+++ b/cmd/tap/tap.go
@@ -36,6 +36,7 @@ type TapConfig struct {
 	DBMaxConns                 int
 	PLCURL                     string
 	RelayUrl                   string
+	LightRailUrl               string
 	FirehoseParallelism        int
 	ResyncParallelism          int
 	OutboxParallelism          int
@@ -46,6 +47,7 @@ type TapConfig struct {
 	EventCacheSize             int
 	FullNetworkMode            bool
 	SignalCollection           string
+	LightRailSignalCollections []string
 	DisableAcks                bool
 	WebhookURL                 string
 	CollectionFilters          []string // e.g., ["app.bsky.feed.post", "app.bsky.graph.*"]

--- a/cmd/tap/util.go
+++ b/cmd/tap/util.go
@@ -64,6 +64,15 @@ func evtHasSignalCollection(evt *comatproto.SyncSubscribeRepos_Commit, signalCol
 	return false
 }
 
+func evtHasLightRailSignalCollection(evt *comatproto.SyncSubscribeRepos_Commit, signalColl []string) bool {
+	for _, coll := range signalColl {
+		if evtHasSignalCollection(evt, coll) {
+			return true
+		}
+	}
+	return false
+}
+
 func isRateLimitError(err error) bool {
 	var xrpcErr *atclient.APIError
 	if errors.As(err, &xrpcErr) {


### PR DESCRIPTION
This pr adds support for using [lightrail](https://lightrail.microcosm.blue) for repo emulation when backing filling since it supports multiple collections. `community.lexicon.calendar.*` is probably the best example. Not everyone will have `rsvp` or `events` so this lets you backfill both easily. 

You can use `lightrail mode` by setting a url and a comma separated signal collection. It is it's own url instead of via the relay since it's mostly standalone atm and not a side card to the relay like the current `listReposByCollection` service.
 