### PR TITLE
add support for prompt=create oauth flow

### DIFF
--- a/atproto/auth/oauth/oauth.go
+++ b/atproto/auth/oauth/oauth.go
@@ -353,6 +353,7 @@ func (app *ClientApp) SendAuthRequest(ctx context.Context, authMeta *AuthServerM
 		ResponseType:        "code",
 		CodeChallenge:       codeChallenge,
 		CodeChallengeMethod: "S256",
+		Prompt:              authOpts.prompt,
 	}
 
 	if app.Config.IsConfidential() {
@@ -578,7 +579,7 @@ func (app *ClientApp) StartAuthFlow(ctx context.Context, identifier string, opts
 		return "", fmt.Errorf("fetching auth server metadata: %w", err)
 	}
 
-	info, err := app.SendAuthRequest(ctx, authserverMeta, app.Config.Scopes, identifier)
+	info, err := app.SendAuthRequest(ctx, authserverMeta, app.Config.Scopes, identifier, opts...)
 	if err != nil {
 		return "", fmt.Errorf("auth request failed: %w", err)
 	}

--- a/atproto/auth/oauth/oauth.go
+++ b/atproto/auth/oauth/oauth.go
@@ -317,9 +317,26 @@ func parseAuthErrorReason(resp *http.Response, reqType string) string {
 	return fmt.Sprintf("%s", errResp["error"])
 }
 
-// Low-level helper to send PAR request to auth server, which involves starting PKCE and DPoP.
-func (app *ClientApp) SendAuthRequest(ctx context.Context, authMeta *AuthServerMetadata, scopes []string, loginHint string) (*AuthRequestData, error) {
+type authOptions struct {
+	prompt *string
+}
 
+// AuthOption is a functional option for configuring additional parameters on the auth request.
+type AuthOption func(*authOptions)
+
+// WithPrompt provides a hint to the auth server of what expected auth behavior should be. Eg, 'create', 'none', 'consent', 'login', 'select_account'
+func WithPrompt(prompt string) AuthOption {
+	return func(opts *authOptions) {
+		opts.prompt = &prompt
+	}
+}
+
+// SendAuthRequest is a low-level helper to send PAR request to auth server, which involves starting PKCE and DPoP.
+func (app *ClientApp) SendAuthRequest(ctx context.Context, authMeta *AuthServerMetadata, scopes []string, loginHint string, opts ...AuthOption) (*AuthRequestData, error) {
+	authOpts := &authOptions{}
+	for _, opt := range opts {
+		opt(authOpts)
+	}
 	parURL := authMeta.PushedAuthorizationRequestEndpoint
 	state := secureRandomBase64(16)
 	pkceVerifier := secureRandomBase64(48)
@@ -520,13 +537,12 @@ func (app *ClientApp) SendInitialTokenRequest(ctx context.Context, authCode stri
 	return &tokenResp, nil
 }
 
-// High-level helper for starting a new session. Resolves identifier to resource server and auth server metadata, sends PAR request, persists request info to store, and returns a redirect URL.
+// StartAuthFlow is a high-level helper for starting a new session. Resolves identifier to resource server and auth server metadata, sends PAR request, persists request info to store, and returns a redirect URL.
 //
 // The `identifier` argument can be an atproto account identifier (handle or DID), or can be a URL to the account's auth server.
 //
-// The returned sting will be a web URL that the user should be redirected to (in browser) to approve the auth flow.
-func (app *ClientApp) StartAuthFlow(ctx context.Context, identifier string) (string, error) {
-
+// The returned string will be a web URL that the user should be redirected to (in browser) to approve the auth flow.
+func (app *ClientApp) StartAuthFlow(ctx context.Context, identifier string, opts ...AuthOption) (string, error) {
 	var authserverURL string
 	var accountDID syntax.DID
 


### PR DESCRIPTION
fixes #1403 

indigo users currently have no away to leverage pds support sending prompt=create with authorization flows. This is a supported workflow for bluesky and other pds' which initiates a and oauth based account creation flow which looks something like this

<img width="1301" height="813" alt="Screenshot 2026-06-14 at 10 49 44 PM" src="https://github.com/user-attachments/assets/a9aed762-d46f-4226-9883-41d0639e2b43" />

This pull adds that support in a way that avoids breaking current apis and introduces a way to add future optional parameterization of other auth-related configuration

example code I used to generate an auth flow url above

```go
authURL, err := clientApp.StartAuthFlow(ctx, "https://bsky.social", oauth.WithPrompt("create"))
```

see also https://github.com/bluesky-social/atproto/pull/4461 and https://github.com/bluesky-social/atproto/discussions/4587


Note, I would have liked to add tests for these changes but no tests exited for the oauth.go and it wasn't clear to me the direction maintainers would like to take testing for code that calls external servers, [httptest.NewServer](https://pkg.go.dev/net/http/httptest#NewServer) ect. I would be open to creating tests for oauth.go given direction maintainers would like to see. 

Note I had to recreate this from https://github.com/bluesky-social/indigo/pull/1408 because my fork got out of sync for reasons I still don't understand