### PR TITLE
Add Ozone applyStrikes binding

### DIFF
--- a/api/ozone/moderationdefs.go
+++ b/api/ozone/moderationdefs.go
@@ -344,8 +344,10 @@ type ModerationDefs_ModEventTag struct {
 type ModerationDefs_ModEventTakedown struct {
 	LexiconTypeID string `json:"$type" cborgen:"$type,const=tools.ozone.moderation.defs#modEventTakedown"`
 	// acknowledgeAccountSubjects: If true, all other reports on content authored by this account will be resolved (acknowledged).
-	AcknowledgeAccountSubjects *bool   `json:"acknowledgeAccountSubjects,omitempty" cborgen:"acknowledgeAccountSubjects,omitempty"`
-	Comment                    *string `json:"comment,omitempty" cborgen:"comment,omitempty"`
+	AcknowledgeAccountSubjects *bool `json:"acknowledgeAccountSubjects,omitempty" cborgen:"acknowledgeAccountSubjects,omitempty"`
+	// applyStrikes: If true, Ozone calculates strikes and any account-level cascade from its instance settings.
+	ApplyStrikes *bool   `json:"applyStrikes,omitempty" cborgen:"applyStrikes,omitempty"`
+	Comment      *string `json:"comment,omitempty" cborgen:"comment,omitempty"`
 	// durationInHours: Indicates how long the takedown should be in effect before automatically expiring.
 	DurationInHours *int64 `json:"durationInHours,omitempty" cborgen:"durationInHours,omitempty"`
 	// policies: Names/Keywords of the policies that drove the decision.

--- a/lexicons/tools/ozone/moderation/defs.json
+++ b/lexicons/tools/ozone/moderation/defs.json
@@ -417,6 +417,10 @@
           "type": "string",
           "format": "datetime",
           "description": "When the strike should expire. If not provided, the strike never expires."
+        },
+        "applyStrikes": {
+          "type": "boolean",
+          "description": "If true, Ozone calculates strikes and any account-level cascade from its instance settings."
         }
       }
     },


### PR DESCRIPTION
Summary:
- add applyStrikes to the Ozone takedown lexicon
- regenerate Go bindings

Source: https://github.com/bluesky-social/atproto/pull/5458
Consumer: https://github.com/bluesky-social/tango/pull/1471

Tests: go test ./api/ozone

Merge/deploy order: 2/5 — merge after atproto; then merge the tango dependency bump.