### PR TITLE
Add app.bsky.video.defs#jobStatus failureCode field

### DIFF
--- a/api/bsky/videodefs.go
+++ b/api/bsky/videodefs.go
@@ -10,11 +10,13 @@ import (
 
 // VideoDefs_JobStatus is a "jobStatus" in the app.bsky.video.defs schema.
 type VideoDefs_JobStatus struct {
-	Blob    *lexutil.LexBlob `json:"blob,omitempty" cborgen:"blob,omitempty"`
-	Did     string           `json:"did" cborgen:"did"`
-	Error   *string          `json:"error,omitempty" cborgen:"error,omitempty"`
-	JobId   string           `json:"jobId" cborgen:"jobId"`
-	Message *string          `json:"message,omitempty" cborgen:"message,omitempty"`
+	Blob  *lexutil.LexBlob `json:"blob,omitempty" cborgen:"blob,omitempty"`
+	Did   string           `json:"did" cborgen:"did"`
+	Error *string          `json:"error,omitempty" cborgen:"error,omitempty"`
+	// failureCode: A machine-readable code for why the video processing job failed.
+	FailureCode *string `json:"failureCode,omitempty" cborgen:"failureCode,omitempty"`
+	JobId       string  `json:"jobId" cborgen:"jobId"`
+	Message     *string `json:"message,omitempty" cborgen:"message,omitempty"`
 	// progress: Progress within the current processing state.
 	Progress *int64 `json:"progress,omitempty" cborgen:"progress,omitempty"`
 	// state: The state of the video processing job. All values not listed as a known value indicate that the job is in process.

--- a/lexicons/app/bsky/video/defs.json
+++ b/lexicons/app/bsky/video/defs.json
@@ -21,6 +21,17 @@
         },
         "blob": { "type": "blob" },
         "error": { "type": "string" },
+        "failureCode": {
+          "type": "string",
+          "description": "A machine-readable code for why the video processing job failed.",
+          "knownValues": [
+            "validation_failure",
+            "encoding_failure",
+            "pds_upload_failure",
+            "pds_upload_unsupported_blob_size",
+            "generic_failure"
+          ]
+        },
         "message": { "type": "string" }
       }
     }


### PR DESCRIPTION
## Summary

- adds generated go code for the new `failureCode` field introduced in https://github.com/bluesky-social/atproto/pull/5283