### PR TITLE
Add relay account limit Slack alerts

### DIFF
--- a/cmd/relay/README.md
+++ b/cmd/relay/README.md
@@ -116,6 +116,15 @@ Be sure to double-check bandwidth usage and pricing if running a public relay! B
 
 The relay admin interface has flexibility for many situations, but in some operational incidents it may be necessary to run SQL commands to do cleanups. This should be done when the relay is not actively operating. It is also recommended to run SQL commands in a transaction that can be rolled back in case of a typo or mistake.
 
+Account-limit alerts can be silenced for individual PDS hosts through the admin API. This state is persisted on the host row and forwarded to sibling relays:
+
+    curl -u admin:$RELAY_ADMIN_PASSWORD \
+      -H 'Content-Type: application/json' \
+      -d '{"host":"pds.example.com","account_limit_alerts_silenced":true}' \
+      http://localhost:2470/admin/pds/changeLimits
+
+Set `account_limit_alerts_silenced` to `false` to resume alerting.
+
 On the public web, you should probably run the relay behind a load-balancer or reverse proxy like `haproxy` or `caddy`, which manages TLS and can have various HTTP limits and behaviors configured. Remember that WebSocket support is required.
 
 The relay does not resolve atproto handles, but it does do DNS resolutions for hostnames, and may do a burst of resolutions at startup. Note that the go runtime may have an internal DNS implementation enabled (this is the default for the Dockerfile). The relay *will* do a large number of DID resolutions, particularly calls to the PLC directory, and particularly after a process restart when the in-process identity cache is warming up.

--- a/cmd/relay/README.md
+++ b/cmd/relay/README.md
@@ -104,7 +104,7 @@ Some notable configuration env vars:
 - `RELAY_LENIENT_SYNC_VALIDATION`: if `true`, allow legacy upstreams which don't implement atproto sync v1.1
 - `RELAY_TRUSTED_DOMAINS`: patterns of PDS hosts which get larger quotas by default, eg `*.host.bsky.network`
 - `RELAY_ACCOUNT_LIMIT_ALERT_THRESHOLD`: fraction of a PDS repo limit that triggers an alert; default is `0.80`
-- `RELAY_ACCOUNT_LIMIT_ALERT_INTERVAL`: how often to check for PDS hosts approaching their repo limits; default is `5m`
+- `RELAY_ACCOUNT_LIMIT_ALERT_INTERVAL`: how often to check for PDS hosts approaching their repo limits, with up to one minute of jitter in either direction; default is `5m`
 - `RELAY_ACCOUNT_LIMIT_ALERT_REPEAT_INTERVAL`: minimum interval between repeat alerts for a host that remains over threshold; default is `6h`
 - `RELAY_SLACK_ALERT_CHANNEL`: Slack channel ID or name for PDS repo-limit alerts
 - `RELAY_SLACK_ALERT_TOKEN`: Slack bot token with permission to post repo-limit alerts; prefer env configuration over CLI args for secrets

--- a/cmd/relay/README.md
+++ b/cmd/relay/README.md
@@ -106,6 +106,7 @@ Some notable configuration env vars:
 - `RELAY_ACCOUNT_LIMIT_ALERT_THRESHOLD`: fraction of a PDS repo limit that triggers an alert; default is `0.80`
 - `RELAY_ACCOUNT_LIMIT_ALERT_INTERVAL`: how often to check for PDS hosts approaching their repo limits, with up to one minute of jitter in either direction; default is `5m`
 - `RELAY_ACCOUNT_LIMIT_ALERT_REPEAT_INTERVAL`: minimum interval between repeat alerts for a host that remains over threshold; default is `6h`
+- `RELAY_ACCOUNT_LIMIT_ALERT_DASHBOARD_URL`: optional absolute URL to include as a relay dashboard button in account-limit alerts
 - `RELAY_SLACK_ALERT_CHANNEL`: Slack channel ID or name for PDS repo-limit alerts
 - `RELAY_SLACK_ALERT_TOKEN`: Slack bot token with permission to post repo-limit alerts; prefer env configuration over CLI args for secrets
 

--- a/cmd/relay/README.md
+++ b/cmd/relay/README.md
@@ -103,6 +103,11 @@ Some notable configuration env vars:
 - `RELAY_REPLAY_WINDOW`: the duration of output "backfill window", eg `24h`
 - `RELAY_LENIENT_SYNC_VALIDATION`: if `true`, allow legacy upstreams which don't implement atproto sync v1.1
 - `RELAY_TRUSTED_DOMAINS`: patterns of PDS hosts which get larger quotas by default, eg `*.host.bsky.network`
+- `RELAY_ACCOUNT_LIMIT_ALERT_THRESHOLD`: fraction of a PDS repo limit that triggers an alert; default is `0.80`
+- `RELAY_ACCOUNT_LIMIT_ALERT_INTERVAL`: how often to check for PDS hosts approaching their repo limits; default is `5m`
+- `RELAY_ACCOUNT_LIMIT_ALERT_REPEAT_INTERVAL`: minimum interval between repeat alerts for a host that remains over threshold; default is `6h`
+- `RELAY_SLACK_ALERT_CHANNEL`: Slack channel ID or name for PDS repo-limit alerts
+- `RELAY_SLACK_ALERT_TOKEN`: Slack bot token with permission to post repo-limit alerts; prefer env configuration over CLI args for secrets
 
 There is a health check endpoint at `/xrpc/_health`. Prometheus metrics are exposed by default on port 2471, path `/metrics`. The service logs fairly verbosely to stdout; use `LOG_LEVEL` to control log volume (`warn`, `info`, etc).
 

--- a/cmd/relay/alerts.go
+++ b/cmd/relay/alerts.go
@@ -11,10 +11,10 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/bluesky-social/indigo/cmd/relay/relay"
+	"github.com/bluesky-social/indigo/cmd/relay/relay/models"
 	"github.com/bluesky-social/indigo/util/cliutil"
 
 	"github.com/labstack/echo/v4"
@@ -58,8 +58,9 @@ type Alerter interface {
 	SendAlert(ctx context.Context, msg AlertMessage) error
 }
 
-type accountLimitUsageLister interface {
-	ListHostsApproachingAccountLimit(ctx context.Context, threshold float64, limit int) ([]relay.HostAccountLimitUsage, error)
+type accountLimitAlertClaimer interface {
+	ClaimDueAccountLimitAlerts(ctx context.Context, threshold float64, repeatInterval time.Duration, limit int) (*relay.HostAccountLimitAlertClaims, error)
+	RecordHostAccountLimitAlertSent(ctx context.Context, hostname string, state models.HostAccountLimitAlertState, sentAt time.Time) error
 }
 
 type AccountLimitAlertSentState struct {
@@ -161,19 +162,16 @@ func (c AccountLimitAlertMonitorConfig) Validate() error {
 
 type AccountLimitAlertMonitor struct {
 	logger  *slog.Logger
-	lister  accountLimitUsageLister
+	claimer accountLimitAlertClaimer
 	alerter Alerter
 	config  AccountLimitAlertMonitorConfig
 
-	lk             sync.Mutex
-	now            func() time.Time
-	lastAlert      map[uint64]time.Time
-	aboveThreshold map[uint64]relay.HostAccountLimitUsage
+	now func() time.Time
 }
 
-func NewAccountLimitAlertMonitor(logger *slog.Logger, lister accountLimitUsageLister, alerter Alerter, config AccountLimitAlertMonitorConfig) (*AccountLimitAlertMonitor, error) {
-	if lister == nil {
-		return nil, fmt.Errorf("account limit alert lister is required")
+func NewAccountLimitAlertMonitor(logger *slog.Logger, claimer accountLimitAlertClaimer, alerter Alerter, config AccountLimitAlertMonitorConfig) (*AccountLimitAlertMonitor, error) {
+	if claimer == nil {
+		return nil, fmt.Errorf("account limit alert claimer is required")
 	}
 	if alerter == nil {
 		return nil, fmt.Errorf("account limit alerter is required")
@@ -185,13 +183,11 @@ func NewAccountLimitAlertMonitor(logger *slog.Logger, lister accountLimitUsageLi
 		return nil, err
 	}
 	return &AccountLimitAlertMonitor{
-		logger:         logger.With("system", "account-limit-alerts"),
-		lister:         lister,
-		alerter:        alerter,
-		config:         config,
-		now:            time.Now,
-		lastAlert:      make(map[uint64]time.Time),
-		aboveThreshold: make(map[uint64]relay.HostAccountLimitUsage),
+		logger:  logger.With("system", "account-limit-alerts"),
+		claimer: claimer,
+		alerter: alerter,
+		config:  config,
+		now:     time.Now,
 	}, nil
 }
 
@@ -249,103 +245,38 @@ func jitteredCheckInterval(interval, jitter time.Duration, randInt63n func(int64
 }
 
 func (m *AccountLimitAlertMonitor) Check(ctx context.Context) error {
-	usages, err := m.lister.ListHostsApproachingAccountLimit(ctx, m.config.Threshold, 0)
+	claims, err := m.claimer.ClaimDueAccountLimitAlerts(ctx, m.config.Threshold, m.config.RepeatInterval, 0)
 	if err != nil {
 		return err
 	}
 
-	now := m.now()
-	m.lk.Lock()
-	currentAbove := make(map[uint64]relay.HostAccountLimitUsage, len(usages))
-	due := make([]relay.HostAccountLimitUsage, 0, len(usages))
-	for _, usage := range usages {
-		currentAbove[usage.ID] = usage
-		last, alertedBefore := m.lastAlert[usage.ID]
-		_, wasAbove := m.aboveThreshold[usage.ID]
-		repeatDue := !alertedBefore || now.Sub(last) >= m.config.RepeatInterval
-		if !wasAbove || repeatDue {
-			due = append(due, usage)
-		}
-	}
-
-	recovered := make([]relay.HostAccountLimitUsage, 0)
-	for id := range m.aboveThreshold {
-		if _, ok := currentAbove[id]; !ok {
-			recovered = append(recovered, m.aboveThreshold[id])
-		}
-	}
-
-	for id, usage := range currentAbove {
-		m.aboveThreshold[id] = usage
-	}
-	m.lk.Unlock()
-
-	for _, usage := range recovered {
+	for _, usage := range claims.Recoveries {
 		if err := m.alerter.SendAlert(ctx, formatAccountLimitRecoveryAlert(m.config, usage)); err != nil {
 			return err
 		}
-		if err := m.recordAccountLimitAlertSent(ctx, accountLimitAlertSentState(AccountLimitAlertKindRecovery, usage, now), true); err != nil {
-			return err
-		}
+		m.forwardAccountLimitAlertSent(ctx, accountLimitAlertSentState(AccountLimitAlertKindRecovery, usage, usage.AlertSentAt))
 	}
 
-	for start := 0; start < len(due); start += m.config.HostsPerMessage {
+	for start := 0; start < len(claims.Warnings); start += m.config.HostsPerMessage {
 		end := start + m.config.HostsPerMessage
-		if end > len(due) {
-			end = len(due)
+		if end > len(claims.Warnings) {
+			end = len(claims.Warnings)
 		}
-		batch := due[start:end]
+		batch := claims.Warnings[start:end]
 		if err := m.alerter.SendAlert(ctx, formatAccountLimitAlert(m.config, batch)); err != nil {
 			return err
 		}
 		for _, usage := range batch {
-			if err := m.recordAccountLimitAlertSent(ctx, accountLimitAlertSentState(AccountLimitAlertKindWarning, usage, now), true); err != nil {
-				return err
-			}
+			m.forwardAccountLimitAlertSent(ctx, accountLimitAlertSentState(AccountLimitAlertKindWarning, usage, usage.AlertSentAt))
 		}
 	}
 	return nil
 }
 
-func (m *AccountLimitAlertMonitor) RecordAccountLimitAlertSent(state AccountLimitAlertSentState) error {
-	return m.recordAccountLimitAlertSent(context.Background(), state, false)
-}
-
-func (m *AccountLimitAlertMonitor) recordAccountLimitAlertSent(ctx context.Context, state AccountLimitAlertSentState, notifySiblings bool) error {
-	now := m.now()
-	if err := state.normalize(now); err != nil {
-		return err
-	}
-
-	usage := relay.HostAccountLimitUsage{
-		ID:           state.HostID,
-		Hostname:     state.Hostname,
-		AccountCount: state.AccountCount,
-		AccountLimit: state.AccountLimit,
-		Usage:        state.Usage,
-	}
-
-	m.lk.Lock()
-	switch state.Kind {
-	case AccountLimitAlertKindWarning:
-		if last, ok := m.lastAlert[state.HostID]; !ok || state.SentAt.After(last) {
-			m.lastAlert[state.HostID] = state.SentAt
-		}
-		m.aboveThreshold[state.HostID] = usage
-	case AccountLimitAlertKindRecovery:
-		if last, ok := m.lastAlert[state.HostID]; ok && last.After(state.SentAt) {
-			m.lk.Unlock()
-			return nil
-		}
-		delete(m.lastAlert, state.HostID)
-		delete(m.aboveThreshold, state.HostID)
-	}
-	m.lk.Unlock()
-
-	if notifySiblings && m.config.SentCallback != nil {
+func (m *AccountLimitAlertMonitor) forwardAccountLimitAlertSent(ctx context.Context, state AccountLimitAlertSentState) {
+	if m.config.SentCallback != nil {
 		m.config.SentCallback(ctx, state)
 	}
-	return nil
 }
 
 func (s *Service) handleAdminRecordAccountLimitAlertSent(c echo.Context) error {
@@ -353,10 +284,14 @@ func (s *Service) handleAdminRecordAccountLimitAlertSent(c echo.Context) error {
 	if err := c.Bind(&body); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid body: %s", err))
 	}
-	if s.accountLimitAlertRecorder == nil {
-		return c.JSON(http.StatusOK, map[string]any{"success": "true"})
+	if err := body.normalize(time.Now().UTC()); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
-	if err := s.accountLimitAlertRecorder.RecordAccountLimitAlertSent(body); err != nil {
+	state := models.HostAccountLimitAlertStateWarning
+	if body.Kind == AccountLimitAlertKindRecovery {
+		state = models.HostAccountLimitAlertStateOK
+	}
+	if err := s.relay.RecordHostAccountLimitAlertSent(c.Request().Context(), body.Hostname, state, body.SentAt); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 	return c.JSON(http.StatusOK, map[string]any{"success": "true"})

--- a/cmd/relay/alerts.go
+++ b/cmd/relay/alerts.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/bluesky-social/indigo/cmd/relay/relay"
+	"github.com/bluesky-social/indigo/util/cliutil"
+)
+
+const accountLimitAlertHostsPerMessage = 50
+
+type AlertMessage struct {
+	Text string
+}
+
+type Alerter interface {
+	SendAlert(ctx context.Context, msg AlertMessage) error
+}
+
+type accountLimitUsageLister interface {
+	ListHostsApproachingAccountLimit(ctx context.Context, threshold float64, limit int) ([]relay.HostAccountLimitUsage, error)
+}
+
+type AccountLimitAlertMonitorConfig struct {
+	Threshold       float64
+	CheckInterval   time.Duration
+	RepeatInterval  time.Duration
+	Environment     string
+	HostsPerMessage int
+}
+
+func DefaultAccountLimitAlertMonitorConfig() AccountLimitAlertMonitorConfig {
+	return AccountLimitAlertMonitorConfig{
+		Threshold:       0.80,
+		CheckInterval:   5 * time.Minute,
+		RepeatInterval:  6 * time.Hour,
+		HostsPerMessage: accountLimitAlertHostsPerMessage,
+	}
+}
+
+func (c AccountLimitAlertMonitorConfig) Validate() error {
+	if c.Threshold <= 0 || c.Threshold > 1 {
+		return fmt.Errorf("account limit alert threshold must be greater than 0 and less than or equal to 1")
+	}
+	if c.CheckInterval <= 0 {
+		return fmt.Errorf("account limit alert interval must be positive")
+	}
+	if c.RepeatInterval <= 0 {
+		return fmt.Errorf("account limit alert repeat interval must be positive")
+	}
+	if c.HostsPerMessage <= 0 {
+		return fmt.Errorf("account limit alert hosts per message must be positive")
+	}
+	return nil
+}
+
+type AccountLimitAlertMonitor struct {
+	logger  *slog.Logger
+	lister  accountLimitUsageLister
+	alerter Alerter
+	config  AccountLimitAlertMonitorConfig
+
+	now            func() time.Time
+	lastAlert      map[uint64]time.Time
+	aboveThreshold map[uint64]relay.HostAccountLimitUsage
+}
+
+func NewAccountLimitAlertMonitor(logger *slog.Logger, lister accountLimitUsageLister, alerter Alerter, config AccountLimitAlertMonitorConfig) (*AccountLimitAlertMonitor, error) {
+	if lister == nil {
+		return nil, fmt.Errorf("account limit alert lister is required")
+	}
+	if alerter == nil {
+		return nil, fmt.Errorf("account limit alerter is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	return &AccountLimitAlertMonitor{
+		logger:         logger.With("system", "account-limit-alerts"),
+		lister:         lister,
+		alerter:        alerter,
+		config:         config,
+		now:            time.Now,
+		lastAlert:      make(map[uint64]time.Time),
+		aboveThreshold: make(map[uint64]relay.HostAccountLimitUsage),
+	}, nil
+}
+
+func (m *AccountLimitAlertMonitor) Run(ctx context.Context) {
+	if err := m.Check(ctx); err != nil {
+		m.logger.Error("account limit alert check failed", "err", err)
+	}
+
+	ticker := time.NewTicker(m.config.CheckInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := m.Check(ctx); err != nil {
+				m.logger.Error("account limit alert check failed", "err", err)
+			}
+		}
+	}
+}
+
+func (m *AccountLimitAlertMonitor) Check(ctx context.Context) error {
+	usages, err := m.lister.ListHostsApproachingAccountLimit(ctx, m.config.Threshold, 0)
+	if err != nil {
+		return err
+	}
+
+	now := m.now()
+	currentAbove := make(map[uint64]relay.HostAccountLimitUsage, len(usages))
+	due := make([]relay.HostAccountLimitUsage, 0, len(usages))
+	for _, usage := range usages {
+		currentAbove[usage.ID] = usage
+		last, alertedBefore := m.lastAlert[usage.ID]
+		_, wasAbove := m.aboveThreshold[usage.ID]
+		repeatDue := !alertedBefore || now.Sub(last) >= m.config.RepeatInterval
+		if !wasAbove || repeatDue {
+			due = append(due, usage)
+		}
+	}
+
+	recovered := make([]relay.HostAccountLimitUsage, 0)
+	for id := range m.aboveThreshold {
+		if _, ok := currentAbove[id]; !ok {
+			recovered = append(recovered, m.aboveThreshold[id])
+		}
+	}
+
+	for _, usage := range recovered {
+		if err := m.alerter.SendAlert(ctx, AlertMessage{Text: formatAccountLimitRecoveryAlert(m.config, usage)}); err != nil {
+			return err
+		}
+		delete(m.aboveThreshold, usage.ID)
+		delete(m.lastAlert, usage.ID)
+	}
+
+	for id, usage := range currentAbove {
+		m.aboveThreshold[id] = usage
+	}
+
+	for start := 0; start < len(due); start += m.config.HostsPerMessage {
+		end := start + m.config.HostsPerMessage
+		if end > len(due) {
+			end = len(due)
+		}
+		batch := due[start:end]
+		if err := m.alerter.SendAlert(ctx, AlertMessage{Text: formatAccountLimitAlert(m.config, batch)}); err != nil {
+			return err
+		}
+		for _, usage := range batch {
+			m.lastAlert[usage.ID] = now
+		}
+	}
+	return nil
+}
+
+func formatAccountLimitRecoveryAlert(config AccountLimitAlertMonitorConfig, usage relay.HostAccountLimitUsage) string {
+	env := strings.TrimSpace(config.Environment)
+	header := "Relay PDS repo limit recovered"
+	if env != "" {
+		header = fmt.Sprintf("%s in %s", header, env)
+	}
+	return fmt.Sprintf(
+		"%s\n%s is no longer above the %.1f%% repo-limit alert threshold (last alert state: %.1f%% used, %d/%d repos)",
+		header,
+		usage.Hostname,
+		config.Threshold*100,
+		usage.Usage*100,
+		usage.AccountCount,
+		usage.AccountLimit,
+	)
+}
+
+func formatAccountLimitAlert(config AccountLimitAlertMonitorConfig, usages []relay.HostAccountLimitUsage) string {
+	env := strings.TrimSpace(config.Environment)
+	header := fmt.Sprintf("Relay PDS repo limit warning: %.1f%% threshold exceeded", config.Threshold*100)
+	if env != "" {
+		header = fmt.Sprintf("%s in %s", header, env)
+	}
+
+	lines := make([]string, 0, len(usages)+1)
+	lines = append(lines, header)
+	for _, usage := range usages {
+		lines = append(lines, fmt.Sprintf(
+			"%s: %.1f%% used (%d/%d repos)",
+			usage.Hostname,
+			usage.Usage*100,
+			usage.AccountCount,
+			usage.AccountLimit,
+		))
+	}
+	return strings.Join(lines, "\n")
+}
+
+type SlackAlerter struct {
+	client   *http.Client
+	endpoint string
+	token    string
+	channel  string
+}
+
+func NewSlackAlerter(token, channel string) (*SlackAlerter, error) {
+	token = strings.TrimSpace(token)
+	channel = strings.TrimSpace(channel)
+	if token == "" {
+		return nil, fmt.Errorf("slack alert token is required")
+	}
+	if channel == "" {
+		return nil, fmt.Errorf("slack alert channel is required")
+	}
+	client := cliutil.NewHttpClient()
+	client.Timeout = 10 * time.Second
+	return &SlackAlerter{
+		client:   client,
+		endpoint: "https://slack.com/api/chat.postMessage",
+		token:    token,
+		channel:  channel,
+	}, nil
+}
+
+func (s *SlackAlerter) SendAlert(ctx context.Context, msg AlertMessage) error {
+	payload := struct {
+		Channel     string `json:"channel"`
+		Text        string `json:"text"`
+		Mrkdwn      bool   `json:"mrkdwn"`
+		UnfurlLinks bool   `json:"unfurl_links"`
+		UnfurlMedia bool   `json:"unfurl_media"`
+	}{
+		Channel:     s.channel,
+		Text:        msg.Text,
+		Mrkdwn:      false,
+		UnfurlLinks: false,
+		UnfurlMedia: false,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+s.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := s.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("slack alert request failed with status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var slackResp struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(respBody, &slackResp); err != nil {
+		return fmt.Errorf("decoding slack alert response: %w", err)
+	}
+	if !slackResp.OK {
+		if slackResp.Error == "" {
+			slackResp.Error = "unknown error"
+		}
+		return fmt.Errorf("slack alert request failed: %s", slackResp.Error)
+	}
+	return nil
+}

--- a/cmd/relay/alerts.go
+++ b/cmd/relay/alerts.go
@@ -7,15 +7,26 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bluesky-social/indigo/cmd/relay/relay"
 	"github.com/bluesky-social/indigo/util/cliutil"
+
+	"github.com/labstack/echo/v4"
 )
 
 const accountLimitAlertHostsPerMessage = 50
+
+type AccountLimitAlertKind string
+
+const (
+	AccountLimitAlertKindWarning  = AccountLimitAlertKind("warning")
+	AccountLimitAlertKindRecovery = AccountLimitAlertKind("recovery")
+)
 
 type AlertMessage struct {
 	Text string
@@ -29,18 +40,72 @@ type accountLimitUsageLister interface {
 	ListHostsApproachingAccountLimit(ctx context.Context, threshold float64, limit int) ([]relay.HostAccountLimitUsage, error)
 }
 
+type AccountLimitAlertSentState struct {
+	Kind         AccountLimitAlertKind `json:"kind"`
+	HostID       uint64                `json:"hostID"`
+	Hostname     string                `json:"hostname"`
+	AccountCount int64                 `json:"accountCount"`
+	AccountLimit int64                 `json:"accountLimit"`
+	Usage        float64               `json:"usage"`
+	SentAt       time.Time             `json:"sentAt"`
+}
+
+func accountLimitAlertSentState(kind AccountLimitAlertKind, usage relay.HostAccountLimitUsage, sentAt time.Time) AccountLimitAlertSentState {
+	return AccountLimitAlertSentState{
+		Kind:         kind,
+		HostID:       usage.ID,
+		Hostname:     usage.Hostname,
+		AccountCount: usage.AccountCount,
+		AccountLimit: usage.AccountLimit,
+		Usage:        usage.Usage,
+		SentAt:       sentAt,
+	}
+}
+
+func (s *AccountLimitAlertSentState) normalize(now time.Time) error {
+	switch s.Kind {
+	case AccountLimitAlertKindWarning, AccountLimitAlertKindRecovery:
+	default:
+		return fmt.Errorf("invalid account limit alert kind: %s", s.Kind)
+	}
+	if s.HostID == 0 {
+		return fmt.Errorf("account limit alert host ID is required")
+	}
+	hostname, _, err := relay.ParseHostname(s.Hostname)
+	if err != nil {
+		return fmt.Errorf("invalid account limit alert hostname: %w", err)
+	}
+	s.Hostname = hostname
+	if s.SentAt.IsZero() {
+		s.SentAt = now
+	}
+	if s.AccountLimit < 0 {
+		return fmt.Errorf("account limit alert account limit must not be negative")
+	}
+	if s.AccountCount < 0 {
+		return fmt.Errorf("account limit alert account count must not be negative")
+	}
+	if s.Usage < 0 {
+		return fmt.Errorf("account limit alert usage must not be negative")
+	}
+	return nil
+}
+
 type AccountLimitAlertMonitorConfig struct {
 	Threshold       float64
 	CheckInterval   time.Duration
+	CheckJitter     time.Duration
 	RepeatInterval  time.Duration
 	Environment     string
 	HostsPerMessage int
+	SentCallback    func(context.Context, AccountLimitAlertSentState)
 }
 
 func DefaultAccountLimitAlertMonitorConfig() AccountLimitAlertMonitorConfig {
 	return AccountLimitAlertMonitorConfig{
 		Threshold:       0.80,
 		CheckInterval:   5 * time.Minute,
+		CheckJitter:     time.Minute,
 		RepeatInterval:  6 * time.Hour,
 		HostsPerMessage: accountLimitAlertHostsPerMessage,
 	}
@@ -52,6 +117,9 @@ func (c AccountLimitAlertMonitorConfig) Validate() error {
 	}
 	if c.CheckInterval <= 0 {
 		return fmt.Errorf("account limit alert interval must be positive")
+	}
+	if c.CheckJitter < 0 {
+		return fmt.Errorf("account limit alert jitter must not be negative")
 	}
 	if c.RepeatInterval <= 0 {
 		return fmt.Errorf("account limit alert repeat interval must be positive")
@@ -68,6 +136,7 @@ type AccountLimitAlertMonitor struct {
 	alerter Alerter
 	config  AccountLimitAlertMonitorConfig
 
+	lk             sync.Mutex
 	now            func() time.Time
 	lastAlert      map[uint64]time.Time
 	aboveThreshold map[uint64]relay.HostAccountLimitUsage
@@ -98,22 +167,56 @@ func NewAccountLimitAlertMonitor(logger *slog.Logger, lister accountLimitUsageLi
 }
 
 func (m *AccountLimitAlertMonitor) Run(ctx context.Context) {
-	if err := m.Check(ctx); err != nil {
-		m.logger.Error("account limit alert check failed", "err", err)
+	delay := initialCheckDelay(m.config.CheckJitter, rand.Int63n)
+	for {
+		if !waitForAlertCheck(ctx, delay) {
+			return
+		}
+		if err := m.Check(ctx); err != nil {
+			m.logger.Error("account limit alert check failed", "err", err)
+		}
+		delay = jitteredCheckInterval(m.config.CheckInterval, m.config.CheckJitter, rand.Int63n)
+	}
+}
+
+func waitForAlertCheck(ctx context.Context, delay time.Duration) bool {
+	if delay <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func initialCheckDelay(jitter time.Duration, randInt63n func(int64) int64) time.Duration {
+	if jitter <= 0 {
+		return 0
+	}
+	if randInt63n == nil {
+		randInt63n = rand.Int63n
+	}
+	return time.Duration(randInt63n(int64(jitter) + 1))
+}
+
+func jitteredCheckInterval(interval, jitter time.Duration, randInt63n func(int64) int64) time.Duration {
+	if jitter <= 0 {
+		return interval
+	}
+	if randInt63n == nil {
+		randInt63n = rand.Int63n
 	}
 
-	ticker := time.NewTicker(m.config.CheckInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			if err := m.Check(ctx); err != nil {
-				m.logger.Error("account limit alert check failed", "err", err)
-			}
-		}
+	offset := time.Duration(randInt63n(int64(jitter)*2+1)) - jitter
+	delay := interval + offset
+	if delay < time.Second {
+		return time.Second
 	}
+	return delay
 }
 
 func (m *AccountLimitAlertMonitor) Check(ctx context.Context) error {
@@ -123,6 +226,7 @@ func (m *AccountLimitAlertMonitor) Check(ctx context.Context) error {
 	}
 
 	now := m.now()
+	m.lk.Lock()
 	currentAbove := make(map[uint64]relay.HostAccountLimitUsage, len(usages))
 	due := make([]relay.HostAccountLimitUsage, 0, len(usages))
 	for _, usage := range usages {
@@ -142,16 +246,18 @@ func (m *AccountLimitAlertMonitor) Check(ctx context.Context) error {
 		}
 	}
 
+	for id, usage := range currentAbove {
+		m.aboveThreshold[id] = usage
+	}
+	m.lk.Unlock()
+
 	for _, usage := range recovered {
 		if err := m.alerter.SendAlert(ctx, AlertMessage{Text: formatAccountLimitRecoveryAlert(m.config, usage)}); err != nil {
 			return err
 		}
-		delete(m.aboveThreshold, usage.ID)
-		delete(m.lastAlert, usage.ID)
-	}
-
-	for id, usage := range currentAbove {
-		m.aboveThreshold[id] = usage
+		if err := m.recordAccountLimitAlertSent(ctx, accountLimitAlertSentState(AccountLimitAlertKindRecovery, usage, now), true); err != nil {
+			return err
+		}
 	}
 
 	for start := 0; start < len(due); start += m.config.HostsPerMessage {
@@ -164,10 +270,67 @@ func (m *AccountLimitAlertMonitor) Check(ctx context.Context) error {
 			return err
 		}
 		for _, usage := range batch {
-			m.lastAlert[usage.ID] = now
+			if err := m.recordAccountLimitAlertSent(ctx, accountLimitAlertSentState(AccountLimitAlertKindWarning, usage, now), true); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
+}
+
+func (m *AccountLimitAlertMonitor) RecordAccountLimitAlertSent(state AccountLimitAlertSentState) error {
+	return m.recordAccountLimitAlertSent(context.Background(), state, false)
+}
+
+func (m *AccountLimitAlertMonitor) recordAccountLimitAlertSent(ctx context.Context, state AccountLimitAlertSentState, notifySiblings bool) error {
+	now := m.now()
+	if err := state.normalize(now); err != nil {
+		return err
+	}
+
+	usage := relay.HostAccountLimitUsage{
+		ID:           state.HostID,
+		Hostname:     state.Hostname,
+		AccountCount: state.AccountCount,
+		AccountLimit: state.AccountLimit,
+		Usage:        state.Usage,
+	}
+
+	m.lk.Lock()
+	switch state.Kind {
+	case AccountLimitAlertKindWarning:
+		if last, ok := m.lastAlert[state.HostID]; !ok || state.SentAt.After(last) {
+			m.lastAlert[state.HostID] = state.SentAt
+		}
+		m.aboveThreshold[state.HostID] = usage
+	case AccountLimitAlertKindRecovery:
+		if last, ok := m.lastAlert[state.HostID]; ok && last.After(state.SentAt) {
+			m.lk.Unlock()
+			return nil
+		}
+		delete(m.lastAlert, state.HostID)
+		delete(m.aboveThreshold, state.HostID)
+	}
+	m.lk.Unlock()
+
+	if notifySiblings && m.config.SentCallback != nil {
+		m.config.SentCallback(ctx, state)
+	}
+	return nil
+}
+
+func (s *Service) handleAdminRecordAccountLimitAlertSent(c echo.Context) error {
+	var body AccountLimitAlertSentState
+	if err := c.Bind(&body); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid body: %s", err))
+	}
+	if s.accountLimitAlertRecorder == nil {
+		return c.JSON(http.StatusOK, map[string]any{"success": "true"})
+	}
+	if err := s.accountLimitAlertRecorder.RecordAccountLimitAlertSent(body); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	return c.JSON(http.StatusOK, map[string]any{"success": "true"})
 }
 
 func formatAccountLimitRecoveryAlert(config AccountLimitAlertMonitorConfig, usage relay.HostAccountLimitUsage) string {

--- a/cmd/relay/alerts.go
+++ b/cmd/relay/alerts.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -29,7 +30,28 @@ const (
 )
 
 type AlertMessage struct {
+	Title    string
+	Text     string
+	Severity AlertSeverity
+	Fields   []AlertField
+	Actions  []AlertAction
+}
+
+type AlertSeverity string
+
+const (
+	AlertSeverityWarning  = AlertSeverity("warning")
+	AlertSeverityRecovery = AlertSeverity("recovery")
+)
+
+type AlertField struct {
+	Title string
+	Value string
+}
+
+type AlertAction struct {
 	Text string
+	URL  string
 }
 
 type Alerter interface {
@@ -97,6 +119,7 @@ type AccountLimitAlertMonitorConfig struct {
 	CheckJitter     time.Duration
 	RepeatInterval  time.Duration
 	Environment     string
+	DashboardURL    string
 	HostsPerMessage int
 	SentCallback    func(context.Context, AccountLimitAlertSentState)
 }
@@ -126,6 +149,12 @@ func (c AccountLimitAlertMonitorConfig) Validate() error {
 	}
 	if c.HostsPerMessage <= 0 {
 		return fmt.Errorf("account limit alert hosts per message must be positive")
+	}
+	if strings.TrimSpace(c.DashboardURL) != "" {
+		u, err := url.Parse(c.DashboardURL)
+		if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+			return fmt.Errorf("account limit alert dashboard URL must be an absolute http or https URL")
+		}
 	}
 	return nil
 }
@@ -252,7 +281,7 @@ func (m *AccountLimitAlertMonitor) Check(ctx context.Context) error {
 	m.lk.Unlock()
 
 	for _, usage := range recovered {
-		if err := m.alerter.SendAlert(ctx, AlertMessage{Text: formatAccountLimitRecoveryAlert(m.config, usage)}); err != nil {
+		if err := m.alerter.SendAlert(ctx, formatAccountLimitRecoveryAlert(m.config, usage)); err != nil {
 			return err
 		}
 		if err := m.recordAccountLimitAlertSent(ctx, accountLimitAlertSentState(AccountLimitAlertKindRecovery, usage, now), true); err != nil {
@@ -266,7 +295,7 @@ func (m *AccountLimitAlertMonitor) Check(ctx context.Context) error {
 			end = len(due)
 		}
 		batch := due[start:end]
-		if err := m.alerter.SendAlert(ctx, AlertMessage{Text: formatAccountLimitAlert(m.config, batch)}); err != nil {
+		if err := m.alerter.SendAlert(ctx, formatAccountLimitAlert(m.config, batch)); err != nil {
 			return err
 		}
 		for _, usage := range batch {
@@ -333,42 +362,74 @@ func (s *Service) handleAdminRecordAccountLimitAlertSent(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]any{"success": "true"})
 }
 
-func formatAccountLimitRecoveryAlert(config AccountLimitAlertMonitorConfig, usage relay.HostAccountLimitUsage) string {
+func formatAccountLimitRecoveryAlert(config AccountLimitAlertMonitorConfig, usage relay.HostAccountLimitUsage) AlertMessage {
 	env := strings.TrimSpace(config.Environment)
-	header := "Relay PDS repo limit recovered"
+	title := "PDS repo limit recovered"
 	if env != "" {
-		header = fmt.Sprintf("%s in %s", header, env)
+		title = fmt.Sprintf("%s in %s", title, env)
 	}
-	return fmt.Sprintf(
-		"%s\n%s is no longer above the %.1f%% repo-limit alert threshold (last alert state: %.1f%% used, %d/%d repos)",
-		header,
-		usage.Hostname,
-		config.Threshold*100,
-		usage.Usage*100,
-		usage.AccountCount,
-		usage.AccountLimit,
-	)
+	msg := AlertMessage{
+		Title:    title,
+		Severity: AlertSeverityRecovery,
+		Text: fmt.Sprintf(
+			"`%s` is no longer above the %.1f%% repo-limit alert threshold.",
+			usage.Hostname,
+			config.Threshold*100,
+		),
+		Fields: []AlertField{
+			{Title: "Last alert state", Value: fmt.Sprintf("%.1f%% used", usage.Usage*100)},
+			{Title: "Last repo count", Value: fmt.Sprintf("%d / %d", usage.AccountCount, usage.AccountLimit)},
+			{Title: "Threshold", Value: fmt.Sprintf("%.1f%%", config.Threshold*100)},
+		},
+	}
+	if env != "" {
+		msg.Fields = append(msg.Fields, AlertField{Title: "Environment", Value: env})
+	}
+	if strings.TrimSpace(config.DashboardURL) != "" {
+		msg.Actions = append(msg.Actions, AlertAction{Text: "Open relay dashboard", URL: strings.TrimSpace(config.DashboardURL)})
+	}
+	return msg
 }
 
-func formatAccountLimitAlert(config AccountLimitAlertMonitorConfig, usages []relay.HostAccountLimitUsage) string {
+func formatAccountLimitAlert(config AccountLimitAlertMonitorConfig, usages []relay.HostAccountLimitUsage) AlertMessage {
 	env := strings.TrimSpace(config.Environment)
-	header := fmt.Sprintf("Relay PDS repo limit warning: %.1f%% threshold exceeded", config.Threshold*100)
+	title := "PDS repo limit warning"
 	if env != "" {
-		header = fmt.Sprintf("%s in %s", header, env)
+		title = fmt.Sprintf("%s in %s", title, env)
 	}
 
 	lines := make([]string, 0, len(usages)+1)
-	lines = append(lines, header)
+	lines = append(lines, fmt.Sprintf("%d PDS host(s) are above the %.1f%% repo-limit alert threshold.", len(usages), config.Threshold*100))
+	highestUsage := float64(0)
 	for _, usage := range usages {
+		if usage.Usage > highestUsage {
+			highestUsage = usage.Usage
+		}
 		lines = append(lines, fmt.Sprintf(
-			"%s: %.1f%% used (%d/%d repos)",
+			"- `%s`: *%.1f%%* used (`%d / %d` repos)",
 			usage.Hostname,
 			usage.Usage*100,
 			usage.AccountCount,
 			usage.AccountLimit,
 		))
 	}
-	return strings.Join(lines, "\n")
+	msg := AlertMessage{
+		Title:    title,
+		Severity: AlertSeverityWarning,
+		Text:     strings.Join(lines, "\n"),
+		Fields: []AlertField{
+			{Title: "Threshold", Value: fmt.Sprintf("%.1f%%", config.Threshold*100)},
+			{Title: "Hosts", Value: fmt.Sprintf("%d", len(usages))},
+			{Title: "Highest usage", Value: fmt.Sprintf("%.1f%%", highestUsage*100)},
+		},
+	}
+	if env != "" {
+		msg.Fields = append(msg.Fields, AlertField{Title: "Environment", Value: env})
+	}
+	if strings.TrimSpace(config.DashboardURL) != "" {
+		msg.Actions = append(msg.Actions, AlertAction{Text: "Open relay dashboard", URL: strings.TrimSpace(config.DashboardURL)})
+	}
+	return msg
 }
 
 type SlackAlerter struct {
@@ -376,6 +437,37 @@ type SlackAlerter struct {
 	endpoint string
 	token    string
 	channel  string
+}
+
+type slackText struct {
+	Type  string `json:"type"`
+	Text  string `json:"text"`
+	Emoji bool   `json:"emoji,omitempty"`
+}
+
+type slackBlock struct {
+	Type     string      `json:"type"`
+	Text     *slackText  `json:"text,omitempty"`
+	Fields   []slackText `json:"fields,omitempty"`
+	Elements []any       `json:"elements,omitempty"`
+}
+
+type slackElement struct {
+	Type     string    `json:"type"`
+	Text     slackText `json:"text"`
+	URL      string    `json:"url,omitempty"`
+	Style    string    `json:"style,omitempty"`
+	ActionID string    `json:"action_id,omitempty"`
+}
+
+type slackContextElement struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type slackAttachment struct {
+	Color  string       `json:"color"`
+	Blocks []slackBlock `json:"blocks"`
 }
 
 func NewSlackAlerter(token, channel string) (*SlackAlerter, error) {
@@ -399,15 +491,15 @@ func NewSlackAlerter(token, channel string) (*SlackAlerter, error) {
 
 func (s *SlackAlerter) SendAlert(ctx context.Context, msg AlertMessage) error {
 	payload := struct {
-		Channel     string `json:"channel"`
-		Text        string `json:"text"`
-		Mrkdwn      bool   `json:"mrkdwn"`
-		UnfurlLinks bool   `json:"unfurl_links"`
-		UnfurlMedia bool   `json:"unfurl_media"`
+		Channel     string            `json:"channel"`
+		Text        string            `json:"text"`
+		Attachments []slackAttachment `json:"attachments,omitempty"`
+		UnfurlLinks bool              `json:"unfurl_links"`
+		UnfurlMedia bool              `json:"unfurl_media"`
 	}{
 		Channel:     s.channel,
-		Text:        msg.Text,
-		Mrkdwn:      false,
+		Text:        slackFallbackText(msg),
+		Attachments: []slackAttachment{slackAttachmentForAlert(msg)},
 		UnfurlLinks: false,
 		UnfurlMedia: false,
 	}
@@ -455,4 +547,85 @@ func (s *SlackAlerter) SendAlert(ctx context.Context, msg AlertMessage) error {
 		return fmt.Errorf("slack alert request failed: %s", slackResp.Error)
 	}
 	return nil
+}
+
+func slackFallbackText(msg AlertMessage) string {
+	if strings.TrimSpace(msg.Title) == "" {
+		return msg.Text
+	}
+	if strings.TrimSpace(msg.Text) == "" {
+		return msg.Title
+	}
+	return msg.Title + "\n" + msg.Text
+}
+
+func slackAttachmentForAlert(msg AlertMessage) slackAttachment {
+	blocks := []slackBlock{}
+	if strings.TrimSpace(msg.Title) != "" {
+		blocks = append(blocks, slackBlock{
+			Type: "header",
+			Text: &slackText{Type: "plain_text", Text: msg.Title, Emoji: true},
+		})
+	}
+	if strings.TrimSpace(msg.Text) != "" {
+		blocks = append(blocks, slackBlock{
+			Type: "section",
+			Text: &slackText{Type: "mrkdwn", Text: msg.Text},
+		})
+	}
+	if len(msg.Fields) > 0 {
+		fields := make([]slackText, 0, len(msg.Fields))
+		for i, field := range msg.Fields {
+			if i >= 10 {
+				break
+			}
+			fields = append(fields, slackText{
+				Type: "mrkdwn",
+				Text: fmt.Sprintf("*%s*\n%s", field.Title, field.Value),
+			})
+		}
+		blocks = append(blocks, slackBlock{Type: "section", Fields: fields})
+	}
+	if len(msg.Actions) > 0 {
+		elements := make([]any, 0, len(msg.Actions))
+		for i, action := range msg.Actions {
+			if i >= 5 {
+				break
+			}
+			if strings.TrimSpace(action.Text) == "" || strings.TrimSpace(action.URL) == "" {
+				continue
+			}
+			elements = append(elements, slackElement{
+				Type:     "button",
+				Text:     slackText{Type: "plain_text", Text: action.Text, Emoji: true},
+				URL:      action.URL,
+				Style:    "primary",
+				ActionID: fmt.Sprintf("relay_alert_action_%d", i),
+			})
+		}
+		if len(elements) > 0 {
+			blocks = append(blocks, slackBlock{Type: "actions", Elements: elements})
+		}
+	}
+	blocks = append(blocks, slackBlock{
+		Type: "context",
+		Elements: []any{
+			slackContextElement{Type: "mrkdwn", Text: "indigo relay account-limit monitor"},
+		},
+	})
+	return slackAttachment{
+		Color:  slackColorForSeverity(msg.Severity),
+		Blocks: blocks,
+	}
+}
+
+func slackColorForSeverity(severity AlertSeverity) string {
+	switch severity {
+	case AlertSeverityRecovery:
+		return "#2EB67D"
+	case AlertSeverityWarning:
+		return "#ECB22E"
+	default:
+		return "#439FE0"
+	}
 }

--- a/cmd/relay/alerts_test.go
+++ b/cmd/relay/alerts_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bluesky-social/indigo/cmd/relay/relay"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeAccountLimitUsageLister struct {
+	usages    []relay.HostAccountLimitUsage
+	lastLimit int
+}
+
+func (f *fakeAccountLimitUsageLister) ListHostsApproachingAccountLimit(ctx context.Context, threshold float64, limit int) ([]relay.HostAccountLimitUsage, error) {
+	f.lastLimit = limit
+	return f.usages, nil
+}
+
+type recordingAlerter struct {
+	messages []AlertMessage
+}
+
+func (r *recordingAlerter) SendAlert(ctx context.Context, msg AlertMessage) error {
+	r.messages = append(r.messages, msg)
+	return nil
+}
+
+func TestAccountLimitAlertMonitorSendsAndRepeatsAfterCooldown(t *testing.T) {
+	lister := &fakeAccountLimitUsageLister{
+		usages: []relay.HostAccountLimitUsage{
+			{ID: 1, Hostname: "pds.example.com", AccountCount: 80, AccountLimit: 100, Usage: 0.8},
+		},
+	}
+	alerter := &recordingAlerter{}
+	config := DefaultAccountLimitAlertMonitorConfig()
+	config.CheckInterval = time.Minute
+	config.RepeatInterval = time.Hour
+	config.Environment = "test"
+
+	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), lister, alerter, config)
+	require.NoError(t, err)
+
+	now := time.Unix(1000, 0)
+	monitor.now = func() time.Time { return now }
+
+	require.NoError(t, monitor.Check(context.Background()))
+	require.Len(t, alerter.messages, 1)
+	assert.Contains(t, alerter.messages[0].Text, "pds.example.com: 80.0% used (80/100 repos)")
+	assert.Contains(t, alerter.messages[0].Text, "in test")
+
+	now = now.Add(30 * time.Minute)
+	require.NoError(t, monitor.Check(context.Background()))
+	require.Len(t, alerter.messages, 1)
+
+	now = now.Add(31 * time.Minute)
+	require.NoError(t, monitor.Check(context.Background()))
+	require.Len(t, alerter.messages, 2)
+}
+
+func TestAccountLimitAlertMonitorSendsRecoveryAndAlertsAgain(t *testing.T) {
+	lister := &fakeAccountLimitUsageLister{
+		usages: []relay.HostAccountLimitUsage{
+			{ID: 1, Hostname: "pds.example.com", AccountCount: 80, AccountLimit: 100, Usage: 0.8},
+		},
+	}
+	alerter := &recordingAlerter{}
+	config := DefaultAccountLimitAlertMonitorConfig()
+	config.RepeatInterval = time.Hour
+
+	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), lister, alerter, config)
+	require.NoError(t, err)
+	now := time.Unix(1000, 0)
+	monitor.now = func() time.Time { return now }
+
+	require.NoError(t, monitor.Check(context.Background()))
+	require.Len(t, alerter.messages, 1)
+
+	lister.usages = nil
+	now = now.Add(10 * time.Minute)
+	require.NoError(t, monitor.Check(context.Background()))
+	require.Len(t, alerter.messages, 2)
+	assert.Contains(t, alerter.messages[1].Text, "Relay PDS repo limit recovered")
+	assert.Contains(t, alerter.messages[1].Text, "pds.example.com is no longer above the 80.0% repo-limit alert threshold")
+
+	lister.usages = []relay.HostAccountLimitUsage{
+		{ID: 1, Hostname: "pds.example.com", AccountCount: 81, AccountLimit: 100, Usage: 0.81},
+	}
+	now = now.Add(10 * time.Minute)
+	require.NoError(t, monitor.Check(context.Background()))
+	require.Len(t, alerter.messages, 3)
+	assert.Contains(t, alerter.messages[2].Text, "pds.example.com: 81.0% used (81/100 repos)")
+}
+
+func TestAccountLimitAlertMonitorBatchesMessagesWithoutQueryCap(t *testing.T) {
+	lister := &fakeAccountLimitUsageLister{
+		usages: []relay.HostAccountLimitUsage{
+			{ID: 1, Hostname: "one.example.com", AccountCount: 80, AccountLimit: 100, Usage: 0.8},
+			{ID: 2, Hostname: "two.example.com", AccountCount: 81, AccountLimit: 100, Usage: 0.81},
+		},
+	}
+	alerter := &recordingAlerter{}
+	config := DefaultAccountLimitAlertMonitorConfig()
+	config.HostsPerMessage = 1
+
+	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), lister, alerter, config)
+	require.NoError(t, err)
+	require.NoError(t, monitor.Check(context.Background()))
+
+	assert.Equal(t, 0, lister.lastLimit)
+	require.Len(t, alerter.messages, 2)
+	assert.Contains(t, alerter.messages[0].Text, "one.example.com")
+	assert.Contains(t, alerter.messages[1].Text, "two.example.com")
+}
+
+func TestSlackAlerterDoesNotPutTokenInPayload(t *testing.T) {
+	const token = "xoxb-secret-token"
+	var gotAuth string
+	var gotPayload map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotPayload))
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	alerter, err := NewSlackAlerter(token, "C123")
+	require.NoError(t, err)
+	alerter.endpoint = server.URL
+	alerter.client = server.Client()
+
+	require.NoError(t, alerter.SendAlert(context.Background(), AlertMessage{Text: "hello"}))
+	assert.Equal(t, "Bearer "+token, gotAuth)
+
+	payloadBytes, err := json.Marshal(gotPayload)
+	require.NoError(t, err)
+	assert.False(t, strings.Contains(string(payloadBytes), token))
+	assert.Equal(t, "C123", gotPayload["channel"])
+	assert.Equal(t, "hello", gotPayload["text"])
+	assert.Equal(t, false, gotPayload["mrkdwn"])
+}

--- a/cmd/relay/alerts_test.go
+++ b/cmd/relay/alerts_test.go
@@ -67,6 +67,122 @@ func TestAccountLimitAlertMonitorSendsAndRepeatsAfterCooldown(t *testing.T) {
 	require.Len(t, alerter.messages, 2)
 }
 
+func TestJitteredCheckInterval(t *testing.T) {
+	interval := 5 * time.Minute
+	jitter := time.Minute
+	rangeSize := int64(2*jitter + 1)
+
+	assert.Equal(t, 4*time.Minute, jitteredCheckInterval(interval, jitter, func(n int64) int64 {
+		assert.Equal(t, rangeSize, n)
+		return 0
+	}))
+	assert.Equal(t, interval, jitteredCheckInterval(interval, jitter, func(n int64) int64 {
+		assert.Equal(t, rangeSize, n)
+		return int64(jitter)
+	}))
+	assert.Equal(t, 6*time.Minute, jitteredCheckInterval(interval, jitter, func(n int64) int64 {
+		assert.Equal(t, rangeSize, n)
+		return int64(2 * jitter)
+	}))
+	assert.Equal(t, time.Second, jitteredCheckInterval(30*time.Second, jitter, func(n int64) int64 {
+		return 0
+	}))
+	assert.Equal(t, interval, jitteredCheckInterval(interval, 0, nil))
+}
+
+func TestInitialCheckDelay(t *testing.T) {
+	jitter := time.Minute
+	rangeSize := int64(jitter + 1)
+
+	assert.Equal(t, time.Duration(0), initialCheckDelay(jitter, func(n int64) int64 {
+		assert.Equal(t, rangeSize, n)
+		return 0
+	}))
+	assert.Equal(t, jitter, initialCheckDelay(jitter, func(n int64) int64 {
+		assert.Equal(t, rangeSize, n)
+		return int64(jitter)
+	}))
+	assert.Equal(t, time.Duration(0), initialCheckDelay(0, nil))
+}
+
+func TestAccountLimitAlertMonitorCirculatesLocalSentState(t *testing.T) {
+	lister := &fakeAccountLimitUsageLister{
+		usages: []relay.HostAccountLimitUsage{
+			{ID: 1, Hostname: "pds.example.com", AccountCount: 80, AccountLimit: 100, Usage: 0.8},
+		},
+	}
+	alerter := &recordingAlerter{}
+	var sent []AccountLimitAlertSentState
+	config := DefaultAccountLimitAlertMonitorConfig()
+	config.SentCallback = func(ctx context.Context, state AccountLimitAlertSentState) {
+		sent = append(sent, state)
+	}
+
+	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), lister, alerter, config)
+	require.NoError(t, err)
+	require.NoError(t, monitor.Check(context.Background()))
+
+	require.Len(t, sent, 1)
+	assert.Equal(t, AccountLimitAlertKindWarning, sent[0].Kind)
+	assert.Equal(t, uint64(1), sent[0].HostID)
+	assert.Equal(t, "pds.example.com", sent[0].Hostname)
+}
+
+func TestAccountLimitAlertMonitorRemoteWarningSuppressesLocalWarning(t *testing.T) {
+	lister := &fakeAccountLimitUsageLister{
+		usages: []relay.HostAccountLimitUsage{
+			{ID: 1, Hostname: "pds.example.com", AccountCount: 80, AccountLimit: 100, Usage: 0.8},
+		},
+	}
+	alerter := &recordingAlerter{}
+	config := DefaultAccountLimitAlertMonitorConfig()
+
+	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), lister, alerter, config)
+	require.NoError(t, err)
+	require.NoError(t, monitor.RecordAccountLimitAlertSent(AccountLimitAlertSentState{
+		Kind:         AccountLimitAlertKindWarning,
+		HostID:       1,
+		Hostname:     "pds.example.com",
+		AccountCount: 80,
+		AccountLimit: 100,
+		Usage:        0.8,
+		SentAt:       time.Now(),
+	}))
+
+	require.NoError(t, monitor.Check(context.Background()))
+	require.Empty(t, alerter.messages)
+}
+
+func TestAccountLimitAlertMonitorRemoteRecoverySuppressesLocalRecovery(t *testing.T) {
+	lister := &fakeAccountLimitUsageLister{}
+	alerter := &recordingAlerter{}
+	config := DefaultAccountLimitAlertMonitorConfig()
+
+	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), lister, alerter, config)
+	require.NoError(t, err)
+	require.NoError(t, monitor.RecordAccountLimitAlertSent(AccountLimitAlertSentState{
+		Kind:         AccountLimitAlertKindWarning,
+		HostID:       1,
+		Hostname:     "pds.example.com",
+		AccountCount: 80,
+		AccountLimit: 100,
+		Usage:        0.8,
+		SentAt:       time.Now(),
+	}))
+	require.NoError(t, monitor.RecordAccountLimitAlertSent(AccountLimitAlertSentState{
+		Kind:         AccountLimitAlertKindRecovery,
+		HostID:       1,
+		Hostname:     "pds.example.com",
+		AccountCount: 80,
+		AccountLimit: 100,
+		Usage:        0.8,
+		SentAt:       time.Now(),
+	}))
+
+	require.NoError(t, monitor.Check(context.Background()))
+	require.Empty(t, alerter.messages)
+}
+
 func TestAccountLimitAlertMonitorSendsRecoveryAndAlertsAgain(t *testing.T) {
 	lister := &fakeAccountLimitUsageLister{
 		usages: []relay.HostAccountLimitUsage{

--- a/cmd/relay/alerts_test.go
+++ b/cmd/relay/alerts_test.go
@@ -55,8 +55,8 @@ func TestAccountLimitAlertMonitorSendsAndRepeatsAfterCooldown(t *testing.T) {
 
 	require.NoError(t, monitor.Check(context.Background()))
 	require.Len(t, alerter.messages, 1)
-	assert.Contains(t, alerter.messages[0].Text, "pds.example.com: 80.0% used (80/100 repos)")
-	assert.Contains(t, alerter.messages[0].Text, "in test")
+	assert.Contains(t, alerter.messages[0].Title, "in test")
+	assert.Contains(t, alerter.messages[0].Text, "`pds.example.com`: *80.0%* used (`80 / 100` repos)")
 
 	now = now.Add(30 * time.Minute)
 	require.NoError(t, monitor.Check(context.Background()))
@@ -205,8 +205,8 @@ func TestAccountLimitAlertMonitorSendsRecoveryAndAlertsAgain(t *testing.T) {
 	now = now.Add(10 * time.Minute)
 	require.NoError(t, monitor.Check(context.Background()))
 	require.Len(t, alerter.messages, 2)
-	assert.Contains(t, alerter.messages[1].Text, "Relay PDS repo limit recovered")
-	assert.Contains(t, alerter.messages[1].Text, "pds.example.com is no longer above the 80.0% repo-limit alert threshold")
+	assert.Contains(t, alerter.messages[1].Title, "PDS repo limit recovered")
+	assert.Contains(t, alerter.messages[1].Text, "`pds.example.com` is no longer above the 80.0% repo-limit alert threshold")
 
 	lister.usages = []relay.HostAccountLimitUsage{
 		{ID: 1, Hostname: "pds.example.com", AccountCount: 81, AccountLimit: 100, Usage: 0.81},
@@ -214,7 +214,7 @@ func TestAccountLimitAlertMonitorSendsRecoveryAndAlertsAgain(t *testing.T) {
 	now = now.Add(10 * time.Minute)
 	require.NoError(t, monitor.Check(context.Background()))
 	require.Len(t, alerter.messages, 3)
-	assert.Contains(t, alerter.messages[2].Text, "pds.example.com: 81.0% used (81/100 repos)")
+	assert.Contains(t, alerter.messages[2].Text, "`pds.example.com`: *81.0%* used (`81 / 100` repos)")
 }
 
 func TestAccountLimitAlertMonitorBatchesMessagesWithoutQueryCap(t *testing.T) {
@@ -255,13 +255,37 @@ func TestSlackAlerterDoesNotPutTokenInPayload(t *testing.T) {
 	alerter.endpoint = server.URL
 	alerter.client = server.Client()
 
-	require.NoError(t, alerter.SendAlert(context.Background(), AlertMessage{Text: "hello"}))
+	require.NoError(t, alerter.SendAlert(context.Background(), AlertMessage{
+		Title:    "PDS repo limit warning in test",
+		Text:     "`pds.example.com`: *85.0%* used (`85 / 100` repos)",
+		Severity: AlertSeverityWarning,
+		Fields: []AlertField{
+			{Title: "Threshold", Value: "80.0%"},
+			{Title: "Highest usage", Value: "85.0%"},
+		},
+		Actions: []AlertAction{
+			{Text: "Open relay dashboard", URL: "https://relay.example.com/dash"},
+		},
+	}))
 	assert.Equal(t, "Bearer "+token, gotAuth)
 
 	payloadBytes, err := json.Marshal(gotPayload)
 	require.NoError(t, err)
 	assert.False(t, strings.Contains(string(payloadBytes), token))
 	assert.Equal(t, "C123", gotPayload["channel"])
-	assert.Equal(t, "hello", gotPayload["text"])
-	assert.Equal(t, false, gotPayload["mrkdwn"])
+	assert.Contains(t, gotPayload["text"], "PDS repo limit warning in test")
+
+	attachments, ok := gotPayload["attachments"].([]any)
+	require.True(t, ok)
+	require.Len(t, attachments, 1)
+	attachment, ok := attachments[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "#ECB22E", attachment["color"])
+	blocks, ok := attachment["blocks"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, blocks)
+
+	payload := string(payloadBytes)
+	assert.Contains(t, payload, "Open relay dashboard")
+	assert.Contains(t, payload, "https://relay.example.com/dash")
 }

--- a/cmd/relay/alerts_test.go
+++ b/cmd/relay/alerts_test.go
@@ -11,19 +11,35 @@ import (
 	"time"
 
 	"github.com/bluesky-social/indigo/cmd/relay/relay"
+	"github.com/bluesky-social/indigo/cmd/relay/relay/models"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type fakeAccountLimitUsageLister struct {
-	usages    []relay.HostAccountLimitUsage
+type fakeAccountLimitAlertClaimer struct {
+	claims    []relay.HostAccountLimitAlertClaims
 	lastLimit int
+	calls     int
+	records   []string
 }
 
-func (f *fakeAccountLimitUsageLister) ListHostsApproachingAccountLimit(ctx context.Context, threshold float64, limit int) ([]relay.HostAccountLimitUsage, error) {
+func (f *fakeAccountLimitAlertClaimer) ClaimDueAccountLimitAlerts(ctx context.Context, threshold float64, repeatInterval time.Duration, limit int) (*relay.HostAccountLimitAlertClaims, error) {
 	f.lastLimit = limit
-	return f.usages, nil
+	if len(f.claims) == 0 {
+		return &relay.HostAccountLimitAlertClaims{}, nil
+	}
+	idx := f.calls
+	if idx >= len(f.claims) {
+		idx = len(f.claims) - 1
+	}
+	f.calls++
+	return &f.claims[idx], nil
+}
+
+func (f *fakeAccountLimitAlertClaimer) RecordHostAccountLimitAlertSent(ctx context.Context, hostname string, state models.HostAccountLimitAlertState, sentAt time.Time) error {
+	f.records = append(f.records, hostname+":"+string(state))
+	return nil
 }
 
 type recordingAlerter struct {
@@ -35,10 +51,14 @@ func (r *recordingAlerter) SendAlert(ctx context.Context, msg AlertMessage) erro
 	return nil
 }
 
-func TestAccountLimitAlertMonitorSendsAndRepeatsAfterCooldown(t *testing.T) {
-	lister := &fakeAccountLimitUsageLister{
-		usages: []relay.HostAccountLimitUsage{
-			{ID: 1, Hostname: "pds.example.com", AccountCount: 80, AccountLimit: 100, Usage: 0.8},
+func TestAccountLimitAlertMonitorSendsClaimedWarning(t *testing.T) {
+	claimer := &fakeAccountLimitAlertClaimer{
+		claims: []relay.HostAccountLimitAlertClaims{
+			{
+				Warnings: []relay.HostAccountLimitUsage{
+					{ID: 1, Hostname: "pds.example.com", AccountCount: 80, AccountLimit: 100, Usage: 0.8, AlertSentAt: time.Unix(1000, 0)},
+				},
+			},
 		},
 	}
 	alerter := &recordingAlerter{}
@@ -47,24 +67,13 @@ func TestAccountLimitAlertMonitorSendsAndRepeatsAfterCooldown(t *testing.T) {
 	config.RepeatInterval = time.Hour
 	config.Environment = "test"
 
-	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), lister, alerter, config)
+	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), claimer, alerter, config)
 	require.NoError(t, err)
-
-	now := time.Unix(1000, 0)
-	monitor.now = func() time.Time { return now }
 
 	require.NoError(t, monitor.Check(context.Background()))
 	require.Len(t, alerter.messages, 1)
 	assert.Contains(t, alerter.messages[0].Title, "in test")
 	assert.Contains(t, alerter.messages[0].Text, "`pds.example.com`: *80.0%* used (`80 / 100` repos)")
-
-	now = now.Add(30 * time.Minute)
-	require.NoError(t, monitor.Check(context.Background()))
-	require.Len(t, alerter.messages, 1)
-
-	now = now.Add(31 * time.Minute)
-	require.NoError(t, monitor.Check(context.Background()))
-	require.Len(t, alerter.messages, 2)
 }
 
 func TestJitteredCheckInterval(t *testing.T) {
@@ -106,9 +115,13 @@ func TestInitialCheckDelay(t *testing.T) {
 }
 
 func TestAccountLimitAlertMonitorCirculatesLocalSentState(t *testing.T) {
-	lister := &fakeAccountLimitUsageLister{
-		usages: []relay.HostAccountLimitUsage{
-			{ID: 1, Hostname: "pds.example.com", AccountCount: 80, AccountLimit: 100, Usage: 0.8},
+	claimer := &fakeAccountLimitAlertClaimer{
+		claims: []relay.HostAccountLimitAlertClaims{
+			{
+				Warnings: []relay.HostAccountLimitUsage{
+					{ID: 1, Hostname: "pds.example.com", AccountCount: 80, AccountLimit: 100, Usage: 0.8, AlertSentAt: time.Unix(1000, 0)},
+				},
+			},
 		},
 	}
 	alerter := &recordingAlerter{}
@@ -118,7 +131,7 @@ func TestAccountLimitAlertMonitorCirculatesLocalSentState(t *testing.T) {
 		sent = append(sent, state)
 	}
 
-	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), lister, alerter, config)
+	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), claimer, alerter, config)
 	require.NoError(t, err)
 	require.NoError(t, monitor.Check(context.Background()))
 
@@ -128,111 +141,49 @@ func TestAccountLimitAlertMonitorCirculatesLocalSentState(t *testing.T) {
 	assert.Equal(t, "pds.example.com", sent[0].Hostname)
 }
 
-func TestAccountLimitAlertMonitorRemoteWarningSuppressesLocalWarning(t *testing.T) {
-	lister := &fakeAccountLimitUsageLister{
-		usages: []relay.HostAccountLimitUsage{
-			{ID: 1, Hostname: "pds.example.com", AccountCount: 80, AccountLimit: 100, Usage: 0.8},
-		},
-	}
-	alerter := &recordingAlerter{}
-	config := DefaultAccountLimitAlertMonitorConfig()
-
-	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), lister, alerter, config)
-	require.NoError(t, err)
-	require.NoError(t, monitor.RecordAccountLimitAlertSent(AccountLimitAlertSentState{
-		Kind:         AccountLimitAlertKindWarning,
-		HostID:       1,
-		Hostname:     "pds.example.com",
-		AccountCount: 80,
-		AccountLimit: 100,
-		Usage:        0.8,
-		SentAt:       time.Now(),
-	}))
-
-	require.NoError(t, monitor.Check(context.Background()))
-	require.Empty(t, alerter.messages)
-}
-
-func TestAccountLimitAlertMonitorRemoteRecoverySuppressesLocalRecovery(t *testing.T) {
-	lister := &fakeAccountLimitUsageLister{}
-	alerter := &recordingAlerter{}
-	config := DefaultAccountLimitAlertMonitorConfig()
-
-	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), lister, alerter, config)
-	require.NoError(t, err)
-	require.NoError(t, monitor.RecordAccountLimitAlertSent(AccountLimitAlertSentState{
-		Kind:         AccountLimitAlertKindWarning,
-		HostID:       1,
-		Hostname:     "pds.example.com",
-		AccountCount: 80,
-		AccountLimit: 100,
-		Usage:        0.8,
-		SentAt:       time.Now(),
-	}))
-	require.NoError(t, monitor.RecordAccountLimitAlertSent(AccountLimitAlertSentState{
-		Kind:         AccountLimitAlertKindRecovery,
-		HostID:       1,
-		Hostname:     "pds.example.com",
-		AccountCount: 80,
-		AccountLimit: 100,
-		Usage:        0.8,
-		SentAt:       time.Now(),
-	}))
-
-	require.NoError(t, monitor.Check(context.Background()))
-	require.Empty(t, alerter.messages)
-}
-
-func TestAccountLimitAlertMonitorSendsRecoveryAndAlertsAgain(t *testing.T) {
-	lister := &fakeAccountLimitUsageLister{
-		usages: []relay.HostAccountLimitUsage{
-			{ID: 1, Hostname: "pds.example.com", AccountCount: 80, AccountLimit: 100, Usage: 0.8},
+func TestAccountLimitAlertMonitorSendsClaimedRecovery(t *testing.T) {
+	claimer := &fakeAccountLimitAlertClaimer{
+		claims: []relay.HostAccountLimitAlertClaims{
+			{
+				Recoveries: []relay.HostAccountLimitUsage{
+					{ID: 1, Hostname: "pds.example.com", AccountCount: 20, AccountLimit: 100, Usage: 0.2, AlertSentAt: time.Unix(1000, 0)},
+				},
+			},
 		},
 	}
 	alerter := &recordingAlerter{}
 	config := DefaultAccountLimitAlertMonitorConfig()
 	config.RepeatInterval = time.Hour
 
-	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), lister, alerter, config)
+	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), claimer, alerter, config)
 	require.NoError(t, err)
-	now := time.Unix(1000, 0)
-	monitor.now = func() time.Time { return now }
 
 	require.NoError(t, monitor.Check(context.Background()))
 	require.Len(t, alerter.messages, 1)
-
-	lister.usages = nil
-	now = now.Add(10 * time.Minute)
-	require.NoError(t, monitor.Check(context.Background()))
-	require.Len(t, alerter.messages, 2)
-	assert.Contains(t, alerter.messages[1].Title, "PDS repo limit recovered")
-	assert.Contains(t, alerter.messages[1].Text, "`pds.example.com` is no longer above the 80.0% repo-limit alert threshold")
-
-	lister.usages = []relay.HostAccountLimitUsage{
-		{ID: 1, Hostname: "pds.example.com", AccountCount: 81, AccountLimit: 100, Usage: 0.81},
-	}
-	now = now.Add(10 * time.Minute)
-	require.NoError(t, monitor.Check(context.Background()))
-	require.Len(t, alerter.messages, 3)
-	assert.Contains(t, alerter.messages[2].Text, "`pds.example.com`: *81.0%* used (`81 / 100` repos)")
+	assert.Contains(t, alerter.messages[0].Title, "PDS repo limit recovered")
+	assert.Contains(t, alerter.messages[0].Text, "`pds.example.com` is no longer above the 80.0% repo-limit alert threshold")
 }
 
 func TestAccountLimitAlertMonitorBatchesMessagesWithoutQueryCap(t *testing.T) {
-	lister := &fakeAccountLimitUsageLister{
-		usages: []relay.HostAccountLimitUsage{
-			{ID: 1, Hostname: "one.example.com", AccountCount: 80, AccountLimit: 100, Usage: 0.8},
-			{ID: 2, Hostname: "two.example.com", AccountCount: 81, AccountLimit: 100, Usage: 0.81},
+	claimer := &fakeAccountLimitAlertClaimer{
+		claims: []relay.HostAccountLimitAlertClaims{
+			{
+				Warnings: []relay.HostAccountLimitUsage{
+					{ID: 1, Hostname: "one.example.com", AccountCount: 80, AccountLimit: 100, Usage: 0.8, AlertSentAt: time.Unix(1000, 0)},
+					{ID: 2, Hostname: "two.example.com", AccountCount: 81, AccountLimit: 100, Usage: 0.81, AlertSentAt: time.Unix(1000, 0)},
+				},
+			},
 		},
 	}
 	alerter := &recordingAlerter{}
 	config := DefaultAccountLimitAlertMonitorConfig()
 	config.HostsPerMessage = 1
 
-	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), lister, alerter, config)
+	monitor, err := NewAccountLimitAlertMonitor(slog.Default(), claimer, alerter, config)
 	require.NoError(t, err)
 	require.NoError(t, monitor.Check(context.Background()))
 
-	assert.Equal(t, 0, lister.lastLimit)
+	assert.Equal(t, 0, claimer.lastLimit)
 	require.Len(t, alerter.messages, 2)
 	assert.Contains(t, alerter.messages[0].Text, "one.example.com")
 	assert.Contains(t, alerter.messages[1].Text, "two.example.com")

--- a/cmd/relay/forward.go
+++ b/cmd/relay/forward.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -82,5 +86,60 @@ func (s *Service) ForwardSiblingRequest(c echo.Context, body []byte) {
 		}
 		upstreamResp.Body.Close()
 		s.logger.Info("successfully forwarded admin HTTP request", "method", req.Method, "url", u.String())
+	}
+}
+
+func (s *Service) ForwardSiblingAccountLimitAlertSent(ctx context.Context, state AccountLimitAlertSentState) {
+	if len(s.config.SiblingRelayHosts) == 0 {
+		return
+	}
+	if len(s.config.AdminPasswords) == 0 {
+		s.logger.Warn("not forwarding account limit alert sent state because no admin password is configured")
+		return
+	}
+
+	body, err := json.Marshal(state)
+	if err != nil {
+		s.logger.Error("marshaling account limit alert sent state failed", "err", err)
+		return
+	}
+	authHeader := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:"+s.config.AdminPasswords[0]))
+
+	for _, rawHost := range s.config.SiblingRelayHosts {
+		hostname, noSSL, err := relay.ParseHostname(rawHost)
+		if err != nil {
+			s.logger.Error("invalid sibling hostname configured", "host", rawHost, "err", err)
+			return
+		}
+
+		scheme := "https"
+		if noSSL {
+			scheme = "http"
+		}
+		u := fmt.Sprintf("%s://%s/admin/alerts/accountLimitSent", scheme, hostname)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+		if err != nil {
+			s.logger.Error("creating alert state forward request failed", "sibling", hostname, "err", err)
+			continue
+		}
+		req.Header.Set("Authorization", authHeader)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", s.relay.Config.UserAgent)
+		req.Header.Add("Via", "HTTP/1.1 atproto-relay")
+
+		resp, err := s.siblingClient.Do(req)
+		if err != nil {
+			s.logger.Warn("forwarded account limit alert state failed", "sibling", hostname, "kind", state.Kind, "host", state.Hostname, "err", err)
+			continue
+		}
+		if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
+			respBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			resp.Body.Close()
+			s.logger.Warn("forwarded account limit alert state failed", "sibling", hostname, "kind", state.Kind, "host", state.Hostname, "statusCode", resp.StatusCode, "body", string(respBytes))
+			continue
+		}
+		resp.Body.Close()
+		s.logger.Info("successfully forwarded account limit alert state", "sibling", hostname, "kind", state.Kind, "host", state.Hostname)
 	}
 }

--- a/cmd/relay/handlers_admin.go
+++ b/cmd/relay/handlers_admin.go
@@ -219,6 +219,10 @@ type hostInfo struct {
 	PerHourEventRate       rateLimit `json:"PerHourEventRate"`
 	PerDayEventRate        rateLimit `json:"PerDayEventRate"`
 	UserCount              int64     `json:"UserCount"`
+
+	AccountLimitAlertsSilenced bool       `json:"AccountLimitAlertsSilenced"`
+	AccountLimitAlertState     string     `json:"AccountLimitAlertState"`
+	AccountLimitAlertSentAt    *time.Time `json:"AccountLimitAlertSentAt,omitempty"`
 }
 
 func (s *Service) handleListHosts(c echo.Context) error {
@@ -252,6 +256,10 @@ func (s *Service) handleListHosts(c echo.Context) error {
 
 			HasActiveConnection: isActive,
 			UserCount:           host.AccountCount,
+
+			AccountLimitAlertsSilenced: host.AccountLimitAlertsSilenced,
+			AccountLimitAlertState:     string(host.AccountLimitAlertState),
+			AccountLimitAlertSentAt:    host.AccountLimitAlertSentAt,
 		}
 
 		// fetch current rate limits
@@ -470,8 +478,9 @@ func (s *Service) handleAdminUnbanDomain(c echo.Context) error {
 }
 
 type RateLimitChangeRequest struct {
-	Hostname  string `json:"host"`
-	RepoLimit *int64 `json:"repo_limit"`
+	Hostname                   string `json:"host"`
+	RepoLimit                  *int64 `json:"repo_limit"`
+	AccountLimitAlertsSilenced *bool  `json:"account_limit_alerts_silenced"`
 }
 
 func (s *Service) handleAdminChangeHostRateLimits(c echo.Context) error {
@@ -487,9 +496,8 @@ func (s *Service) handleAdminChangeHostRateLimits(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid hostname: %s", err))
 	}
 
-	// catch empty/nil body
-	if body.RepoLimit == nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "missing repo_limit parameter")
+	if body.RepoLimit == nil && body.AccountLimitAlertsSilenced == nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "missing repo_limit or account_limit_alerts_silenced parameter")
 	}
 
 	host, err := s.relay.GetHost(ctx, hostname)
@@ -498,8 +506,15 @@ func (s *Service) handleAdminChangeHostRateLimits(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, fmt.Sprintf("unknown hostname: %s", err))
 	}
 
-	if err := s.relay.UpdateHostAccountLimit(ctx, host.ID, *body.RepoLimit); err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to update limits: %s", err))
+	if body.RepoLimit != nil {
+		if err := s.relay.UpdateHostAccountLimit(ctx, host.ID, *body.RepoLimit); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to update limits: %s", err))
+		}
+	}
+	if body.AccountLimitAlertsSilenced != nil {
+		if err := s.relay.UpdateHostAccountLimitAlertsSilenced(ctx, host.ID, *body.AccountLimitAlertsSilenced); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to update account limit alert silence state: %s", err))
+		}
 	}
 
 	// forward on to any sibling instances

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -272,7 +272,7 @@ func safeDatabaseURLForLog(dburl string) string {
 	return u.String()
 }
 
-func configureAccountLimitAlertMonitor(cmd *cli.Command, logger *slog.Logger, r *relay.Relay) (*AccountLimitAlertMonitor, error) {
+func configureAccountLimitAlertMonitor(cmd *cli.Command, logger *slog.Logger, r *relay.Relay, sentCallback func(context.Context, AccountLimitAlertSentState)) (*AccountLimitAlertMonitor, error) {
 	slackToken := strings.TrimSpace(cmd.String("slack-alert-token"))
 	slackChannel := strings.TrimSpace(cmd.String("slack-alert-channel"))
 	if slackToken == "" && slackChannel == "" {
@@ -291,6 +291,7 @@ func configureAccountLimitAlertMonitor(cmd *cli.Command, logger *slog.Logger, r 
 	config.CheckInterval = cmd.Duration("account-limit-alert-interval")
 	config.RepeatInterval = cmd.Duration("account-limit-alert-repeat-interval")
 	config.Environment = cmd.String("env")
+	config.SentCallback = sentCallback
 
 	monitor, err := NewAccountLimitAlertMonitor(logger, r, alerter, config)
 	if err != nil {
@@ -378,9 +379,14 @@ func runRelay(ctx context.Context, cmd *cli.Command) error {
 	}
 	persister.SetUidSource(r)
 
-	alertMonitor, err := configureAccountLimitAlertMonitor(cmd, logger, r)
+	alertMonitor, err := configureAccountLimitAlertMonitor(cmd, logger, r, func(ctx context.Context, state AccountLimitAlertSentState) {
+		go svc.ForwardSiblingAccountLimitAlertSent(ctx, state)
+	})
 	if err != nil {
 		return err
+	}
+	if alertMonitor != nil {
+		svc.SetAccountLimitAlertRecorder(alertMonitor)
 	}
 	alertCtx, cancelAlerts := context.WithCancel(ctx)
 	alertDone := make(chan struct{})

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -180,6 +180,11 @@ func run(args []string) error {
 					Usage:   "minimum interval between repeated alerts for a PDS host that remains over the alert threshold",
 				},
 				&cli.StringFlag{
+					Name:    "account-limit-alert-dashboard-url",
+					Sources: cli.EnvVars("RELAY_ACCOUNT_LIMIT_ALERT_DASHBOARD_URL", "RELAY_ALERT_DASHBOARD_URL"),
+					Usage:   "optional absolute URL to include as a relay dashboard button in account-limit alerts",
+				},
+				&cli.StringFlag{
 					Name:    "slack-alert-channel",
 					Sources: cli.EnvVars("RELAY_SLACK_ALERT_CHANNEL", "RELAY_ALERT_SLACK_CHANNEL"),
 					Usage:   "Slack channel ID or name for PDS repo-limit alerts",
@@ -291,6 +296,7 @@ func configureAccountLimitAlertMonitor(cmd *cli.Command, logger *slog.Logger, r 
 	config.CheckInterval = cmd.Duration("account-limit-alert-interval")
 	config.RepeatInterval = cmd.Duration("account-limit-alert-repeat-interval")
 	config.Environment = cmd.String("env")
+	config.DashboardURL = strings.TrimSpace(cmd.String("account-limit-alert-dashboard-url"))
 	config.SentCallback = sentCallback
 
 	monitor, err := NewAccountLimitAlertMonitor(logger, r, alerter, config)

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -159,6 +161,34 @@ func run(args []string) error {
 					Sources: cli.EnvVars("ENVIRONMENT"),
 					Usage:   "declared hosting environment (prod, qa, etc); used in metrics",
 				},
+				&cli.Float64Flag{
+					Name:    "account-limit-alert-threshold",
+					Value:   0.80,
+					Sources: cli.EnvVars("RELAY_ACCOUNT_LIMIT_ALERT_THRESHOLD"),
+					Usage:   "fraction of a PDS repo limit that triggers an alert",
+				},
+				&cli.DurationFlag{
+					Name:    "account-limit-alert-interval",
+					Value:   5 * time.Minute,
+					Sources: cli.EnvVars("RELAY_ACCOUNT_LIMIT_ALERT_INTERVAL"),
+					Usage:   "how often to check for PDS hosts approaching their repo limits",
+				},
+				&cli.DurationFlag{
+					Name:    "account-limit-alert-repeat-interval",
+					Value:   6 * time.Hour,
+					Sources: cli.EnvVars("RELAY_ACCOUNT_LIMIT_ALERT_REPEAT_INTERVAL"),
+					Usage:   "minimum interval between repeated alerts for a PDS host that remains over the alert threshold",
+				},
+				&cli.StringFlag{
+					Name:    "slack-alert-channel",
+					Sources: cli.EnvVars("RELAY_SLACK_ALERT_CHANNEL", "RELAY_ALERT_SLACK_CHANNEL"),
+					Usage:   "Slack channel ID or name for PDS repo-limit alerts",
+				},
+				&cli.StringFlag{
+					Name:    "slack-alert-token",
+					Sources: cli.EnvVars("RELAY_SLACK_ALERT_TOKEN", "RELAY_ALERT_SLACK_TOKEN"),
+					Usage:   "Slack bot token for PDS repo-limit alerts; environment variables are recommended",
+				},
 				&cli.BoolFlag{
 					Name: "enable-db-tracing",
 				},
@@ -209,6 +239,66 @@ func configLogger(cmd *cli.Command, writer io.Writer) *slog.Logger {
 	return logger
 }
 
+func safeDatabaseURLForLog(dburl string) string {
+	if strings.HasPrefix(dburl, "sqlite://") || strings.HasPrefix(dburl, "sqlite=") {
+		return dburl
+	}
+	if strings.HasPrefix(dburl, "postgres=") {
+		return "postgres=<redacted>"
+	}
+
+	u, err := url.Parse(dburl)
+	if err != nil || u.Scheme == "" {
+		return "<redacted>"
+	}
+	if u.User != nil {
+		username := u.User.Username()
+		if username == "" {
+			u.User = url.UserPassword("xxxxx", "xxxxx")
+		} else {
+			u.User = url.UserPassword(username, "xxxxx")
+		}
+	}
+	if u.RawQuery != "" {
+		q := u.Query()
+		for k := range q {
+			lowerKey := strings.ToLower(k)
+			if strings.Contains(lowerKey, "pass") || strings.Contains(lowerKey, "token") || strings.Contains(lowerKey, "secret") {
+				q.Set(k, "xxxxx")
+			}
+		}
+		u.RawQuery = q.Encode()
+	}
+	return u.String()
+}
+
+func configureAccountLimitAlertMonitor(cmd *cli.Command, logger *slog.Logger, r *relay.Relay) (*AccountLimitAlertMonitor, error) {
+	slackToken := strings.TrimSpace(cmd.String("slack-alert-token"))
+	slackChannel := strings.TrimSpace(cmd.String("slack-alert-channel"))
+	if slackToken == "" && slackChannel == "" {
+		return nil, nil
+	}
+	if slackToken == "" || slackChannel == "" {
+		return nil, fmt.Errorf("both slack alert token and slack alert channel are required when relay account-limit alerting is configured")
+	}
+
+	alerter, err := NewSlackAlerter(slackToken, slackChannel)
+	if err != nil {
+		return nil, err
+	}
+	config := DefaultAccountLimitAlertMonitorConfig()
+	config.Threshold = cmd.Float64("account-limit-alert-threshold")
+	config.CheckInterval = cmd.Duration("account-limit-alert-interval")
+	config.RepeatInterval = cmd.Duration("account-limit-alert-repeat-interval")
+	config.Environment = cmd.String("env")
+
+	monitor, err := NewAccountLimitAlertMonitor(logger, r, alerter, config)
+	if err != nil {
+		return nil, err
+	}
+	return monitor, nil
+}
+
 func runRelay(ctx context.Context, cmd *cli.Command) error {
 	logger := configLogger(cmd, os.Stdout)
 
@@ -218,7 +308,7 @@ func runRelay(ctx context.Context, cmd *cli.Command) error {
 
 	dburl := cmd.String("db-url")
 	maxConn := cmd.Int("max-db-conn")
-	logger.Info("configuring database", "url", dburl, "maxConn", maxConn)
+	logger.Info("configuring database", "url", safeDatabaseURLForLog(dburl), "maxConn", maxConn)
 	db, err := cliutil.SetupDatabase(dburl, maxConn)
 	if err != nil {
 		return err
@@ -288,6 +378,34 @@ func runRelay(ctx context.Context, cmd *cli.Command) error {
 	}
 	persister.SetUidSource(r)
 
+	alertMonitor, err := configureAccountLimitAlertMonitor(cmd, logger, r)
+	if err != nil {
+		return err
+	}
+	alertCtx, cancelAlerts := context.WithCancel(ctx)
+	alertDone := make(chan struct{})
+	if alertMonitor != nil {
+		logger.Info("starting PDS account-limit alert monitor", "threshold", cmd.Float64("account-limit-alert-threshold"), "interval", cmd.Duration("account-limit-alert-interval"), "repeatInterval", cmd.Duration("account-limit-alert-repeat-interval"), "slackChannel", cmd.String("slack-alert-channel"))
+		go func() {
+			defer close(alertDone)
+			alertMonitor.Run(alertCtx)
+		}()
+	} else {
+		close(alertDone)
+	}
+	var stopAlertsOnce sync.Once
+	stopAlerts := func() {
+		stopAlertsOnce.Do(func() {
+			cancelAlerts()
+			select {
+			case <-alertDone:
+			case <-time.After(5 * time.Second):
+				logger.Warn("timed out waiting for account-limit alert monitor to stop")
+			}
+		})
+	}
+	defer stopAlerts()
+
 	// start metrics endpoint
 	go func() {
 		if err := svc.StartMetrics(cmd.String("metrics-listen")); err != nil {
@@ -321,6 +439,7 @@ func runRelay(ctx context.Context, cmd *cli.Command) error {
 	select {
 	case <-signals:
 		logger.Info("received shutdown signal")
+		stopAlerts()
 		errs := svc.Shutdown()
 		for err := range errs {
 			logger.Error("error during shutdown", "err", err)
@@ -330,6 +449,7 @@ func runRelay(ctx context.Context, cmd *cli.Command) error {
 			logger.Error("error during startup", "err", err)
 		}
 		logger.Info("shutting down")
+		stopAlerts()
 		errs := svc.Shutdown()
 		for err := range errs {
 			logger.Error("error during shutdown", "err", err)

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -391,9 +391,6 @@ func runRelay(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
-	if alertMonitor != nil {
-		svc.SetAccountLimitAlertRecorder(alertMonitor)
-	}
 	alertCtx, cancelAlerts := context.WithCancel(ctx)
 	alertDone := make(chan struct{})
 	if alertMonitor != nil {

--- a/cmd/relay/main_test.go
+++ b/cmd/relay/main_test.go
@@ -1,9 +1,17 @@
 package main
 
 import (
+	"io"
+	"net"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/bluesky-social/indigo/cmd/relay/relay"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSafeDatabaseURLForLog(t *testing.T) {
@@ -11,4 +19,79 @@ func TestSafeDatabaseURLForLog(t *testing.T) {
 	assert.Equal(t, "postgres=<redacted>", safeDatabaseURLForLog("postgres=host=localhost user=relay password=secret dbname=relay"))
 	assert.Equal(t, "postgres://relay:xxxxx@localhost:5432/relay?sslmode=disable", safeDatabaseURLForLog("postgres://relay:secret@localhost:5432/relay?sslmode=disable"))
 	assert.Equal(t, "postgres://localhost:5432/relay?password=xxxxx&sslmode=disable", safeDatabaseURLForLog("postgres://localhost:5432/relay?sslmode=disable&password=secret"))
+}
+
+func TestAdminRoutesRequireAdminAuth(t *testing.T) {
+	svc, err := NewService(&relay.Relay{
+		Config: relay.RelayConfig{
+			UserAgent: "indigo-relay-test",
+		},
+	}, &ServiceConfig{
+		AdminPasswords:      []string{"correct-password"},
+		ListenerBootTimeout: time.Second,
+	})
+	require.NoError(t, err)
+
+	li, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer li.Close()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- svc.startWithListener(li)
+	}()
+
+	client := &http.Client{Timeout: time.Second}
+	routes := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{method: http.MethodGet, path: "/admin/pds/list"},
+		{method: http.MethodPost, path: "/admin/pds/changeLimits", body: `{}`},
+		{method: http.MethodPost, path: "/admin/alerts/accountLimitSent", body: `{}`},
+	}
+
+	for _, route := range routes {
+		t.Run(route.method+" "+route.path+" without auth", func(t *testing.T) {
+			req, err := http.NewRequest(route.method, "http://"+li.Addr().String()+route.path, strings.NewReader(route.body))
+			require.NoError(t, err)
+			if route.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			_, _ = io.Copy(io.Discard, resp.Body)
+
+			assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+			assert.Equal(t, "Basic", resp.Header.Get("WWW-Authenticate"))
+		})
+
+		t.Run(route.method+" "+route.path+" with wrong auth", func(t *testing.T) {
+			req, err := http.NewRequest(route.method, "http://"+li.Addr().String()+route.path, strings.NewReader(route.body))
+			require.NoError(t, err)
+			if route.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+			req.SetBasicAuth("admin", "wrong-password")
+
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			_, _ = io.Copy(io.Discard, resp.Body)
+
+			assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+			assert.Equal(t, "Basic", resp.Header.Get("WWW-Authenticate"))
+		})
+	}
+
+	require.NoError(t, li.Close())
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for test relay server to stop")
+	}
 }

--- a/cmd/relay/main_test.go
+++ b/cmd/relay/main_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeDatabaseURLForLog(t *testing.T) {
+	assert.Equal(t, "sqlite://data/relay/relay.sqlite", safeDatabaseURLForLog("sqlite://data/relay/relay.sqlite"))
+	assert.Equal(t, "postgres=<redacted>", safeDatabaseURLForLog("postgres=host=localhost user=relay password=secret dbname=relay"))
+	assert.Equal(t, "postgres://relay:xxxxx@localhost:5432/relay?sslmode=disable", safeDatabaseURLForLog("postgres://relay:secret@localhost:5432/relay?sslmode=disable"))
+	assert.Equal(t, "postgres://localhost:5432/relay?password=xxxxx&sslmode=disable", safeDatabaseURLForLog("postgres://localhost:5432/relay?sslmode=disable&password=secret"))
+}

--- a/cmd/relay/relay-admin-ui/src/components/Dash/Dash.tsx
+++ b/cmd/relay/relay-admin-ui/src/components/Dash/Dash.tsx
@@ -412,6 +412,55 @@ const Dash: FC<{}> = () => {
     });
   };
 
+  const updateAccountLimitAlertsSilenced = (pds: PDS, silenced: boolean) => {
+    const applyOptimisticSilenceState = (list: PDS[] | null): PDS[] | null => {
+      if (!list) {
+        return list;
+      }
+      return list.map((item) => {
+        if (item.ID !== pds.ID) {
+          return item;
+        }
+        return {
+          ...item,
+          AccountLimitAlertsSilenced: silenced,
+          AccountLimitAlertState: silenced ? "ok" : item.AccountLimitAlertState,
+          AccountLimitAlertSentAt: silenced ? undefined : item.AccountLimitAlertSentAt,
+        };
+      });
+    };
+
+    setPDSList(applyOptimisticSilenceState);
+    setFullPDSList(applyOptimisticSilenceState);
+
+    fetch(`${RELAY_HOST}/admin/pds/changeLimits`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ` + btoa("admin:" + adminToken),
+      },
+      body: JSON.stringify({
+        host: pds.Host,
+        account_limit_alerts_silenced: silenced,
+      }),
+    }).then((res) => {
+      if (res.status !== 200) {
+        setAlertWithTimeout(
+          "failure",
+          `Failed to ${silenced ? "silence" : "unsilence"} account limit alerts: ${res.statusText} (${res.status})`,
+          true
+        );
+      } else {
+        setAlertWithTimeout(
+          "success",
+          `Successfully ${silenced ? "silenced" : "unsilenced"} account limit alerts`,
+          true
+        );
+      }
+      refreshPDSList();
+    });
+  };
+
   const handleBlockClick = (pds: PDS, shouldBlock: boolean) => {
     setModalAction({
       type: shouldBlock ? "block" : "disconnect",
@@ -862,6 +911,14 @@ const Dash: FC<{}> = () => {
                 </th>
                 <th
                   scope="col"
+                  className="px-3 py-3.5 text-center text-sm font-semibold text-gray-900 pr-6 whitespace-nowrap"
+                >
+                  <a href="#" className="group inline-flex">
+                    Alerts
+                  </a>
+                </th>
+                <th
+                  scope="col"
                   className="px-3 py-3.5 text-right text-sm font-semibold text-gray-900 pr-6 whitespace-nowrap"
                 >
                   <a
@@ -1061,6 +1118,39 @@ const Dash: FC<{}> = () => {
                             aria-hidden="true"
                           />
                         </a>
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-sm text-gray-400 text-center w-8 pr-6">
+                        <button
+                          className={
+                            "rounded-md p-1.5 focus:outline-none focus:ring-2 focus:ring-offset-2 " +
+                            (pds.AccountLimitAlertsSilenced
+                              ? "text-amber-600 hover:text-green-600 hover:bg-green-100 focus:ring-green-600 focus:ring-offset-green-50"
+                              : "text-green-600 hover:text-amber-600 hover:bg-amber-100 focus:ring-amber-600 focus:ring-offset-amber-50")
+                          }
+                          title={
+                            pds.AccountLimitAlertsSilenced
+                              ? "Resume account limit alerts"
+                              : "Silence account limit alerts"
+                          }
+                          onClick={() => {
+                            updateAccountLimitAlertsSilenced(
+                              pds,
+                              !pds.AccountLimitAlertsSilenced
+                            );
+                          }}
+                        >
+                          {pds.AccountLimitAlertsSilenced ? (
+                            <ShieldExclamationIcon
+                              className="h-5 w-5 inline-block"
+                              aria-hidden="true"
+                            />
+                          ) : (
+                            <ShieldCheckIcon
+                              className="h-5 w-5 inline-block"
+                              aria-hidden="true"
+                            />
+                          )}
+                        </button>
                       </td>
                       <td className="whitespace-nowrap px-3 py-2 text-sm text-gray-400 text-center w-8 pr-6">
                         {new Date(Date.parse(pds.CreatedAt)).toLocaleString()}

--- a/cmd/relay/relay-admin-ui/src/models/pds.ts
+++ b/cmd/relay/relay-admin-ui/src/models/pds.ts
@@ -21,6 +21,9 @@ interface PDS {
   PerDayEventRate: RateLimit;
   RepoCount: number;
   RepoLimit: number;
+  AccountLimitAlertsSilenced: boolean;
+  AccountLimitAlertState: string;
+  AccountLimitAlertSentAt?: string;
 }
 
 type PDSKey = keyof PDS;

--- a/cmd/relay/relay/host_usage.go
+++ b/cmd/relay/relay/host_usage.go
@@ -1,0 +1,58 @@
+package relay
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/bluesky-social/indigo/cmd/relay/relay/models"
+)
+
+type HostAccountLimitUsage struct {
+	ID           uint64
+	Hostname     string
+	AccountCount int64
+	AccountLimit int64
+	Usage        float64
+}
+
+func (r *Relay) ListHostsApproachingAccountLimit(ctx context.Context, threshold float64, limit int) ([]HostAccountLimitUsage, error) {
+	if threshold <= 0 || threshold > 1 {
+		return nil, fmt.Errorf("account limit alert threshold must be greater than 0 and less than or equal to 1")
+	}
+	if limit < 0 {
+		return nil, fmt.Errorf("account limit alert query limit must not be negative")
+	}
+
+	var hosts []models.Host
+	query := r.db.WithContext(ctx).
+		Model(&models.Host{}).
+		Where("account_limit > 0 AND account_count >= account_limit * ? AND status <> ?", threshold, models.HostStatusBanned).
+		Order("account_count * 1.0 / account_limit DESC, id ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	if err := query.Find(&hosts).Error; err != nil {
+		return nil, err
+	}
+
+	out := make([]HostAccountLimitUsage, 0, len(hosts))
+	for _, h := range hosts {
+		out = append(out, HostAccountLimitUsage{
+			ID:           h.ID,
+			Hostname:     h.Hostname,
+			AccountCount: h.AccountCount,
+			AccountLimit: h.AccountLimit,
+			Usage:        float64(h.AccountCount) / float64(h.AccountLimit),
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Usage == out[j].Usage {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].Usage > out[j].Usage
+	})
+
+	return out, nil
+}

--- a/cmd/relay/relay/host_usage.go
+++ b/cmd/relay/relay/host_usage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/bluesky-social/indigo/cmd/relay/relay/models"
 )
@@ -14,6 +15,12 @@ type HostAccountLimitUsage struct {
 	AccountCount int64
 	AccountLimit int64
 	Usage        float64
+	AlertSentAt  time.Time
+}
+
+type HostAccountLimitAlertClaims struct {
+	Warnings   []HostAccountLimitUsage
+	Recoveries []HostAccountLimitUsage
 }
 
 func (r *Relay) ListHostsApproachingAccountLimit(ctx context.Context, threshold float64, limit int) ([]HostAccountLimitUsage, error) {
@@ -55,4 +62,149 @@ func (r *Relay) ListHostsApproachingAccountLimit(ctx context.Context, threshold 
 	})
 
 	return out, nil
+}
+
+func (r *Relay) ClaimDueAccountLimitAlerts(ctx context.Context, threshold float64, repeatInterval time.Duration, limit int) (*HostAccountLimitAlertClaims, error) {
+	if threshold <= 0 || threshold > 1 {
+		return nil, fmt.Errorf("account limit alert threshold must be greater than 0 and less than or equal to 1")
+	}
+	if repeatInterval <= 0 {
+		return nil, fmt.Errorf("account limit alert repeat interval must be positive")
+	}
+	if limit < 0 {
+		return nil, fmt.Errorf("account limit alert query limit must not be negative")
+	}
+
+	now := time.Now().UTC()
+	cutoff := now.Add(-repeatInterval)
+
+	warnings, err := r.claimDueAccountLimitWarnings(ctx, threshold, cutoff, now, limit)
+	if err != nil {
+		return nil, err
+	}
+	recoveries, err := r.claimDueAccountLimitRecoveries(ctx, threshold, now, limit)
+	if err != nil {
+		return nil, err
+	}
+	return &HostAccountLimitAlertClaims{
+		Warnings:   warnings,
+		Recoveries: recoveries,
+	}, nil
+}
+
+func (r *Relay) claimDueAccountLimitWarnings(ctx context.Context, threshold float64, cutoff time.Time, now time.Time, limit int) ([]HostAccountLimitUsage, error) {
+	var hosts []models.Host
+	query := r.db.WithContext(ctx).
+		Model(&models.Host{}).
+		Where("account_limit > 0 AND account_count >= account_limit * ? AND status <> ? AND account_limit_alerts_silenced = ?", threshold, models.HostStatusBanned, false).
+		Where("(account_limit_alert_state <> ? OR account_limit_alert_state IS NULL OR account_limit_alert_sent_at IS NULL OR account_limit_alert_sent_at <= ?)", models.HostAccountLimitAlertStateWarning, cutoff).
+		Order("account_count * 1.0 / account_limit DESC, id ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	if err := query.Find(&hosts).Error; err != nil {
+		return nil, err
+	}
+
+	out := make([]HostAccountLimitUsage, 0, len(hosts))
+	for _, host := range hosts {
+		result := r.db.WithContext(ctx).Model(&models.Host{}).
+			Where("id = ? AND account_limit > 0 AND account_count >= account_limit * ? AND status <> ? AND account_limit_alerts_silenced = ?", host.ID, threshold, models.HostStatusBanned, false).
+			Where("(account_limit_alert_state <> ? OR account_limit_alert_state IS NULL OR account_limit_alert_sent_at IS NULL OR account_limit_alert_sent_at <= ?)", models.HostAccountLimitAlertStateWarning, cutoff).
+			Updates(map[string]any{
+				"account_limit_alert_state":   models.HostAccountLimitAlertStateWarning,
+				"account_limit_alert_sent_at": now,
+			})
+		if result.Error != nil {
+			return nil, result.Error
+		}
+		if result.RowsAffected == 0 {
+			continue
+		}
+		out = append(out, hostAccountLimitUsage(host, now))
+	}
+	return out, nil
+}
+
+func (r *Relay) claimDueAccountLimitRecoveries(ctx context.Context, threshold float64, now time.Time, limit int) ([]HostAccountLimitUsage, error) {
+	var hosts []models.Host
+	query := r.db.WithContext(ctx).
+		Model(&models.Host{}).
+		Where("account_limit > 0 AND account_count < account_limit * ? AND status <> ? AND account_limit_alerts_silenced = ? AND account_limit_alert_state = ?", threshold, models.HostStatusBanned, false, models.HostAccountLimitAlertStateWarning).
+		Order("account_count * 1.0 / account_limit DESC, id ASC")
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	if err := query.Find(&hosts).Error; err != nil {
+		return nil, err
+	}
+
+	out := make([]HostAccountLimitUsage, 0, len(hosts))
+	for _, host := range hosts {
+		result := r.db.WithContext(ctx).Model(&models.Host{}).
+			Where("id = ? AND account_limit > 0 AND account_count < account_limit * ? AND status <> ? AND account_limit_alerts_silenced = ? AND account_limit_alert_state = ?", host.ID, threshold, models.HostStatusBanned, false, models.HostAccountLimitAlertStateWarning).
+			Updates(map[string]any{
+				"account_limit_alert_state":   models.HostAccountLimitAlertStateOK,
+				"account_limit_alert_sent_at": now,
+			})
+		if result.Error != nil {
+			return nil, result.Error
+		}
+		if result.RowsAffected == 0 {
+			continue
+		}
+		out = append(out, hostAccountLimitUsage(host, now))
+	}
+	return out, nil
+}
+
+func (r *Relay) RecordHostAccountLimitAlertSent(ctx context.Context, hostname string, state models.HostAccountLimitAlertState, sentAt time.Time) error {
+	switch state {
+	case models.HostAccountLimitAlertStateOK, models.HostAccountLimitAlertStateWarning:
+	default:
+		return fmt.Errorf("invalid account limit alert state: %s", state)
+	}
+	if sentAt.IsZero() {
+		sentAt = time.Now().UTC()
+	}
+	result := r.db.WithContext(ctx).Model(&models.Host{}).
+		Where("hostname = ? AND account_limit_alerts_silenced = ?", hostname, false).
+		Where("account_limit_alert_sent_at IS NULL OR account_limit_alert_sent_at <= ?", sentAt).
+		Updates(map[string]any{
+			"account_limit_alert_state":   state,
+			"account_limit_alert_sent_at": sentAt,
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+func (r *Relay) UpdateHostAccountLimitAlertsSilenced(ctx context.Context, hostID uint64, silenced bool) error {
+	updates := map[string]any{
+		"account_limit_alerts_silenced": silenced,
+	}
+	if silenced {
+		updates["account_limit_alert_state"] = models.HostAccountLimitAlertStateOK
+		updates["account_limit_alert_sent_at"] = nil
+	}
+	result := r.db.WithContext(ctx).Model(models.Host{}).Where("id = ?", hostID).Updates(updates)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrHostNotFound
+	}
+	return nil
+}
+
+func hostAccountLimitUsage(h models.Host, alertSentAt time.Time) HostAccountLimitUsage {
+	return HostAccountLimitUsage{
+		ID:           h.ID,
+		Hostname:     h.Hostname,
+		AccountCount: h.AccountCount,
+		AccountLimit: h.AccountLimit,
+		Usage:        float64(h.AccountCount) / float64(h.AccountLimit),
+		AlertSentAt:  alertSentAt,
+	}
 }

--- a/cmd/relay/relay/host_usage_test.go
+++ b/cmd/relay/relay/host_usage_test.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/bluesky-social/indigo/cmd/relay/relay/models"
 
@@ -12,10 +13,16 @@ import (
 	"gorm.io/gorm"
 )
 
-func TestListHostsApproachingAccountLimit(t *testing.T) {
+func testRelayWithHostDB(t *testing.T) (*Relay, *gorm.DB) {
+	t.Helper()
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 	require.NoError(t, db.AutoMigrate(&models.Host{}))
+	return &Relay{db: db}, db
+}
+
+func TestListHostsApproachingAccountLimit(t *testing.T) {
+	r, db := testRelayWithHostDB(t)
 
 	hosts := []models.Host{
 		{Hostname: "below.example.com", AccountCount: 79, AccountLimit: 100, Status: models.HostStatusActive},
@@ -27,7 +34,6 @@ func TestListHostsApproachingAccountLimit(t *testing.T) {
 		require.NoError(t, db.Create(&host).Error)
 	}
 
-	r := &Relay{db: db}
 	usages, err := r.ListHostsApproachingAccountLimit(context.Background(), 0.80, 10)
 	require.NoError(t, err)
 	require.Len(t, usages, 2)
@@ -37,6 +43,139 @@ func TestListHostsApproachingAccountLimit(t *testing.T) {
 	assert.Equal(t, int64(50), usages[0].AccountLimit)
 	assert.Equal(t, 0.90, usages[0].Usage)
 	assert.Equal(t, "at.example.com", usages[1].Hostname)
+}
+
+func TestClaimDueAccountLimitAlertsPersistsWarningState(t *testing.T) {
+	ctx := context.Background()
+	r, db := testRelayWithHostDB(t)
+	require.NoError(t, db.Create(&models.Host{
+		Hostname:     "over.example.com",
+		AccountCount: 85,
+		AccountLimit: 100,
+		Status:       models.HostStatusActive,
+	}).Error)
+
+	claims, err := r.ClaimDueAccountLimitAlerts(ctx, 0.8, time.Hour, 0)
+	require.NoError(t, err)
+	require.Len(t, claims.Warnings, 1)
+	require.Empty(t, claims.Recoveries)
+	assert.Equal(t, "over.example.com", claims.Warnings[0].Hostname)
+	assert.False(t, claims.Warnings[0].AlertSentAt.IsZero())
+
+	claims, err = r.ClaimDueAccountLimitAlerts(ctx, 0.8, time.Hour, 0)
+	require.NoError(t, err)
+	require.Empty(t, claims.Warnings)
+	require.Empty(t, claims.Recoveries)
+
+	var host models.Host
+	require.NoError(t, db.First(&host, "hostname = ?", "over.example.com").Error)
+	assert.Equal(t, models.HostAccountLimitAlertStateWarning, host.AccountLimitAlertState)
+	require.NotNil(t, host.AccountLimitAlertSentAt)
+}
+
+func TestClaimDueAccountLimitAlertsRepeatsAfterInterval(t *testing.T) {
+	ctx := context.Background()
+	r, db := testRelayWithHostDB(t)
+	oldSentAt := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, db.Create(&models.Host{
+		Hostname:                "over.example.com",
+		AccountCount:            85,
+		AccountLimit:            100,
+		Status:                  models.HostStatusActive,
+		AccountLimitAlertState:  models.HostAccountLimitAlertStateWarning,
+		AccountLimitAlertSentAt: &oldSentAt,
+	}).Error)
+
+	claims, err := r.ClaimDueAccountLimitAlerts(ctx, 0.8, time.Hour, 0)
+	require.NoError(t, err)
+	require.Len(t, claims.Warnings, 1)
+	require.Empty(t, claims.Recoveries)
+}
+
+func TestClaimDueAccountLimitAlertsClaimsRecovery(t *testing.T) {
+	ctx := context.Background()
+	r, db := testRelayWithHostDB(t)
+	sentAt := time.Now().Add(-time.Hour)
+	require.NoError(t, db.Create(&models.Host{
+		Hostname:                "recovered.example.com",
+		AccountCount:            20,
+		AccountLimit:            100,
+		Status:                  models.HostStatusActive,
+		AccountLimitAlertState:  models.HostAccountLimitAlertStateWarning,
+		AccountLimitAlertSentAt: &sentAt,
+	}).Error)
+
+	claims, err := r.ClaimDueAccountLimitAlerts(ctx, 0.8, time.Hour, 0)
+	require.NoError(t, err)
+	require.Empty(t, claims.Warnings)
+	require.Len(t, claims.Recoveries, 1)
+	assert.Equal(t, "recovered.example.com", claims.Recoveries[0].Hostname)
+
+	var host models.Host
+	require.NoError(t, db.First(&host, "hostname = ?", "recovered.example.com").Error)
+	assert.Equal(t, models.HostAccountLimitAlertStateOK, host.AccountLimitAlertState)
+}
+
+func TestClaimDueAccountLimitAlertsSkipsSilencedHosts(t *testing.T) {
+	ctx := context.Background()
+	r, db := testRelayWithHostDB(t)
+	require.NoError(t, db.Create(&models.Host{
+		Hostname:                   "silenced.example.com",
+		AccountCount:               95,
+		AccountLimit:               100,
+		Status:                     models.HostStatusActive,
+		AccountLimitAlertsSilenced: true,
+	}).Error)
+
+	claims, err := r.ClaimDueAccountLimitAlerts(ctx, 0.8, time.Hour, 0)
+	require.NoError(t, err)
+	require.Empty(t, claims.Warnings)
+	require.Empty(t, claims.Recoveries)
+}
+
+func TestUpdateHostAccountLimitAlertsSilencedResetsAlertState(t *testing.T) {
+	ctx := context.Background()
+	r, db := testRelayWithHostDB(t)
+	sentAt := time.Now().Add(-time.Hour)
+	host := models.Host{
+		Hostname:                "silence-me.example.com",
+		AccountCount:            95,
+		AccountLimit:            100,
+		Status:                  models.HostStatusActive,
+		AccountLimitAlertState:  models.HostAccountLimitAlertStateWarning,
+		AccountLimitAlertSentAt: &sentAt,
+	}
+	require.NoError(t, db.Create(&host).Error)
+
+	require.NoError(t, r.UpdateHostAccountLimitAlertsSilenced(ctx, host.ID, true))
+
+	var updated models.Host
+	require.NoError(t, db.First(&updated, host.ID).Error)
+	assert.True(t, updated.AccountLimitAlertsSilenced)
+	assert.Equal(t, models.HostAccountLimitAlertStateOK, updated.AccountLimitAlertState)
+	assert.Nil(t, updated.AccountLimitAlertSentAt)
+}
+
+func TestRecordHostAccountLimitAlertSentIgnoresStaleState(t *testing.T) {
+	ctx := context.Background()
+	r, db := testRelayWithHostDB(t)
+	newerSentAt := time.Now()
+	require.NoError(t, db.Create(&models.Host{
+		Hostname:                "state.example.com",
+		AccountCount:            95,
+		AccountLimit:            100,
+		Status:                  models.HostStatusActive,
+		AccountLimitAlertState:  models.HostAccountLimitAlertStateWarning,
+		AccountLimitAlertSentAt: &newerSentAt,
+	}).Error)
+
+	require.NoError(t, r.RecordHostAccountLimitAlertSent(ctx, "state.example.com", models.HostAccountLimitAlertStateOK, newerSentAt.Add(-time.Minute)))
+
+	var host models.Host
+	require.NoError(t, db.First(&host, "hostname = ?", "state.example.com").Error)
+	assert.Equal(t, models.HostAccountLimitAlertStateWarning, host.AccountLimitAlertState)
+	require.NotNil(t, host.AccountLimitAlertSentAt)
+	assert.True(t, host.AccountLimitAlertSentAt.Equal(newerSentAt))
 }
 
 func TestListHostsApproachingAccountLimitRejectsInvalidThreshold(t *testing.T) {

--- a/cmd/relay/relay/host_usage_test.go
+++ b/cmd/relay/relay/host_usage_test.go
@@ -1,0 +1,50 @@
+package relay
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bluesky-social/indigo/cmd/relay/relay/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestListHostsApproachingAccountLimit(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.Host{}))
+
+	hosts := []models.Host{
+		{Hostname: "below.example.com", AccountCount: 79, AccountLimit: 100, Status: models.HostStatusActive},
+		{Hostname: "at.example.com", AccountCount: 80, AccountLimit: 100, Status: models.HostStatusActive},
+		{Hostname: "over.example.com", AccountCount: 45, AccountLimit: 50, Status: models.HostStatusActive},
+		{Hostname: "banned.example.com", AccountCount: 100, AccountLimit: 100, Status: models.HostStatusBanned},
+	}
+	for _, host := range hosts {
+		require.NoError(t, db.Create(&host).Error)
+	}
+
+	r := &Relay{db: db}
+	usages, err := r.ListHostsApproachingAccountLimit(context.Background(), 0.80, 10)
+	require.NoError(t, err)
+	require.Len(t, usages, 2)
+
+	assert.Equal(t, "over.example.com", usages[0].Hostname)
+	assert.Equal(t, int64(45), usages[0].AccountCount)
+	assert.Equal(t, int64(50), usages[0].AccountLimit)
+	assert.Equal(t, 0.90, usages[0].Usage)
+	assert.Equal(t, "at.example.com", usages[1].Hostname)
+}
+
+func TestListHostsApproachingAccountLimitRejectsInvalidThreshold(t *testing.T) {
+	r := &Relay{}
+	_, err := r.ListHostsApproachingAccountLimit(context.Background(), 0, 10)
+	require.Error(t, err)
+	_, err = r.ListHostsApproachingAccountLimit(context.Background(), 1.1, 10)
+	require.Error(t, err)
+	_, err = r.ListHostsApproachingAccountLimit(context.Background(), 0.8, -1)
+	require.Error(t, err)
+}

--- a/cmd/relay/relay/models/models.go
+++ b/cmd/relay/relay/models/models.go
@@ -22,6 +22,13 @@ const (
 	HostStatusBanned    = HostStatus("banned")
 )
 
+type HostAccountLimitAlertState string
+
+const (
+	HostAccountLimitAlertStateOK      = HostAccountLimitAlertState("ok")
+	HostAccountLimitAlertStateWarning = HostAccountLimitAlertState("warning")
+)
+
 type Host struct {
 	ID uint64 `gorm:"column:id;primarykey" json:"id"`
 
@@ -48,6 +55,15 @@ type Host struct {
 
 	// represents the number of accounts on the host, minus any in "deleted" state
 	AccountCount int64 `gorm:"column:account_count;default:0" json:"accountCount"`
+
+	// if true, account-limit alerting is disabled for this host
+	AccountLimitAlertsSilenced bool `gorm:"column:account_limit_alerts_silenced;default:false" json:"accountLimitAlertsSilenced"`
+
+	// persisted account-limit alert state, used to avoid duplicate alerts across process restarts
+	AccountLimitAlertState HostAccountLimitAlertState `gorm:"column:account_limit_alert_state;default:ok" json:"accountLimitAlertState"`
+
+	// last account-limit warning or recovery alert send time
+	AccountLimitAlertSentAt *time.Time `gorm:"column:account_limit_alert_sent_at" json:"accountLimitAlertSentAt,omitempty"`
 }
 
 func (Host) TableName() string {

--- a/cmd/relay/service.go
+++ b/cmd/relay/service.go
@@ -24,12 +24,6 @@ type Service struct {
 	config ServiceConfig
 
 	siblingClient http.Client
-
-	accountLimitAlertRecorder accountLimitAlertRecorder
-}
-
-type accountLimitAlertRecorder interface {
-	RecordAccountLimitAlertSent(state AccountLimitAlertSentState) error
 }
 
 type ServiceConfig struct {
@@ -71,10 +65,6 @@ func NewService(r *relay.Relay, config *ServiceConfig) (*Service, error) {
 	}
 
 	return svc, nil
-}
-
-func (svc *Service) SetAccountLimitAlertRecorder(recorder accountLimitAlertRecorder) {
-	svc.accountLimitAlertRecorder = recorder
 }
 
 func (svc *Service) StartMetrics(listen string) error {

--- a/cmd/relay/service.go
+++ b/cmd/relay/service.go
@@ -24,6 +24,12 @@ type Service struct {
 	config ServiceConfig
 
 	siblingClient http.Client
+
+	accountLimitAlertRecorder accountLimitAlertRecorder
+}
+
+type accountLimitAlertRecorder interface {
+	RecordAccountLimitAlertSent(state AccountLimitAlertSentState) error
 }
 
 type ServiceConfig struct {
@@ -65,6 +71,10 @@ func NewService(r *relay.Relay, config *ServiceConfig) (*Service, error) {
 	}
 
 	return svc, nil
+}
+
+func (svc *Service) SetAccountLimitAlertRecorder(recorder accountLimitAlertRecorder) {
+	svc.accountLimitAlertRecorder = recorder
 }
 
 func (svc *Service) StartMetrics(listen string) error {
@@ -182,6 +192,9 @@ func (svc *Service) startWithListener(listen net.Listener) error {
 	admin.POST("/pds/block", svc.handleBlockHost)
 	admin.POST("/pds/unblock", svc.handleUnblockHost)
 	// removed: admin.POST("/pds/addTrustedDomain", svc.handleAdminAddTrustedDomain)
+
+	// Alert-related Admin API
+	admin.POST("/alerts/accountLimitSent", svc.handleAdminRecordAccountLimitAlertSent)
 
 	// Consumer-related Admin API
 	admin.GET("/consumers/list", svc.handleAdminListConsumers)


### PR DESCRIPTION
## Summary

This adds Slack alerting for relay PDS hosts that are getting close to their repo/account limit. The monitor is off unless Slack alert config is provided, and it defaults to alerting at 80% of the host limit.

The monitor checks on a configurable interval, with up to +/-1 minute of jitter so multiple relay instances started at the same time are less likely to race each other. Hosts that remain over threshold are re-alerted only after the repeat interval. When a host drops back below threshold, the relay sends a simple recovery alert.

## Behavior

- Adds `RELAY_SLACK_ALERT_CHANNEL` / `RELAY_SLACK_ALERT_TOKEN` for Slack delivery, plus `RELAY_ACCOUNT_LIMIT_ALERT_THRESHOLD`, `RELAY_ACCOUNT_LIMIT_ALERT_INTERVAL`, `RELAY_ACCOUNT_LIMIT_ALERT_REPEAT_INTERVAL`, and optional `RELAY_ACCOUNT_LIMIT_ALERT_DASHBOARD_URL`.
- Sends Block Kit Slack messages with the environment, threshold, repo counts, and hostnames. The dashboard URL, when configured, is included as a button.
- Persists alert state on each host: whether alerts are silenced, the current alert state, and the last sent time. This prevents relay restarts from immediately re-sending alerts that were already sent.
- Claims due alerts with conditional database updates before sending, which is the main duplicate-suppression mechanism when more than one relay instance is running.
- Forwards sent alert state to sibling relay instances using the existing sibling-forwarding path, and ignores stale forwarded state.
- Adds an admin dashboard shield toggle, and API support, to silence or unsilence account-limit alerts for a host. Silence changes are forwarded to sibling instances through the existing admin change-limits flow.

The new columns are added through the existing GORM auto-migration path.

## Testing

- `go test ./cmd/relay/...`
- `yarn build` in `cmd/relay/relay-admin-ui`
