### PR TITLE
cmd/tap: Use is_active instead of isActive in README

### DIFF
--- a/cmd/tap/README.md
+++ b/cmd/tap/README.md
@@ -163,7 +163,7 @@ Events are delivered as JSON:
   "identity": {
     "did": "did:plc:abc123",
     "handle": "alice.bsky.social",
-    "isActive": true,
+    "is_active": true,
     "status": "active"
   }
 }


### PR DESCRIPTION
Update the identity event example in `cmd/tap/README.md` to use `is_active` instead of `isActive`.

This matches the JSON tag on `IdentityEvt` in `cmd/tap/types.go`:
https://github.com/bluesky-social/indigo/blob/dfe5578fd537e71dd1ed884dd09b876dd768dfd5/cmd/tap/types.go#L55

(Sorry, Copilot left an unintended review comment because of my configuration mistake. Please ignore it)