### PR TITLE
identity: separate http.Client for did:plc resolution

### DIFF
--- a/atproto/identity/base_directory.go
+++ b/atproto/identity/base_directory.go
@@ -21,6 +21,9 @@ type BaseDirectory struct {
 	DIDWebLimitFunc func(ctx context.Context, hostname string) error
 	// HTTP client used for did:web, did:plc, and HTTP (well-known) handle resolution
 	HTTPClient http.Client
+	// HTTP client used for did:plc resolution. If nil, HTTPClient is used.
+	// The PLC directory service is configured (via PLCURL) and are fewer hardening concerns than did:web or handle resolution.
+	PLCClient *http.Client
 	// DNS resolver used for DNS handle resolution. Calling code can use a custom Dialer to query against a specific DNS server, or re-implement the interface for even more control over the resolution process
 	Resolver net.Resolver
 	// when doing DNS handle resolution, should this resolver attempt re-try against an authoritative nameserver if the first TXT lookup fails?

--- a/atproto/identity/did.go
+++ b/atproto/identity/did.go
@@ -151,7 +151,12 @@ func (d *BaseDirectory) resolveDIDPLC(ctx context.Context, did syntax.DID) ([]by
 		req.Header.Set("User-Agent", d.UserAgent)
 	}
 
-	resp, err := d.HTTPClient.Do(req)
+	c := d.PLCClient
+	if c == nil {
+		c = &d.HTTPClient
+	}
+
+	resp, err := c.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%w: PLC directory lookup: %w", ErrDIDResolutionFailed, err)
 	}

--- a/atproto/identity/directory.go
+++ b/atproto/identity/directory.go
@@ -74,6 +74,9 @@ func DefaultDirectory() Directory {
 				MaxIdleConns:    100,
 			},
 		},
+		PLCClient: &http.Client{
+			Timeout: time.Second * 10,
+		},
 		Resolver: net.Resolver{
 			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
 				d := net.Dialer{Timeout: time.Second * 3}

--- a/atproto/identity/live_test.go
+++ b/atproto/identity/live_test.go
@@ -48,7 +48,10 @@ func testDirectoryLive(t *testing.T, d Directory) {
 	_, err = d.LookupDID(ctx, syntax.DID("did:web:fake-dummy-no-resolve.atproto.com"))
 	assert.ErrorIs(err, ErrDIDNotFound)
 
-	_, err = d.LookupDID(ctx, syntax.DID("did:plc:fake-dummy-no-resolve.atproto.com"))
+	_, err = d.LookupDID(ctx, syntax.DID("did:web:api.bsky.app"))
+	assert.NoError(err)
+
+	_, err = d.LookupDID(ctx, syntax.DID("did:plc:aaaaaaaaaaaaaaaaaaaaaaaa"))
 	assert.ErrorIs(err, ErrDIDNotFound)
 
 	_, err = d.LookupHandle(ctx, syntax.HandleInvalid)
@@ -59,6 +62,12 @@ func TestBaseDirectory(t *testing.T) {
 	t.Skip("TODO: skipping live network test")
 	d := BaseDirectory{}
 	testDirectoryLive(t, &d)
+}
+
+func TestDefaultDirectory(t *testing.T) {
+	t.Skip("TODO: skipping live network test")
+	d := DefaultDirectory()
+	testDirectoryLive(t, d)
 }
 
 func TestCacheDirectory(t *testing.T) {


### PR DESCRIPTION
The motivation here is to be able to configure the `http.Client` used for did:plc differently from the client used for did:web and HTTP handle resolution.

The PLC directory endpoint is explicitly configured and at least somewhat trusted, while did:web and HTTP handle resolution is done against explicitly untrusted hosts and URLs.

This PR should be a no-op for calling code which explicitly configures a `BaseDirectory`. For calling code using `identity.DefaultDirectory()`, the behavioral should be minimal.