### PR TITLE
early spaces proposal support

### DIFF
--- a/atproto/auth/permission.go
+++ b/atproto/auth/permission.go
@@ -25,11 +25,16 @@ type Permission struct {
 	Accept     []string `json:"accept,omitempty"`
 	Action     []string `json:"action,omitempty"`
 	Attribute  string   `json:"attr,omitempty"`
+	Collection []string `json:"collection,omitempty"`
+
 	Audience   string   `json:"aud,omitempty"`
 	InheritAud bool     `json:"inheritAud,omitempty"`
-	Collection []string `json:"collection,omitempty"`
 	Endpoint   []string `json:"lxm,omitempty"`
 	NSID       string   `json:"nsid,omitempty"`
+	SpaceType  string   `json:"spaceType,omitempty"`
+	Authority  string   `json:"authority,omitempty"`
+	SpaceKey   string   `json:"skey,omitempty"`
+	Manage     []string `json:"manage,omitempty"`
 }
 
 // Renders a permission as a permission scope string.
@@ -82,6 +87,25 @@ func (p *Permission) ScopeString() string {
 		}
 		if p.Audience != "" {
 			params.Set("aud", p.Audience)
+		}
+	case "space":
+		if p.SpaceType != "" {
+			positional = p.SpaceType
+		}
+		if p.Authority != "" {
+			params.Set("authority", p.Authority)
+		}
+		if p.SpaceKey != "" {
+			params.Set("skey", p.SpaceKey)
+		}
+		if len(p.Collection) > 0 {
+			params["collection"] = p.Collection
+		}
+		if len(p.Action) > 0 {
+			params["action"] = p.Action
+		}
+		if len(p.Manage) > 0 {
+			params["manage"] = p.Manage
 		}
 	default:
 		return ""
@@ -280,6 +304,75 @@ func ParsePermissionString(scope string) (*Permission, error) {
 		}
 		if p.Audience != "*" && !validServiceRef(p.Audience) {
 			return nil, ErrInvalidPermissionParams
+		}
+	case "space":
+		for k, _ := range g.Params {
+			if !(k == "spaceType" || k == "authority" || k == "skey" || k == "collection" || k == "action" || k == "manage") {
+				return nil, fmt.Errorf("%w: unsupported 'space' param: %s", ErrInvalidPermissionParams, k)
+			}
+		}
+		if g.Params.Has("spaceType") {
+			if g.Positional != "" || len(g.Params["spaceType"]) != 1 {
+				return nil, ErrInvalidPermissionParams
+			}
+			p.SpaceType = g.Params.Get("spaceType")
+		}
+		if g.Positional != "" {
+			p.SpaceType = g.Positional
+		}
+		if p.SpaceType != "*" {
+			_, err := syntax.ParseNSID(p.SpaceType)
+			if err != nil {
+				return nil, fmt.Errorf("%w: %w", ErrInvalidPermissionParams, err)
+			}
+		}
+		if g.Params.Has("authority") {
+			if len(g.Params["authority"]) != 1 {
+				return nil, ErrInvalidPermissionParams
+			}
+			p.Authority = g.Params.Get("authority")
+		}
+		if !(p.Authority == "" || p.Authority == "*" || p.Authority == "self") {
+			_, err := syntax.ParseDID(p.Authority)
+			if err != nil {
+				return nil, fmt.Errorf("%w: %w", ErrInvalidPermissionParams, err)
+			}
+		}
+		if g.Params.Has("skey") {
+			if len(g.Params["skey"]) != 1 {
+				return nil, ErrInvalidPermissionParams
+			}
+			p.SpaceKey = g.Params.Get("skey")
+		}
+		if !(p.SpaceKey == "" || p.SpaceKey == "*") {
+			_, err := syntax.ParseRecordKey(p.SpaceKey)
+			if err != nil {
+				return nil, fmt.Errorf("%w: %w", ErrInvalidPermissionParams, err)
+			}
+		}
+		if g.Params.Has("collection") {
+			p.Collection = g.Params["collection"]
+		}
+		for _, coll := range p.Collection {
+			if coll == "*" {
+				continue
+			}
+			_, err := syntax.ParseNSID(coll)
+			if err != nil {
+				return nil, fmt.Errorf("%w: %w", ErrInvalidPermissionParams, err)
+			}
+		}
+		p.Action = g.Params["action"]
+		for _, act := range p.Action {
+			if act != "read" && act != "create" && act != "update" && act != "delete" && act != "read_self" {
+				return nil, ErrInvalidPermissionParams
+			}
+		}
+		p.Manage = g.Params["manage"]
+		for _, mng := range p.Manage {
+			if mng != "create" && mng != "update" && mng != "delete" {
+				return nil, ErrInvalidPermissionParams
+			}
 		}
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrUnknownResource, g.Resource)

--- a/atproto/auth/permission_test.go
+++ b/atproto/auth/permission_test.go
@@ -24,6 +24,7 @@ func TestRoundTrip(t *testing.T) {
 		"account:email?action=manage",
 		"identity:handle",
 		"include:app.example.authBasics",
+		"space:com.example.forum?action=read_self&authority=%2A",
 	}
 
 	for _, scope := range testScopes {

--- a/atproto/auth/testdata/permission_scopes_invalid.txt
+++ b/atproto/auth/testdata/permission_scopes_invalid.txt
@@ -103,3 +103,16 @@ rpc?aud=did:web:example.com
 # missing AUD
 rpc?lxm=com.example.method1
 rpc:com.example.method1
+
+space
+space:123
+space?spaceType=123
+space?spaceType=com.example.bookmarks&spaceType=com.example.prefs
+space:com.example.bookmarks?spaceType=com.example.bookmarks
+space:com.example.forum?authority=123
+space:com.example.forum?authority=did:web:example.com&authority=did:web:example.org
+space:com.example.forum?skey=/
+space:com.example.forum?skey=1&skey=2
+space:com.example.forum?action=123
+space:com.example.forum?manage=123
+space:com.example.forum?collection=123

--- a/atproto/auth/testdata/permission_scopes_valid.txt
+++ b/atproto/auth/testdata/permission_scopes_valid.txt
@@ -38,6 +38,24 @@ rpc?aud=*&lxm=com.example.method1&lxm=com.example.method2
 rpc:com.example.query?aud=did:web:api.example.com%23api_example
 rpc?aud=did%3Aweb%3Aapi.example.com%23frag&lxm=com.example.query&lxm=com.example.procedure
 
+# examples from the proposal
+space:com.example.bookmarks
+space:com.atmoboards.forum?authority=*
+space:com.atmoboards.forum?authority=*&action=read
+space:com.atmoboards.forum?authority=*&action=read_self
+space:com.atmoboards.forum?authority=*&collection=*
+space:com.atmoboards.forum?authority=did:plc:abc123&skey=default&collection=com.atmoboards.thread&action=create&action=update
+space:com.atmoboards.forum?authority=*&action=read_self&manage=update&manage=delete
+space:com.atmoboards.forum?authority=*&manage=update&manage=delete
+space:*?authority=did:plc:abc123
+
+# more examples
+space?spaceType=com.example.bookmarks
+space:*
+space:com.example.bookmarks?authority=self
+space:com.example.bookmarks?skey=*
+space:com.example.bookmarks?collection=*
+space:com.example.forum?action=read_self&authority=%2A
 
 # examples from specification text 
 repo:app.example.profile

--- a/atproto/identity/diddoc_test.go
+++ b/atproto/identity/diddoc_test.go
@@ -38,7 +38,11 @@ func TestDIDDocParse(t *testing.T) {
 		pk, err := id.PublicKey()
 		assert.NoError(err)
 		assert.NotNil(pk)
+		spk, err := id.SpacePublicKey()
+		assert.NoError(err)
+		assert.NotNil(spk)
 		assert.Equal("https://bsky.social", id.PDSEndpoint())
+		assert.Equal("https://bsky.social", id.SpaceHostEndpoint())
 		hdl, err := id.DeclaredHandle()
 		assert.NoError(err)
 		assert.Equal("atproto.com", hdl.String())
@@ -75,11 +79,45 @@ func TestDIDDocFeedGenParse(t *testing.T) {
 	assert.Error(err)
 	assert.ErrorIs(err, ErrKeyNotDeclared)
 	assert.Nil(pk)
+	spk, err := id.SpacePublicKey()
+	assert.Error(err)
+	assert.ErrorIs(err, ErrKeyNotDeclared)
+	assert.Nil(spk)
 	assert.Equal("", id.PDSEndpoint())
+	assert.Equal("", id.SpaceHostEndpoint())
 	hdl, err := id.DeclaredHandle()
 	assert.Error(err)
 	assert.Empty(hdl)
 	svc, ok := id.Services["bsky_fg"]
 	assert.True(ok)
 	assert.Equal("https://discover.bsky.social", svc.URL)
+}
+
+func TestDIDDocSpaceParse(t *testing.T) {
+	assert := assert.New(t)
+	f, err := os.Open("testdata/space_doc.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	docBytes, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var doc DIDDocument
+	err = json.Unmarshal(docBytes, &doc)
+	assert.NoError(err)
+
+	id := ParseIdentity(&doc)
+
+	pk, err := id.PublicKey()
+	assert.NoError(err)
+	assert.NotNil(pk)
+	spk, err := id.SpacePublicKey()
+	assert.NoError(err)
+	assert.NotNil(spk)
+	assert.Equal("https://pds.example.com", id.PDSEndpoint())
+	assert.Equal("https://space-host.example.com", id.SpaceHostEndpoint())
 }

--- a/atproto/identity/identity.go
+++ b/atproto/identity/identity.go
@@ -124,6 +124,25 @@ func (i *Identity) PublicKey() (atcrypto.PublicKey, error) {
 	return i.GetPublicKey("atproto")
 }
 
+// Identifies and parses the atproto space key for this identity's DID document. This is '#atproto_space', falling back to '#atproto' if that is not defined.
+//
+// Returns [ErrKeyNotFound] if there is no such key.
+//
+// Note that [atcrypto.PublicKey] is an interface, not a concrete type.
+func (i *Identity) SpacePublicKey() (atcrypto.PublicKey, error) {
+
+	// if a space-specific key is defined, try using that (and return error on failure)
+	if i.Keys != nil {
+		_, ok := i.Keys["atproto_space"]
+		if ok {
+			return i.GetPublicKey("atproto_space")
+		}
+	}
+
+	// otherwise fall back to regular atproto key
+	return i.GetPublicKey("atproto")
+}
+
 // Identifies and parses a specified service signing public key out of any keys in this identity's DID document.
 //
 // Returns [ErrKeyNotFound] if there is no such key.
@@ -169,6 +188,24 @@ func (i *Identity) GetPublicKey(id string) (atcrypto.PublicKey, error) {
 //
 // Returns an empty string if the service isn't found, or if the URL fails to parse.
 func (i *Identity) PDSEndpoint() string {
+	return i.GetServiceEndpoint("atproto_pds")
+}
+
+// The space host endpoint for this identity, if one is included in the DID document. Uses 'atproto_space_host' if defined, otherwise falls back to PDS endpoint.
+//
+// The endpoint should be an HTTP URL with method, hostname, and optional port. It may or may not include path segments.
+//
+// Returns an empty string if the service isn't found, or if the URL fails to parse.
+func (i *Identity) SpaceHostEndpoint() string {
+	// if 'atproto_space_host' is defined, try that first (returning error if invalid)
+	if i.Services != nil {
+		_, ok := i.Services["atproto_space_host"]
+		if ok {
+			return i.GetServiceEndpoint("atproto_space_host")
+		}
+	}
+
+	// otherwise fall back to 'atproto_pds'
 	return i.GetServiceEndpoint("atproto_pds")
 }
 

--- a/atproto/identity/testdata/space_doc.json
+++ b/atproto/identity/testdata/space_doc.json
@@ -1,0 +1,37 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/multikey/v1",
+    "https://w3id.org/security/suites/secp256k1-2019/v1"
+  ],
+  "id": "did:plc:abcdenxzyoun6zhxrhs64oiz",
+  "alsoKnownAs": [
+    "at://space.example.com"
+  ],
+  "verificationMethod": [
+    {
+      "id": "did:plc:abcdenxzyoun6zhxrhs64oiz#atproto",
+      "type": "Multikey",
+      "controller": "did:plc:abcdenxzyoun6zhxrhs64oiz",
+      "publicKeyMultibase": "zQ3shXjHeiBuRCKmM36cuYnm7YEMzhGnCmCyW92sRJ9pribSF"
+    },
+    {
+      "id": "did:plc:abcdenxzyoun6zhxrhs64oiz#atproto_space",
+      "type": "Multikey",
+      "controller": "did:plc:abcdenxzyoun6zhxrhs64oiz",
+      "publicKeyMultibase": "zQ3shXjHeiBuRCKmM36cuYnm7YEMzhGnCmCyW92sRJ9pribSF"
+    }
+  ],
+  "service": [
+    {
+      "id": "#atproto_pds",
+      "type": "AtprotoPersonalDataServer",
+      "serviceEndpoint": "https://pds.example.com"
+    },
+    {
+      "id": "#atproto_space_host",
+      "type": "AtprotoSpaceHost",
+      "serviceEndpoint": "https://space-host.example.com"
+    }
+  ]
+}

--- a/atproto/lexicon/language.go
+++ b/atproto/lexicon/language.go
@@ -708,7 +708,7 @@ func (s *SchemaString) CheckSchema() error {
 	}
 	if s.Format != nil {
 		switch *s.Format {
-		case "at-identifier", "at-uri", "cid", "datetime", "did", "handle", "nsid", "uri", "language", "tid", "record-key":
+		case "at-identifier", "at-uri", "space-ref", "cid", "datetime", "did", "handle", "nsid", "uri", "language", "tid", "record-key":
 			// pass
 		default:
 			return fmt.Errorf("unknown string format: %s", *s.Format)
@@ -749,6 +749,11 @@ func (s *SchemaString) Validate(d any, flags ValidateFlags) error {
 			}
 		case "at-uri":
 			if _, err := syntax.ParseATURI(v); err != nil {
+				return err
+			}
+		case "space-ref":
+			// XXX: swap out with ParseSpaceRef once implemented in indigo
+			if _, err := syntax.ParseURI(v); err != nil {
 				return err
 			}
 		case "cid":

--- a/atproto/lexicon/language.go
+++ b/atproto/lexicon/language.go
@@ -33,6 +33,8 @@ func (s *SchemaDef) CheckSchema() error {
 		return v.CheckSchema()
 	case SchemaPermission:
 		return v.CheckSchema()
+	case SchemaSpace:
+		return v.CheckSchema()
 	case SchemaBoolean:
 		return v.CheckSchema()
 	case SchemaInteger:
@@ -67,7 +69,7 @@ func (s *SchemaDef) CheckSchema() error {
 // Checks if def is of "parimary" type
 func (s *SchemaDef) IsPrimary() bool {
 	switch s.Inner.(type) {
-	case SchemaRecord, SchemaQuery, SchemaProcedure, SchemaSubscription, SchemaPermissionSet:
+	case SchemaRecord, SchemaQuery, SchemaProcedure, SchemaSubscription, SchemaPermissionSet, SchemaSpace:
 		return true
 	}
 	return false
@@ -237,6 +239,13 @@ func (s *SchemaDef) UnmarshalJSON(b []byte) error {
 		}
 		s.Inner = *v
 		return nil
+	case "space":
+		v := new(SchemaSpace)
+		if err = json.Unmarshal(b, v); err != nil {
+			return err
+		}
+		s.Inner = *v
+		return nil
 	case "boolean":
 		v := new(SchemaBoolean)
 		if err = json.Unmarshal(b, v); err != nil {
@@ -344,17 +353,24 @@ func (s *SchemaRecord) CheckSchema() error {
 	if s.Type != "record" {
 		return fmt.Errorf("expected 'record' schema")
 	}
-	switch s.Key {
+	if err := checkKeyType(s.Key); err != nil {
+		return err
+	}
+	return s.Record.CheckSchema()
+}
+
+func checkKeyType(key string) error {
+	switch key {
 	case "":
-		return fmt.Errorf("record key specifier is required")
+		return fmt.Errorf("record/space key specifier is required")
 	case "tid", "nsid", "any":
 		// pass
 	default:
-		if !strings.HasPrefix(s.Key, "literal:") {
-			return fmt.Errorf("invalid record key specifier: %s", s.Key)
+		if !strings.HasPrefix(key, "literal:") {
+			return fmt.Errorf("invalid record/space key specifier: %s", key)
 		}
 	}
-	return s.Record.CheckSchema()
+	return nil
 }
 
 type SchemaQuery struct {
@@ -541,6 +557,45 @@ func (s *SchemaPermission) CheckSchema() error {
 		return fmt.Errorf("%s permission not allowed in permission sets", s.Resource)
 	default:
 		return fmt.Errorf("unsupported permission resource: %s", s.Resource)
+	}
+	return nil
+}
+
+type SchemaSpace struct {
+	Type        string            `json:"type"` // "space"
+	Description *string           `json:"description,omitempty"`
+	Key         string            `json:"key"`
+	Name        string            `json:"name"`
+	NameLang    map[string]string `json:"name:lang,omitempty"`
+	Collections []string          `json:"collections"`
+}
+
+func (s *SchemaSpace) CheckSchema() error {
+	if s.Type != "space" {
+		return fmt.Errorf("expected 'space' schema")
+	}
+	if err := checkKeyType(s.Key); err != nil {
+		return err
+	}
+	if len(s.Name) < 1 || len(s.Name) > 64 {
+		// TODO: graphemes vs bytes?
+		return fmt.Errorf("space name must be between 1 and 64 characters long")
+	}
+	for lang, name := range s.NameLang {
+		_, err := syntax.ParseLanguage(lang)
+		if err != nil {
+			return err
+		}
+		if len(name) < 1 || len(name) > 64 {
+			// TODO: graphemes vs bytes?
+			return fmt.Errorf("space name must be between 1 and 64 characters long")
+		}
+	}
+	for _, c := range s.Collections {
+		_, err := syntax.ParseNSID(c)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/atproto/lexicon/testdata/catalog/record.json
+++ b/atproto/lexicon/testdata/catalog/record.json
@@ -193,6 +193,11 @@
           "format": "at-uri",
           "description": "an at-uri string"
         },
+        "spaceref": {
+          "type": "string",
+          "format": "space-ref",
+          "description": "a space-ref string"
+        },
         "cid": {
           "type": "string",
           "format": "cid",

--- a/atproto/lexicon/testdata/catalog/space.json
+++ b/atproto/lexicon/testdata/catalog/space.json
@@ -1,0 +1,20 @@
+{
+  "lexicon": 1,
+  "id": "example.lexicon.space",
+  "description": "exercises many lexicon features for the space type",
+  "defs": {
+    "main": {
+      "type": "space",
+      "key": "literal:self",
+      "description": "Additional description",
+      "name": "Example for Group",
+      "name:lang": {
+        "fr": "Example for Group"
+      },
+      "collections": [
+        "com.example.calendar.event",
+        "com.example.calendar.rsvp"
+      ]
+    }
+  }
+}

--- a/atproto/lexicon/testdata/record-data-invalid.json
+++ b/atproto/lexicon/testdata/record-data-invalid.json
@@ -219,6 +219,17 @@
     }
   },
   {
+    "name": "invalid string format spaceref",
+    "rkey": "demo",
+    "data": {
+      "$type": "example.lexicon.record",
+      "integer": 1,
+      "formats": {
+        "spaceref": "123"
+      }
+    }
+  },
+  {
     "name": "invalid string format cid",
     "rkey": "demo",
     "data": {

--- a/atproto/lexicon/testdata/record-data-valid.json
+++ b/atproto/lexicon/testdata/record-data-valid.json
@@ -57,6 +57,7 @@
         "handle": "handle.example.com",
         "atidentifier": "handle.example.com",
         "aturi": "at://handle.example.com/com.example.nsid/asdf123",
+        "spaceref": "at://did:abc:123/space/com.example.nsid/asdf123",
         "nsid": "com.example.nsid",
         "cid": "bafyreiclp443lavogvhj3d2ob2cxbfuscni2k5jk7bebjzg7khl3esabwq",
         "datetime": "2023-10-30T22:25:23Z",

--- a/lex/lexgen/codegen.go
+++ b/lex/lexgen/codegen.go
@@ -148,6 +148,8 @@ func (gen *CodeGenerator) WriteType(ft *FlatType) error {
 		// pass; we only generate message types, not overall subscription
 	case lexicon.SchemaPermissionSet, lexicon.SchemaPermission:
 		// pass for Go codegen
+	case lexicon.SchemaSpace:
+		// pass for Go codegen
 	case lexicon.SchemaToken:
 		// TODO: pass for now; could be a var/const?
 	case lexicon.SchemaString, lexicon.SchemaInteger, lexicon.SchemaBoolean, lexicon.SchemaUnknown:

--- a/lex/lexgen/flatten.go
+++ b/lex/lexgen/flatten.go
@@ -181,6 +181,9 @@ func (fl *FlatLexicon) flattenType(fd *FlatDef, tpath []string, def *lexicon.Sch
 	case lexicon.SchemaPermissionSet, lexicon.SchemaPermission:
 		// pass-through (emit)
 		fl.Types = append(fl.Types, ft)
+	case lexicon.SchemaSpace:
+		// pass-through (emit)
+		fl.Types = append(fl.Types, ft)
 	default:
 		return fmt.Errorf("unsupported def type for flattening (%s): %T", fd.Name, def.Inner)
 	}

--- a/lex/lexgen/util.go
+++ b/lex/lexgen/util.go
@@ -25,6 +25,8 @@ func defType(sd *lexicon.SchemaDef) (string, error) {
 		return "permission-set", nil
 	case lexicon.SchemaPermission:
 		return "permission", nil
+	case lexicon.SchemaSpace:
+		return "space", nil
 	case lexicon.SchemaBoolean:
 		return "boolean", nil
 	case lexicon.SchemaInteger:
@@ -71,6 +73,8 @@ func defDescription(sd *lexicon.SchemaDef) string {
 	case lexicon.SchemaPermissionSet:
 		desc = v.Description
 	case lexicon.SchemaPermission:
+		desc = v.Description
+	case lexicon.SchemaSpace:
 		desc = v.Description
 	case lexicon.SchemaBoolean:
 		desc = v.Description

--- a/lex/lexlint/breaking.go
+++ b/lex/lexlint/breaking.go
@@ -331,7 +331,7 @@ func breakingDefs(nsid syntax.NSID, name string, local, remote lexicon.SchemaDef
 				})
 			}
 		}
-	case lexicon.SchemaUnknown, lexicon.SchemaPermissionSet, lexicon.SchemaToken:
+	case lexicon.SchemaUnknown, lexicon.SchemaPermissionSet, lexicon.SchemaSpace, lexicon.SchemaToken:
 		// pass
 	default:
 		slog.Warn("unhandled schema def type in breaking check", "type", reflect.TypeOf(local.Inner))

--- a/lex/lexlint/lint.go
+++ b/lex/lexlint/lint.go
@@ -228,7 +228,7 @@ func lintSchemaDef(nsid syntax.NSID, defname string, def lexicon.SchemaDef) []Li
 			// TODO: any lints on permissions?
 			_ = perm
 		}
-	case lexicon.SchemaPermission, lexicon.SchemaBoolean, lexicon.SchemaInteger, lexicon.SchemaString, lexicon.SchemaBytes, lexicon.SchemaCIDLink, lexicon.SchemaArray, lexicon.SchemaObject, lexicon.SchemaBlob, lexicon.SchemaToken, lexicon.SchemaRef, lexicon.SchemaUnion, lexicon.SchemaUnknown:
+	case lexicon.SchemaPermission, lexicon.SchemaBoolean, lexicon.SchemaInteger, lexicon.SchemaString, lexicon.SchemaBytes, lexicon.SchemaCIDLink, lexicon.SchemaArray, lexicon.SchemaObject, lexicon.SchemaBlob, lexicon.SchemaToken, lexicon.SchemaRef, lexicon.SchemaUnion, lexicon.SchemaUnknown, lexicon.SchemaSpace:
 		reciss := lintSchemaRecursive(nsid, def)
 		if len(reciss) > 0 {
 			issues = append(issues, reciss...)


### PR DESCRIPTION
This PR adds some enabling support for permission spaces to existing indigo atproto packages.

These are bits which might get merged sooner than later, because they are needed even for early experimentation, and are entwined with existing methods and types. For example, we probably want to be able to have `goat` public space lexicon schema declarations even during this prototype/experimentation phase. But because of the design of the API it would be messy to have a separate codepath just for `space` schema declarations, separate from all the other declaration types.

I am separately working on implementations of things like the sync mechanism (eg, LtHash), new cryptographic primitives (like the HMAC and HKDF stuff), and higher-level client helpers.