### PR TITLE
harden identity.Directory usage

### DIFF
--- a/atproto/lexicon/resolve.go
+++ b/atproto/lexicon/resolve.go
@@ -50,6 +50,7 @@ func ResolveLexiconSchemaFile(ctx context.Context, dir identity.Directory, nsid 
 
 // internal helper for fetching lexicon record as JSON bytes
 func resolveLexiconJSON(ctx context.Context, dir identity.Directory, nsid syntax.NSID) (*json.RawMessage, error) {
+	// this BaseDirectory is only used for DNS TXT resolution, not HTTP
 	baseDir := identity.BaseDirectory{}
 	did, err := baseDir.ResolveNSID(ctx, nsid)
 	if err != nil {

--- a/cmd/bluepages/server.go
+++ b/cmd/bluepages/server.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/bluesky-social/indigo/atproto/identity"
+	"github.com/bluesky-social/indigo/util/ssrf"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -58,13 +59,8 @@ func NewServer(config Config) (*Server, error) {
 	baseDir := identity.BaseDirectory{
 		PLCURL: config.PLCHost,
 		HTTPClient: http.Client{
-			Timeout: time.Second * 10,
-			Transport: &http.Transport{
-				Proxy: http.ProxyFromEnvironment,
-				// would want this around 100ms for services doing lots of handle resolution (to reduce number of idle connections). Impacts PLC connections as well, but not too bad.
-				IdleConnTimeout: time.Millisecond * 100,
-				MaxIdleConns:    1000,
-			},
+			Timeout:   time.Second * 10,
+			Transport: ssrf.PublicOnlyTransport(),
 		},
 		Resolver: net.Resolver{
 			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {

--- a/cmd/bluepages/server.go
+++ b/cmd/bluepages/server.go
@@ -62,6 +62,9 @@ func NewServer(config Config) (*Server, error) {
 			Timeout:   time.Second * 10,
 			Transport: ssrf.PublicOnlyTransport(),
 		},
+		PLCClient: &http.Client{
+			Timeout: time.Second * 10,
+		},
 		Resolver: net.Resolver{
 			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
 				d := net.Dialer{Timeout: time.Second * 3}

--- a/cmd/gosky/main.go
+++ b/cmd/gosky/main.go
@@ -190,7 +190,7 @@ var readRepoStreamCmd = &cli.Command{
 			_ = con.Close()
 		}()
 
-		bdir := identity.BaseDirectory{}
+		dir := identity.DefaultDirectory()
 		resolveHandles := cctx.Bool("resolve-handles")
 
 		cache, _ := lru.New[string, *cachedHandle](10000)
@@ -202,7 +202,7 @@ var readRepoStreamCmd = &cli.Command{
 				}
 			}
 
-			ident, err := bdir.LookupDID(ctx, syntax.DID(did))
+			ident, err := dir.LookupDID(ctx, syntax.DID(did))
 			if err != nil {
 				return "", err
 			}

--- a/cmd/hepa/main.go
+++ b/cmd/hepa/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/bluesky-social/indigo/automod/capture"
 	"github.com/bluesky-social/indigo/automod/consumer"
+	"github.com/bluesky-social/indigo/util/ssrf"
 
 	"github.com/earthboundkid/versioninfo/v2"
 	"github.com/urfave/cli/v3"
@@ -209,7 +210,8 @@ func configDirectory(cmd *cli.Command) (identity.Directory, error) {
 	baseDir := identity.BaseDirectory{
 		PLCURL: cmd.String("atp-plc-host"),
 		HTTPClient: http.Client{
-			Timeout: time.Second * 15,
+			Timeout:   time.Second * 15,
+			Transport: ssrf.PublicOnlyTransport(),
 		},
 		PLCLimiter:            rate.NewLimiter(rate.Limit(cmd.Int("plc-rate-limit")), 1),
 		TryAuthoritativeDNS:   true,

--- a/cmd/hepa/main.go
+++ b/cmd/hepa/main.go
@@ -213,6 +213,9 @@ func configDirectory(cmd *cli.Command) (identity.Directory, error) {
 			Timeout:   time.Second * 15,
 			Transport: ssrf.PublicOnlyTransport(),
 		},
+		PLCClient: &http.Client{
+			Timeout: time.Second * 10,
+		},
 		PLCLimiter:            rate.NewLimiter(rate.Limit(cmd.Int("plc-rate-limit")), 1),
 		TryAuthoritativeDNS:   true,
 		SkipDNSDomainSuffixes: []string{".bsky.social", ".staging.bsky.dev"},

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -334,6 +334,9 @@ func runRelay(ctx context.Context, cmd *cli.Command) error {
 			Timeout:   time.Second * 5,
 			Transport: ssrf.PublicOnlyTransport(),
 		},
+		PLCClient: &http.Client{
+			Timeout: time.Second * 10,
+		},
 		Resolver: net.Resolver{
 			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
 				d := net.Dialer{Timeout: time.Second * 3}

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
@@ -25,6 +27,7 @@ import (
 	"github.com/bluesky-social/indigo/cmd/relay/stream/eventmgr"
 	"github.com/bluesky-social/indigo/cmd/relay/stream/persist/diskpersist"
 	"github.com/bluesky-social/indigo/util/cliutil"
+	"github.com/bluesky-social/indigo/util/ssrf"
 
 	"github.com/earthboundkid/versioninfo/v2"
 	"github.com/urfave/cli/v3"
@@ -327,6 +330,16 @@ func runRelay(ctx context.Context, cmd *cli.Command) error {
 		SkipDNSDomainSuffixes:  []string{".bsky.social"},
 		TryAuthoritativeDNS:    true,
 		PLCURL:                 cmd.String("plc-host"),
+		HTTPClient: http.Client{
+			Timeout:   time.Second * 5,
+			Transport: ssrf.PublicOnlyTransport(),
+		},
+		Resolver: net.Resolver{
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				d := net.Dialer{Timeout: time.Second * 3}
+				return d.DialContext(ctx, network, address)
+			},
+		},
 	}
 	dir := identity.NewCacheDirectory(&baseDir, cmd.Int("ident-cache-size"), time.Hour*24, time.Minute*2, time.Minute*5)
 

--- a/cmd/tap/tap.go
+++ b/cmd/tap/tap.go
@@ -69,6 +69,9 @@ func NewTap(config TapConfig) (*Tap, error) {
 			Timeout:   time.Second * 15,
 			Transport: ssrf.PublicOnlyTransport(),
 		},
+		PLCClient: &http.Client{
+			Timeout: time.Second * 10,
+		},
 		TryAuthoritativeDNS:   false,
 		SkipDNSDomainSuffixes: []string{".bsky.social"},
 	}

--- a/cmd/tap/tap.go
+++ b/cmd/tap/tap.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/cmd/tap/models"
+	"github.com/bluesky-social/indigo/util/ssrf"
+
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -61,7 +64,11 @@ func NewTap(config TapConfig) (*Tap, error) {
 	}
 
 	bdir := identity.BaseDirectory{
-		PLCURL:                config.PLCURL,
+		PLCURL: config.PLCURL,
+		HTTPClient: http.Client{
+			Timeout:   time.Second * 15,
+			Transport: ssrf.PublicOnlyTransport(),
+		},
 		TryAuthoritativeDNS:   false,
 		SkipDNSDomainSuffixes: []string{".bsky.social"},
 	}


### PR DESCRIPTION
This changes how services configure their `identity.Directory` to be a bit safer and simpler. It also configures separate PLCClient instances of `http.Client` so that local PLC proxies/replicas still work.

As noted elsewhere, the near term goal is to additionally switch over to `jttp`, which includes additional hardening checks.