### PR TITLE
mst: validate PrefixLen range when decoding node data

### DIFF
--- a/atproto/repo/mst/encoding.go
+++ b/atproto/repo/mst/encoding.go
@@ -90,7 +90,10 @@ func (n *Node) NodeData() NodeData {
 // Tansforms an encoded `NodeData` to `Node` data structure format.
 //
 // c: optional CID argument for the CID of the CBOR representation of the NodeData
-func (d *NodeData) Node(c *cid.Cid) Node {
+//
+// Returns an error if any entry's PrefixLen is out of range, since NodeData
+// comes from untrusted input and PrefixLen is used as a slice bound.
+func (d *NodeData) Node(c *cid.Cid) (Node, error) {
 	height := -1
 	n := Node{
 		CID:     c,
@@ -104,6 +107,9 @@ func (d *NodeData) Node(c *cid.Cid) Node {
 
 	var prevKey []byte
 	for _, e := range d.Entries {
+		if e.PrefixLen < 0 || e.PrefixLen > int64(len(prevKey)) {
+			return n, fmt.Errorf("%w: entry PrefixLen (%d) out of range for previous key length (%d)", ErrInvalidTree, e.PrefixLen, len(prevKey))
+		}
 		// TODO perf: pre-allocate
 		key := []byte{}
 		key = append(key, prevKey[:e.PrefixLen]...)
@@ -126,7 +132,7 @@ func (d *NodeData) Node(c *cid.Cid) Node {
 
 	// TODO: height doesn't get set properly if this is an intermediate node; we rely on `EnsureHeights` getting called to fix that
 	n.Height = height
-	return n
+	return n, nil
 }
 
 // TODO: this feels like a hack, and easy to forget
@@ -210,7 +216,10 @@ func loadNodeFromStore(ctx context.Context, bs MSTBlockSource, ref cid.Cid) (*No
 		return nil, err
 	}
 
-	n := nd.Node(&ref)
+	n, err := nd.Node(&ref)
+	if err != nil {
+		return nil, err
+	}
 
 	for i, e := range n.Entries {
 		if e.IsChild() {

--- a/atproto/repo/mst/encoding_test.go
+++ b/atproto/repo/mst/encoding_test.go
@@ -1,0 +1,120 @@
+package mst
+
+// Regression tests for untrusted PrefixLen values in decoded NodeData
+// (Linear SEC-4). PrefixLen comes from attacker-controlled CBOR in commit
+// CARs and is used as a slice bound against the previous key; before the
+// range check it caused a fatal slice-bounds panic on the relay ingest path.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ipfs/go-cid"
+)
+
+func testEntryCid(t *testing.T) cid.Cid {
+	c, err := cid.Decode("bafyreie5cvv4h45feadgeuwhbcutmh6t2ceseocckahdoe6uat64zmz454")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// PrefixLen beyond the length of the previous key (empty for the first
+// entry) must return an error, not panic.
+func TestNodePrefixLenOutOfRange(t *testing.T) {
+	assert := assert.New(t)
+
+	nd := NodeData{
+		Entries: []EntryData{{
+			PrefixLen: 100,
+			KeySuffix: []byte("x"),
+			Value:     testEntryCid(t),
+		}},
+	}
+	_, err := nd.Node(nil)
+	assert.Error(err)
+}
+
+// Negative PrefixLen must return an error, not panic.
+func TestNodePrefixLenNegative(t *testing.T) {
+	assert := assert.New(t)
+
+	nd := NodeData{
+		Entries: []EntryData{{
+			PrefixLen: -1,
+			KeySuffix: []byte("x"),
+			Value:     testEntryCid(t),
+		}},
+	}
+	_, err := nd.Node(nil)
+	assert.Error(err)
+}
+
+// Huge PrefixLen values (which previously drove a 1TB make() preallocation
+// in the legacy package) must be rejected cheaply by the same range check.
+func TestNodePrefixLenHuge(t *testing.T) {
+	assert := assert.New(t)
+
+	nd := NodeData{
+		Entries: []EntryData{{
+			PrefixLen: 1 << 40,
+			KeySuffix: []byte("x"),
+			Value:     testEntryCid(t),
+		}},
+	}
+	_, err := nd.Node(nil)
+	assert.Error(err)
+}
+
+// Boundary values that are legal must keep working: PrefixLen == 0 on the
+// first entry, and PrefixLen == len(prevKey) on a later entry.
+func TestNodePrefixLenValidBoundaries(t *testing.T) {
+	assert := assert.New(t)
+
+	firstKey := "com.example.record/3jqfcqzm3fo2j"
+	nd := NodeData{
+		Entries: []EntryData{
+			{
+				PrefixLen: 0,
+				KeySuffix: []byte(firstKey),
+				Value:     testEntryCid(t),
+			},
+			{
+				PrefixLen: int64(len(firstKey)),
+				KeySuffix: []byte("abc"),
+				Value:     testEntryCid(t),
+			},
+		},
+	}
+	n, err := nd.Node(nil)
+	assert.NoError(err)
+	assert.Len(n.Entries, 2)
+	assert.Equal([]byte(firstKey), n.Entries[0].Key)
+	assert.Equal([]byte(firstKey+"abc"), n.Entries[1].Key)
+}
+
+// Out-of-range PrefixLen on a later entry (prevKey non-empty) must also be
+// rejected, covering the len(prevKey) upper bound with a non-zero baseline.
+func TestNodePrefixLenOutOfRangeLaterEntry(t *testing.T) {
+	assert := assert.New(t)
+
+	firstKey := "com.example.record/3jqfcqzm3fo2j"
+	nd := NodeData{
+		Entries: []EntryData{
+			{
+				PrefixLen: 0,
+				KeySuffix: []byte(firstKey),
+				Value:     testEntryCid(t),
+			},
+			{
+				PrefixLen: int64(len(firstKey)) + 1,
+				KeySuffix: []byte("x"),
+				Value:     testEntryCid(t),
+			},
+		},
+	}
+	_, err := nd.Node(nil)
+	assert.Error(err)
+}

--- a/atproto/repo/mst/encoding_test.go
+++ b/atproto/repo/mst/encoding_test.go
@@ -1,10 +1,5 @@
 package mst
 
-// Regression tests for untrusted PrefixLen values in decoded NodeData
-// (Linear SEC-4). PrefixLen comes from attacker-controlled CBOR in commit
-// CARs and is used as a slice bound against the previous key; before the
-// range check it caused a fatal slice-bounds panic on the relay ingest path.
-
 import (
 	"testing"
 

--- a/atproto/repo/mst/mst_interop_test.go
+++ b/atproto/repo/mst/mst_interop_test.go
@@ -60,7 +60,8 @@ func TestManualNode(t *testing.T) {
 			},
 		},
 	}
-	n := simple_nd.Node(nil)
+	n, err := simple_nd.Node(nil)
+	assert.NoError(err)
 	assert.Equal(simple_nd, n.NodeData())
 
 	mcid, err := n.writeBlocks(context.Background(), nil, true)

--- a/mst/mst_util.go
+++ b/mst/mst_util.go
@@ -79,8 +79,6 @@ func deserializeNodeData(ctx context.Context, cst cbor.IpldStore, nd *NodeData, 
 	var lastKey string
 	var keyb []byte // re-used between entries
 	for _, e := range nd.Entries {
-		// PrefixLen is attacker-controlled (untrusted CBOR) and is used both as
-		// an allocation capacity and a slice bound below; range-check it first
 		if e.PrefixLen < 0 || e.PrefixLen > int64(len(lastKey)) {
 			return nil, fmt.Errorf("mst node entry PrefixLen (%d) out of range for previous key length (%d)", e.PrefixLen, len(lastKey))
 		}

--- a/mst/mst_util.go
+++ b/mst/mst_util.go
@@ -79,6 +79,11 @@ func deserializeNodeData(ctx context.Context, cst cbor.IpldStore, nd *NodeData, 
 	var lastKey string
 	var keyb []byte // re-used between entries
 	for _, e := range nd.Entries {
+		// PrefixLen is attacker-controlled (untrusted CBOR) and is used both as
+		// an allocation capacity and a slice bound below; range-check it first
+		if e.PrefixLen < 0 || e.PrefixLen > int64(len(lastKey)) {
+			return nil, fmt.Errorf("mst node entry PrefixLen (%d) out of range for previous key length (%d)", e.PrefixLen, len(lastKey))
+		}
 		if keyb == nil {
 			keyb = make([]byte, 0, int(e.PrefixLen)+len(e.KeySuffix))
 		}

--- a/mst/mst_util_test.go
+++ b/mst/mst_util_test.go
@@ -1,0 +1,74 @@
+package mst
+
+// Regression tests for untrusted PrefixLen values in decoded NodeData
+// (Linear SEC-4). PrefixLen comes from attacker-controlled CBOR and was
+// previously used both as a make() capacity (mst_util.go, 1TB preallocation
+// on PrefixLen=1<<40 -> uncatchable fatal OOM) and as a slice bound
+// (slice-bounds panic). Both must now surface as errors from hydration.
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/bluesky-social/indigo/util"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	"github.com/multiformats/go-multihash"
+)
+
+func hostileTree(t *testing.T, prefixLen int64) *MerkleSearchTree {
+	val := mustCid(t, "bafkreicwamkg77pijyudfbdmskelsnuztr6gp62lqfjv3e3urbs3gxnv2m")
+	nd := NodeData{
+		Entries: []TreeEntry{{
+			PrefixLen: prefixLen,
+			KeySuffix: []byte("x"),
+			Val:       val,
+		}},
+	}
+	var buf bytes.Buffer
+	if err := nd.MarshalCBOR(&buf); err != nil {
+		t.Fatal(err)
+	}
+	c, err := cid.NewPrefixV1(cid.DagCBOR, multihash.SHA2_256).Sum(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	blk, err := blocks.NewBlockWithCid(buf.Bytes(), c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bs := blockstore.NewBlockstore(datastore.NewMapDatastore())
+	if err := bs.Put(context.Background(), blk); err != nil {
+		t.Fatal(err)
+	}
+	return LoadMST(util.CborStore(bs), c)
+}
+
+// Out-of-range PrefixLen on hydration must error, not panic.
+func TestDeserializePrefixLenOutOfRange(t *testing.T) {
+	tree := hostileTree(t, 100)
+	if _, err := tree.Get(context.Background(), "x"); err == nil {
+		t.Fatal("expected error for out-of-range PrefixLen")
+	}
+}
+
+// Negative PrefixLen on hydration must error, not panic.
+func TestDeserializePrefixLenNegative(t *testing.T) {
+	tree := hostileTree(t, -1)
+	if _, err := tree.Get(context.Background(), "x"); err == nil {
+		t.Fatal("expected error for negative PrefixLen")
+	}
+}
+
+// Huge PrefixLen must error before any allocation is attempted (previously
+// a 1TB make() preallocation -> fatal runtime OOM, uncatchable by recover).
+func TestDeserializePrefixLenHuge(t *testing.T) {
+	tree := hostileTree(t, 1<<40)
+	if _, err := tree.Get(context.Background(), "x"); err == nil {
+		t.Fatal("expected error for huge PrefixLen")
+	}
+}

--- a/mst/mst_util_test.go
+++ b/mst/mst_util_test.go
@@ -1,11 +1,5 @@
 package mst
 
-// Regression tests for untrusted PrefixLen values in decoded NodeData
-// (Linear SEC-4). PrefixLen comes from attacker-controlled CBOR and was
-// previously used both as a make() capacity (mst_util.go, 1TB preallocation
-// on PrefixLen=1<<40 -> uncatchable fatal OOM) and as a slice bound
-// (slice-bounds panic). Both must now surface as errors from hydration.
-
 import (
 	"bytes"
 	"context"
@@ -64,8 +58,6 @@ func TestDeserializePrefixLenNegative(t *testing.T) {
 	}
 }
 
-// Huge PrefixLen must error before any allocation is attempted (previously
-// a 1TB make() preallocation -> fatal runtime OOM, uncatchable by recover).
 func TestDeserializePrefixLenHuge(t *testing.T) {
 	tree := hostileTree(t, 1<<40)
 	if _, err := tree.Get(context.Background(), "x"); err == nil {


### PR DESCRIPTION
## Changes
- `atproto/repo/mst/encoding.go`: `Node()` signature changed from `Node(c *cid.Cid) Node` to `Node(c *cid.Cid) (Node, error)`; each entry's `PrefixLen` is checked against the previous key length before being used as a slice bound, returning a wrapped `ErrInvalidTree`. Caller `loadNodeFromStore` propagates the error
- `mst/mst_util.go` (`deserializeNodeData`): same range check before the `make()` preallocation
- One test caller updated for the new `Node()` signature (`mst_interop_test.go`).
- No behavior change for well-formed data: `PrefixLen == 0` (first entry) and `PrefixLen == len(prevKey)` (later entries) remain valid, covered by boundary tests.

## Review notes
- `Node()` is an exported API change (new error return) — any external consumers of `atproto/repo/mst` will need a mechanical update; in-repo callers are all updated here.
- Defense-in-depth follow-up (not in this PR): a `recover()` in the relay parallel scheduler's worker loop so future parser panics degrade to dropped events rather than process death. Deliberately excluded to keep this fix minimal and reviewable.
