### PR TITLE
gitignore: re-add palomar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ test-coverage.out
 /gosky
 /hepa
 /lexgen
+/palomar
 /rainbow
 /relay
 /sonar


### PR DESCRIPTION
Removing this from the gitignore resulted in accidentally committing the old palomar binary. Adding this back to the gitignore will ensure no future commits include it.