### PR TITLE
harden more untrusted network fetches

### DIFF
--- a/atproto/auth/oauth/oauth.go
+++ b/atproto/auth/oauth/oauth.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bluesky-social/indigo/atproto/atcrypto"
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/bluesky-social/indigo/util/ssrf"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/go-querystring/query"
@@ -52,7 +53,10 @@ type ClientConfig struct {
 // Constructs a [ClientApp] based on configuration.
 func NewClientApp(config *ClientConfig, store ClientAuthStore) *ClientApp {
 	app := &ClientApp{
-		Client:   http.DefaultClient,
+		Client: &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: ssrf.PublicOnlyTransport(),
+		},
 		Resolver: NewResolver(),
 		Dir:      identity.DefaultDirectory(),
 		Config:   config,

--- a/atproto/lexicon/resolve.go
+++ b/atproto/lexicon/resolve.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"time"
 
 	"github.com/bluesky-social/indigo/api/agnostic"
 	"github.com/bluesky-social/indigo/atproto/atclient"
@@ -77,7 +79,10 @@ func fetchRecordJSON(ctx context.Context, ident identity.Identity, aturi syntax.
 	slog.Debug("fetching record", "did", ident.DID.String(), "collection", aturi.Collection().String(), "rkey", aturi.RecordKey().String())
 	// the this is an untrusted endpoint URL
 	client := atclient.NewAPIClient(ident.PDSEndpoint())
-	client.Client.Transport = ssrf.PublicOnlyTransport()
+	client.Client = &http.Client{
+		Timeout:   60 * time.Second,
+		Transport: ssrf.PublicOnlyTransport(),
+	}
 	resp, err := agnostic.RepoGetRecord(ctx, client, "", aturi.Collection().String(), ident.DID.String(), aturi.RecordKey().String())
 	if err != nil {
 		return nil, err

--- a/atproto/lexicon/resolve.go
+++ b/atproto/lexicon/resolve.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bluesky-social/indigo/atproto/atdata"
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
+	"github.com/bluesky-social/indigo/util/ssrf"
 )
 
 // Low-level routine for resolving an NSID to full Lexicon data record (as stored in a repository).
@@ -74,7 +75,9 @@ func resolveLexiconJSON(ctx context.Context, dir identity.Directory, nsid syntax
 func fetchRecordJSON(ctx context.Context, ident identity.Identity, aturi syntax.ATURI) (*json.RawMessage, error) {
 
 	slog.Debug("fetching record", "did", ident.DID.String(), "collection", aturi.Collection().String(), "rkey", aturi.RecordKey().String())
+	// the this is an untrusted endpoint URL
 	client := atclient.NewAPIClient(ident.PDSEndpoint())
+	client.Client.Transport = ssrf.PublicOnlyTransport()
 	resp, err := agnostic.RepoGetRecord(ctx, client, "", aturi.Collection().String(), ident.DID.String(), aturi.RecordKey().String())
 	if err != nil {
 		return nil, err

--- a/automod/capture/fetch.go
+++ b/automod/capture/fetch.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
+	"time"
 
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/atproto/identity"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/bluesky-social/indigo/automod"
+	"github.com/bluesky-social/indigo/util/ssrf"
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
@@ -25,7 +28,13 @@ func FetchAndProcessRecord(ctx context.Context, eng *automod.Engine, aturi synta
 	if pdsURL == "" {
 		return fmt.Errorf("could not resolve PDS endpoint for AT-URI account: %s", ident.DID.String())
 	}
-	pdsClient := xrpc.Client{Host: pdsURL}
+	pdsClient := xrpc.Client{
+		Host: pdsURL,
+		Client: &http.Client{
+			Timeout:   60 * time.Second,
+			Transport: ssrf.PublicOnlyTransport(),
+		},
+	}
 
 	eng.Logger.Info("fetching record", "did", ident.DID.String(), "collection", aturi.Collection().String(), "rkey", aturi.RecordKey().String())
 	out, err := comatproto.RepoGetRecord(ctx, &pdsClient, "", aturi.Collection().String(), ident.DID.String(), aturi.RecordKey().String())
@@ -61,7 +70,13 @@ func FetchRecent(ctx context.Context, eng *automod.Engine, atid syntax.AtIdentif
 	if pdsURL == "" {
 		return nil, nil, fmt.Errorf("could not resolve PDS endpoint for account: %s", ident.DID.String())
 	}
-	pdsClient := xrpc.Client{Host: pdsURL}
+	pdsClient := xrpc.Client{
+		Host: pdsURL,
+		Client: &http.Client{
+			Timeout:   60 * time.Second,
+			Transport: ssrf.PublicOnlyTransport(),
+		},
+	}
 
 	resp, err := comatproto.RepoListRecords(ctx, &pdsClient, "app.bsky.feed.post", "", int64(limit), ident.DID.String(), false)
 	if err != nil {

--- a/automod/engine/blobs.go
+++ b/automod/engine/blobs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bluesky-social/indigo/atproto/atdata"
 	lexutil "github.com/bluesky-social/indigo/lex/util"
+	"github.com/bluesky-social/indigo/util/ssrf"
 
 	"github.com/earthboundkid/versioninfo/v2"
 )
@@ -71,7 +72,10 @@ func (c *RecordContext) fetchBlob(blob lexutil.LexBlob) ([]byte, error) {
 
 	client := c.engine.BlobClient
 	if client == nil {
-		client = http.DefaultClient
+		client = &http.Client{
+			Timeout:   90 * time.Second,
+			Transport: ssrf.PublicOnlyTransport(),
+		}
 	}
 
 	resp, err := client.Do(req)

--- a/cmd/collectiondir/collectiondir.go
+++ b/cmd/collectiondir/collectiondir.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bluesky-social/indigo/util/ssrf"
+
 	"github.com/earthboundkid/versioninfo/v2"
 	"github.com/urfave/cli/v3"
 )
@@ -308,7 +310,10 @@ var adminCrawlCmd = &cli.Command{
 			fmt.Println("no hosts")
 		}
 
-		client := http.Client{Timeout: 1 * time.Second}
+		client := http.Client{
+			Timeout:   1 * time.Second,
+			Transport: ssrf.PublicOnlyTransport(),
+		}
 		var headers http.Header = make(http.Header)
 		if cmd.IsSet("auth") {
 			headers.Add("Authorization", "Bearer "+cmd.String("auth"))

--- a/cmd/collectiondir/serve.go
+++ b/cmd/collectiondir/serve.go
@@ -26,6 +26,7 @@ import (
 	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/bluesky-social/indigo/events"
+	"github.com/bluesky-social/indigo/util/ssrf"
 	"github.com/bluesky-social/indigo/util/svcutil"
 	"github.com/bluesky-social/indigo/xrpc"
 
@@ -899,7 +900,9 @@ func (cs *collectionServer) crawlThread(hostIn string) {
 	if host != hostIn {
 		cs.log.Info("going to crawl", "in", hostIn, "as", host)
 	}
-	httpClient := http.Client{}
+	httpClient := http.Client{
+		Transport: ssrf.PublicOnlyTransport(),
+	}
 	rpcClient := xrpc.Client{
 		Host:   host,
 		Client: &httpClient,

--- a/cmd/hepa/server.go
+++ b/cmd/hepa/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/bluesky-social/indigo/util"
 	"github.com/bluesky-social/indigo/xrpc"
 
+	"github.com/jcalabro/jttp"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/redis/go-redis/v9"
 )
@@ -203,7 +204,13 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 		bskyClient.Headers = make(map[string]string)
 		bskyClient.Headers["x-ratelimit-bypass"] = config.RatelimitBypass
 	}
-	blobClient := util.RobustHTTPClient()
+	// blob client is used for untrusted network fetches, and also needs to be resilient to failure
+	blobClient := jttp.New(
+		jttp.WithTimeout(30*time.Second),
+		jttp.WithRetries(3),
+		jttp.WithRetryWait(1*time.Second, 10*time.Second),
+		jttp.WithStrictSSRFProtection(),
+	)
 	eng := automod.Engine{
 		Logger:      logger,
 		Directory:   dir,

--- a/cmd/hepa/server.go
+++ b/cmd/hepa/server.go
@@ -21,7 +21,7 @@ import (
 	"github.com/bluesky-social/indigo/util"
 	"github.com/bluesky-social/indigo/xrpc"
 
-	"github.com/jcalabro/jttp"
+	"github.com/bluesky-social/gttp"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/redis/go-redis/v9"
 )
@@ -205,11 +205,11 @@ func NewServer(dir identity.Directory, config Config) (*Server, error) {
 		bskyClient.Headers["x-ratelimit-bypass"] = config.RatelimitBypass
 	}
 	// blob client is used for untrusted network fetches, and also needs to be resilient to failure
-	blobClient := jttp.New(
-		jttp.WithTimeout(30*time.Second),
-		jttp.WithRetries(3),
-		jttp.WithRetryWait(1*time.Second, 10*time.Second),
-		jttp.WithStrictSSRFProtection(),
+	blobClient := gttp.New(
+		gttp.WithTimeout(30*time.Second),
+		gttp.WithRetries(3),
+		gttp.WithRetryWait(1*time.Second, 10*time.Second),
+		gttp.WithStrictSSRFProtection(),
 	)
 	eng := automod.Engine{
 		Logger:      logger,

--- a/cmd/netsync/main.go
+++ b/cmd/netsync/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/bluesky-social/indigo/atproto/atdata"
 	"github.com/bluesky-social/indigo/repo"
+	"github.com/bluesky-social/indigo/util/ssrf"
 
 	"github.com/earthboundkid/versioninfo/v2"
 	"github.com/ipfs/go-cid"
@@ -280,7 +281,8 @@ func Netsync(ctx context.Context, cmd *cli.Command) error {
 		exit: make(chan struct{}),
 		wg:   sync.WaitGroup{},
 		client: &http.Client{
-			Timeout: 180 * time.Second,
+			Timeout:   180 * time.Second,
+			Transport: ssrf.PublicOnlyTransport(),
 		},
 
 		logger: logger,

--- a/cmd/tap/resyncer.go
+++ b/cmd/tap/resyncer.go
@@ -16,6 +16,8 @@ import (
 	repolib "github.com/bluesky-social/indigo/atproto/repo"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 	"github.com/bluesky-social/indigo/cmd/tap/models"
+	"github.com/bluesky-social/indigo/util/ssrf"
+
 	"github.com/ipfs/go-cid"
 	"go.opentelemetry.io/otel/attribute"
 	"gorm.io/gorm"
@@ -198,6 +200,7 @@ func (r *Resyncer) doResync(ctx context.Context, did string) (bool, error) {
 
 	r.logger.Info("fetching repo from PDS", "did", did, "pds", pdsURL)
 
+	// NOTE: this is an untrusted endpoint URL
 	client := atclient.NewAPIClient(pdsURL)
 	client.Headers.Set("User-Agent", userAgent())
 	timeout := r.repoFetchTimeout
@@ -205,7 +208,8 @@ func (r *Resyncer) doResync(ctx context.Context, did string) (bool, error) {
 		timeout = 30 * time.Second
 	}
 	client.Client = &http.Client{
-		Timeout: timeout,
+		Timeout:   timeout,
+		Transport: ssrf.PublicOnlyTransport(),
 	}
 
 	repoBytes, err := comatproto.SyncGetRepo(ctx, client, did, "")


### PR DESCRIPTION
This covers a number of network fetches to untrusted hosts, other than `identity.Directory` usage (covered in other PRs).

These changes may have an impact on downstream code. For example, the OAuth change could impact some local/offline development workflows (though it should not break simple development with "localhost" `client_id`).

This only uses `jttp` a bit; future work is to use that more broadly.