### PR TITLE
automod: improve account metadata fetch logic

### DIFF
--- a/automod/engine/fetch_account_meta.go
+++ b/automod/engine/fetch_account_meta.go
@@ -15,15 +15,15 @@ import (
 	"github.com/bluesky-social/indigo/xrpc"
 )
 
-var newAccountRetryDuration = 3 * 1000 * time.Millisecond
+var newAccountRetryDuration = 2 * 1000 * time.Millisecond
 
 // Helper to hydrate metadata about an account from several sources: PDS (if access), mod service (if access), public identity resolution
 func (e *Engine) GetAccountMeta(ctx context.Context, ident *identity.Identity) (*AccountMeta, error) {
 
 	logger := e.Logger.With("did", ident.DID.String())
 
-	// fallback in case client wasn't configured (eg, testing)
-	if e.BskyClient == nil {
+	// fallback in case upstream clients are not configured (eg, testing)
+	if e.BskyClient == nil && e.OzoneClient == nil {
 		logger.Debug("skipping account meta hydration")
 		am := AccountMeta{
 			Identity: ident,
@@ -47,6 +47,7 @@ func (e *Engine) GetAccountMeta(ctx context.Context, ident *identity.Identity) (
 	}
 
 	// doing a "full" fetch from here on
+	fetchedAnyAccountData := false
 	accountMetaFetches.Inc()
 	am := AccountMeta{
 		Identity: ident,
@@ -59,64 +60,21 @@ func (e *Engine) GetAccountMeta(ctx context.Context, ident *identity.Identity) (
 	}
 	am.AccountFlags = flags
 
-	// fetch account metadata from AppView
-	pv, err := appbsky.ActorGetProfile(ctx, e.BskyClient, ident.DID.String())
-	// most common cause of this is a race between automod and ozone/appview for new accounts. just sleep a couple seconds and retry!
-	var xrpcError *xrpc.Error
-	if err != nil && errors.As(err, &xrpcError) && (xrpcError.StatusCode == 400 || xrpcError.StatusCode == 404) {
-		logger.Debug("account profile lookup initially failed (from bsky appview), will retry", "err", err, "sleepDuration", newAccountRetryDuration)
-		time.Sleep(newAccountRetryDuration)
-		pv, err = appbsky.ActorGetProfile(ctx, e.BskyClient, ident.DID.String())
-	}
-	if err != nil {
-		logger.Warn("account profile lookup failed (from bsky appview)", "err", err)
-		return &am, nil
-	}
-
-	am.Profile = ProfileSummary{
-		HasAvatar:   pv.Avatar != nil,
-		AvatarCid:   cidFromCdnUrl(pv.Avatar),
-		BannerCid:   cidFromCdnUrl(pv.Banner),
-		Description: pv.Description,
-		DisplayName: pv.DisplayName,
-	}
-	if pv.PostsCount != nil {
-		am.PostsCount = *pv.PostsCount
-	}
-	if pv.FollowersCount != nil {
-		am.FollowersCount = *pv.FollowersCount
-	}
-	if pv.FollowsCount != nil {
-		am.FollowsCount = *pv.FollowsCount
-	}
-
-	var labels []string
-	var negLabels []string
-	for _, lbl := range pv.Labels {
-		if lbl.Neg != nil && *lbl.Neg == true {
-			negLabels = append(negLabels, lbl.Val)
-		} else {
-			labels = append(labels, lbl.Val)
-		}
-	}
-	am.AccountLabels = dedupeStrings(labels)
-	am.AccountNegatedLabels = dedupeStrings(negLabels)
-
-	if pv.CreatedAt != nil {
-		ts, err := syntax.ParseDatetimeTime(*pv.CreatedAt)
-		if err != nil {
-			logger.Warn("invalid profile createdAt", "err", err, "createdAt", pv.CreatedAt)
-		} else {
-			am.CreatedAt = &ts
-		}
-	}
-
-	// first attempt to fetch private account metadata from Ozone
+	// first attempt to fetch private account metadata from Ozone.
+	// this can also include public labels, but does not include public profile info (eg, display name)
 	if e.OzoneClient != nil {
 		rd, err := toolsozone.ModerationGetRepo(ctx, e.OzoneClient, ident.DID.String())
 		if err != nil {
 			logger.Warn("failed to fetch private account metadata from Ozone", "err", err)
+			var xrpcError *xrpc.Error
+			if errors.As(err, &xrpcError) {
+				accountOzoneFetches.WithLabelValues(fmt.Sprint(xrpcError.StatusCode)).Inc()
+			} else {
+				accountOzoneFetches.WithLabelValues("error").Inc()
+			}
 		} else {
+			accountOzoneFetches.WithLabelValues("200").Inc()
+			fetchedAnyAccountData = true
 			ap := AccountPrivate{}
 			if rd.Email != nil && *rd.Email != "" {
 				ap.Email = *rd.Email
@@ -152,6 +110,19 @@ func (e *Engine) GetAccountMeta(ctx context.Context, ident *identity.Identity) (
 					}
 				}
 			}
+
+			var labels []string
+			var negLabels []string
+			for _, lbl := range rd.Labels {
+				if lbl.Neg != nil && *lbl.Neg == true {
+					negLabels = append(negLabels, lbl.Val)
+				} else {
+					labels = append(labels, lbl.Val)
+				}
+			}
+			am.AccountLabels = dedupeStrings(labels)
+			am.AccountNegatedLabels = dedupeStrings(negLabels)
+
 			if rd.ThreatSignatures != nil || len(rd.ThreatSignatures) > 0 {
 				asigs := make([]AbuseSignature, len(rd.ThreatSignatures))
 				for i, sig := range rd.ThreatSignatures {
@@ -159,35 +130,102 @@ func (e *Engine) GetAccountMeta(ctx context.Context, ident *identity.Identity) (
 				}
 				ap.AbuseSignatures = asigs
 			}
+
 			am.Private = &ap
 		}
 	}
-	// fall back to PDS/entryway fetching; less metadata available
+	// if the ozone private data fetch failed, try to fall back to PDS/entryway fetching. this has less metadata available, but sometimes catches new account creation
+	// TODO: this only makes sense for accounts hosted by the infra operator, and using an entryway. aka, pretty bluesky-specific, and will error on all external accounts
 	if am.Private == nil && e.AdminClient != nil {
-		pv, err := comatproto.AdminGetAccountInfo(ctx, e.AdminClient, ident.DID.String())
+		ai, err := comatproto.AdminGetAccountInfo(ctx, e.AdminClient, ident.DID.String())
 		if err != nil {
 			logger.Warn("failed to fetch private account metadata from PDS/entryway", "err", err)
+			// NOTE: not bothering with metrics on this rare codepath
 		} else {
+			// NOTE: not setting fetchedAnyAccountData; these results won't get cached in isolation
 			ap := AccountPrivate{}
-			if pv.Email != nil && *pv.Email != "" {
-				ap.Email = *pv.Email
+			if ai.Email != nil && *ai.Email != "" {
+				ap.Email = *ai.Email
 			}
-			if pv.EmailConfirmedAt != nil && *pv.EmailConfirmedAt != "" {
+			if ai.EmailConfirmedAt != nil && *ai.EmailConfirmedAt != "" {
 				ap.EmailConfirmed = true
 			}
-			ts, err := syntax.ParseDatetimeTime(pv.IndexedAt)
+			ts, err := syntax.ParseDatetimeTime(ai.IndexedAt)
 			if err != nil {
-				return nil, fmt.Errorf("bad entryway account IndexedAt: %w", err)
+				logger.Warn("bad PDS/entryway account IndexedAt", "err", err)
+			} else {
+				ap.IndexedAt = &ts
+				if am.CreatedAt == nil {
+					am.CreatedAt = &ts
+				}
 			}
-			ap.IndexedAt = &ts
 			am.Private = &ap
-			if am.CreatedAt == nil {
+		}
+	}
+
+	// fetch other account metadata from bsky AppView
+	// this only gets public info, which can include profile contents as well as public labels
+	pv, err := appbsky.ActorGetProfile(ctx, e.BskyClient, ident.DID.String())
+	if err != nil {
+		logger.Warn("account profile lookup failed (from bsky appview)", "err", err)
+		var xrpcError *xrpc.Error
+		if errors.As(err, &xrpcError) {
+			accountAppviewFetches.WithLabelValues(fmt.Sprint(xrpcError.StatusCode)).Inc()
+		} else {
+			accountAppviewFetches.WithLabelValues("error").Inc()
+		}
+	} else {
+		accountAppviewFetches.WithLabelValues("200").Inc()
+		fetchedAnyAccountData = true
+		am.Profile = ProfileSummary{
+			HasAvatar:   pv.Avatar != nil,
+			AvatarCid:   cidFromCdnUrl(pv.Avatar),
+			BannerCid:   cidFromCdnUrl(pv.Banner),
+			Description: pv.Description,
+			DisplayName: pv.DisplayName,
+		}
+		if pv.PostsCount != nil {
+			am.PostsCount = *pv.PostsCount
+		}
+		if pv.FollowersCount != nil {
+			am.FollowersCount = *pv.FollowersCount
+		}
+		if pv.FollowsCount != nil {
+			am.FollowsCount = *pv.FollowsCount
+		}
+
+		if len(am.AccountLabels) == 0 && len(am.AccountNegatedLabels) == 0 {
+			var labels []string
+			var negLabels []string
+			for _, lbl := range pv.Labels {
+				if lbl.Neg != nil && *lbl.Neg == true {
+					negLabels = append(negLabels, lbl.Val)
+				} else {
+					labels = append(labels, lbl.Val)
+				}
+			}
+			am.AccountLabels = dedupeStrings(labels)
+			am.AccountNegatedLabels = dedupeStrings(negLabels)
+		}
+
+		if pv.CreatedAt != nil && am.CreatedAt == nil {
+			ts, err := syntax.ParseDatetimeTime(*pv.CreatedAt)
+			if err != nil {
+				logger.Warn("invalid appview profile createdAt timestamp", "err", err, "createdAt", pv.CreatedAt)
+			} else {
 				am.CreatedAt = &ts
 			}
 		}
 	}
 
+	// skip updating cache if no real data fetched
+	if !fetchedAnyAccountData {
+		logger.Warn("account metadata fetch didn't get any data; not updating cache")
+		return &am, nil
+	}
+
 	if am.CreatedAt == nil {
+		// TODO: might be safe to remove this legacy/debugging log line
 		logger.Warn("account metadata missing CreatedAt time")
 	}
 

--- a/automod/engine/metrics.go
+++ b/automod/engine/metrics.go
@@ -60,6 +60,16 @@ var accountMetaFetches = promauto.NewCounter(prometheus.CounterOpts{
 	Help: "Number of account metadata reads (API calls)",
 })
 
+var accountOzoneFetches = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "automod_ozone_fetches",
+	Help: "Number of Ozone API account metadata calls, by HTTP status code",
+}, []string{"status"})
+
+var accountAppviewFetches = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "automod_appview_fetches",
+	Help: "Number of Bluesky AppView API account metadata calls, by HTTP status code",
+}, []string{"status"})
+
 var accountRelationshipFetches = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "automod_account_relationship_fetches",
 	Help: "Number of account relationship reads (API calls)",


### PR DESCRIPTION
This PR changes the logic and codeflow for how the automod engine fetches account metadata from ozone and/or the bsky appview (with rare fallback to an entryway API).

The motivation for these changes are to be resilient to failure to fetch info from the bsky appview in particular. It is not uncommon for the appview to return and HTTP error because an account is suspended, but the account continues to emit events. In these situations, the metadata from ozone is sufficient.

At the same time, this keeps things working in situations where an ozone instance is not configured.

Adds a couple additional metrics, and drops a "new account retry" sleep down to 2 seconds. this is also now against ozone, so we don't expect failures if the account is simply suspended; and will end up caching the overall fetch as long as the appview does respond (for example).

For reviewers: a concern to keep in mind is that the account metadata cache has an expiration of 24 hours. Having bad/empty metadata cached could be bad in some situations. Ozone events and account/identity events can purge that cache for individual accounts. And not all the metadata is critical (eg, the profile info isn't often used in automod rules; profile records themselves have rules on the record themselves).