### PR TITLE
harden identity package

### DIFF
--- a/atproto/identity/base_directory.go
+++ b/atproto/identity/base_directory.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// The zero value ('BaseDirectory{}') is a usable Directory.
+// The zero value ('BaseDirectory{}') is a functional [Directory], but it does not include protections against untrusted network endpoints (eg, SSRF). Use [DefaultDirectory()] or explicitly configure HTTPClient with a safely configured [http.Client].
 type BaseDirectory struct {
 	// if non-empty, this string should have URL method, hostname, and optional port; it should not have a path or trailing slash
 	PLCURL string
@@ -19,7 +19,7 @@ type BaseDirectory struct {
 	PLCLimiter *rate.Limiter
 	// If not nil, this function will be called inline with DID Web lookups, and can be used to limit the number of requests to a given hostname
 	DIDWebLimitFunc func(ctx context.Context, hostname string) error
-	// HTTP client used for did:web, did:plc, and HTTP (well-known) handle resolution
+	// HTTP client used for did:web and HTTP (well-known) handle resolution. It is important this include SSRF protections; `http.DefaultClient` and bare `http.Client{}` do not.
 	HTTPClient http.Client
 	// HTTP client used for did:plc resolution. If nil, HTTPClient is used.
 	// The PLC directory service is configured (via PLCURL) and are fewer hardening concerns than did:web or handle resolution.

--- a/atproto/identity/did.go
+++ b/atproto/identity/did.go
@@ -14,6 +14,9 @@ import (
 	"github.com/bluesky-social/indigo/atproto/syntax"
 )
 
+// 5 MByte as a somewhat arbitrary value to start (should probably be smaller)
+var maxDIDBodySize int64 = 5 * 1024 * 1024
+
 // Resolves a DID to a parsed `DIDDocument` struct.
 //
 // This method does not bi-directionally verify handles. Most atproto-specific code should use the `identity.Directory` interface ("Lookup" methods), which implement that check by default, and provide more ergonomic helpers for working with atproto-relevant information in DID documents.
@@ -116,15 +119,15 @@ func (d *BaseDirectory) resolveDIDWeb(ctx context.Context, did syntax.DID) ([]by
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
-		io.Copy(io.Discard, resp.Body)
+		io.Copy(io.Discard, io.LimitReader(resp.Body, maxDIDBodySize))
 		return nil, fmt.Errorf("%w: did:web HTTP status 404", ErrDIDNotFound)
 	}
 	if resp.StatusCode != http.StatusOK {
-		io.Copy(io.Discard, resp.Body)
+		io.Copy(io.Discard, io.LimitReader(resp.Body, maxDIDBodySize))
 		return nil, fmt.Errorf("%w: did:web HTTP status %d", ErrDIDResolutionFailed, resp.StatusCode)
 	}
 
-	return io.ReadAll(resp.Body)
+	return io.ReadAll(io.LimitReader(resp.Body, maxDIDBodySize))
 }
 
 func (d *BaseDirectory) resolveDIDPLC(ctx context.Context, did syntax.DID) ([]byte, error) {

--- a/atproto/identity/did.go
+++ b/atproto/identity/did.go
@@ -127,6 +127,13 @@ func (d *BaseDirectory) resolveDIDWeb(ctx context.Context, did syntax.DID) ([]by
 		return nil, fmt.Errorf("%w: did:web HTTP status %d", ErrDIDResolutionFailed, resp.StatusCode)
 	}
 
+	if resp.ContentLength > maxDIDBodySize {
+		// NOTE: intentionally not draining body
+		return nil, fmt.Errorf("%w: did:web body too large for %s", ErrDIDResolutionFailed, did)
+	}
+
+	// TODO: this could result in a truncated handle value with no error thrown (if Content-Length is not set).
+	// See: https://github.com/bluesky-social/indigo/issues/1460
 	return io.ReadAll(io.LimitReader(resp.Body, maxDIDBodySize))
 }
 

--- a/atproto/identity/directory.go
+++ b/atproto/identity/directory.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/bluesky-social/indigo/util/ssrf"
 
 	"github.com/earthboundkid/versioninfo/v2"
 )
@@ -63,12 +64,14 @@ var DefaultPLCURL = "https://plc.directory"
 
 // Returns a reasonable Directory implementation for applications
 func DefaultDirectory() Directory {
+	ssrfHTTPDialer := ssrf.PublicOnlyDialer()
 	base := BaseDirectory{
 		PLCURL: DefaultPLCURL,
 		HTTPClient: http.Client{
 			Timeout: time.Second * 10,
 			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
+				DialContext: ssrfHTTPDialer.DialContext,
+				Proxy:       http.ProxyFromEnvironment,
 				// would want this around 100ms for services doing lots of handle resolution. Impacts PLC connections as well, but not too bad.
 				IdleConnTimeout: time.Millisecond * 1000,
 				MaxIdleConns:    100,

--- a/atproto/identity/directory.go
+++ b/atproto/identity/directory.go
@@ -63,6 +63,8 @@ var ErrInvalidHandle = errors.New("invalid handle")
 var DefaultPLCURL = "https://plc.directory"
 
 // Returns a reasonable Directory implementation for applications
+//
+// If an HTTP proxy is configured (via environment variable), SSRF protections will not apply to external requests (it is the responsibility of the proxy to handle SSRF). However, note that the default SSRF protections will apply to connections to the HTTP proxy itself, which breaks the common case of local-network HTTP proxies. In this situation, calling code and applications need to configure a custom [identity.Directory].
 func DefaultDirectory() Directory {
 	ssrfHTTPDialer := ssrf.PublicOnlyDialer()
 	base := BaseDirectory{

--- a/atproto/identity/directory.go
+++ b/atproto/identity/directory.go
@@ -70,11 +70,14 @@ func DefaultDirectory() Directory {
 		HTTPClient: http.Client{
 			Timeout: time.Second * 10,
 			Transport: &http.Transport{
-				DialContext: ssrfHTTPDialer.DialContext,
-				Proxy:       http.ProxyFromEnvironment,
-				// would want this around 100ms for services doing lots of handle resolution. Impacts PLC connections as well, but not too bad.
-				IdleConnTimeout: time.Millisecond * 1000,
-				MaxIdleConns:    100,
+				Proxy:             http.ProxyFromEnvironment,
+				DialContext:       ssrfHTTPDialer.DialContext,
+				ForceAttemptHTTP2: true,
+				MaxIdleConns:      100,
+				// would want this around 100ms for services doing lots of handle resolution
+				IdleConnTimeout:       time.Millisecond * 1000,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
 			},
 		},
 		PLCClient: &http.Client{

--- a/atproto/identity/handle.go
+++ b/atproto/identity/handle.go
@@ -14,6 +14,8 @@ import (
 	"github.com/bluesky-social/indigo/atproto/syntax"
 )
 
+var maxHandleBodySize int64 = 2048
+
 func parseTXTResp(res []string) (syntax.DID, error) {
 	for _, s := range res {
 		if strings.HasPrefix(s, "did=") {
@@ -147,7 +149,7 @@ func (d *BaseDirectory) ResolveHandleWellKnown(ctx context.Context, handle synta
 		return "", fmt.Errorf("%w: HTTP well-known request error: %w", ErrHandleResolutionFailed, err)
 	}
 	defer resp.Body.Close()
-	if resp.ContentLength > 2048 {
+	if resp.ContentLength > maxHandleBodySize {
 		// NOTE: intentionally not draining body
 		return "", fmt.Errorf("%w: HTTP well-known body too large for %s", ErrHandleResolutionFailed, handle)
 	}
@@ -160,7 +162,7 @@ func (d *BaseDirectory) ResolveHandleWellKnown(ctx context.Context, handle synta
 		return "", fmt.Errorf("%w: HTTP well-known status %d for %s", ErrHandleResolutionFailed, resp.StatusCode, handle)
 	}
 
-	b, err := io.ReadAll(io.LimitReader(resp.Body, 2048))
+	b, err := io.ReadAll(io.LimitReader(resp.Body, maxHandleBodySize))
 	if err != nil {
 		return "", fmt.Errorf("%w: HTTP well-known body read for %s: %w", ErrHandleResolutionFailed, handle, err)
 	}

--- a/atproto/identity/handle.go
+++ b/atproto/identity/handle.go
@@ -149,10 +149,6 @@ func (d *BaseDirectory) ResolveHandleWellKnown(ctx context.Context, handle synta
 		return "", fmt.Errorf("%w: HTTP well-known request error: %w", ErrHandleResolutionFailed, err)
 	}
 	defer resp.Body.Close()
-	if resp.ContentLength > maxHandleBodySize {
-		// NOTE: intentionally not draining body
-		return "", fmt.Errorf("%w: HTTP well-known body too large for %s", ErrHandleResolutionFailed, handle)
-	}
 	if resp.StatusCode == http.StatusNotFound {
 		io.Copy(io.Discard, resp.Body)
 		return "", fmt.Errorf("%w: HTTP 404 for %s", ErrHandleNotFound, handle)
@@ -161,7 +157,13 @@ func (d *BaseDirectory) ResolveHandleWellKnown(ctx context.Context, handle synta
 		io.Copy(io.Discard, resp.Body)
 		return "", fmt.Errorf("%w: HTTP well-known status %d for %s", ErrHandleResolutionFailed, resp.StatusCode, handle)
 	}
+	if resp.ContentLength > maxHandleBodySize {
+		// NOTE: intentionally not draining body
+		return "", fmt.Errorf("%w: HTTP well-known body too large for %s", ErrHandleResolutionFailed, handle)
+	}
 
+	// TODO: this could result in a truncated handle value with no error thrown (if Content-Length is not set).
+	// See: https://github.com/bluesky-social/indigo/issues/1460
 	b, err := io.ReadAll(io.LimitReader(resp.Body, maxHandleBodySize))
 	if err != nil {
 		return "", fmt.Errorf("%w: HTTP well-known body read for %s: %w", ErrHandleResolutionFailed, handle, err)

--- a/atproto/identity/live_test.go
+++ b/atproto/identity/live_test.go
@@ -10,9 +10,10 @@ import (
 	"time"
 
 	"github.com/bluesky-social/indigo/atproto/syntax"
-	"golang.org/x/time/rate"
+	"github.com/bluesky-social/indigo/util/ssrf"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
 )
 
 // NOTE: this hits the open internet! marked as skip below by default
@@ -89,7 +90,8 @@ func TestCacheCoalesce(t *testing.T) {
 	base := BaseDirectory{
 		PLCURL: "https://plc.directory",
 		HTTPClient: http.Client{
-			Timeout: time.Second * 15,
+			Timeout:   time.Second * 15,
+			Transport: ssrf.PublicOnlyTransport(),
 		},
 		// Limit the number of requests we can make to the PLC to 1 per second
 		PLCLimiter:            rate.NewLimiter(1, 1),

--- a/atproto/identity/redisdir/live_test.go
+++ b/atproto/identity/redisdir/live_test.go
@@ -11,9 +11,10 @@ import (
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
-	"golang.org/x/time/rate"
+	"github.com/bluesky-social/indigo/util/ssrf"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
 )
 
 var redisLocalTestURL string = "redis://localhost:6379/0"
@@ -95,7 +96,8 @@ func TestRedisCoalesce(t *testing.T) {
 	base := identity.BaseDirectory{
 		PLCURL: "https://plc.directory",
 		HTTPClient: http.Client{
-			Timeout: time.Second * 15,
+			Timeout:   time.Second * 15,
+			Transport: ssrf.PublicOnlyTransport(),
 		},
 		// Limit the number of requests we can make to the PLC to 1 per second
 		PLCLimiter:            rate.NewLimiter(1, 1),


### PR DESCRIPTION
Adds some extra safety checks to `identity.DefaultDirectory` and `BaseDirectory`, and adds some doc comments.

These change *do* have behavioral impact for code which uses this package. By splitting out the PLC http client we hope the most common local dev impacts will be limited. But folks with localhost did:web service accounts might encounter issues. 

Updates to other services which use the identity package will be a separate PR.

Note that we intend to switch to [jttp](https://github.com/jcalabro/jttp) soon for some of this HTTP hardening.