### PR TITLE
Add `updatedAt` to interests preference

### DIFF
--- a/api/bsky/actordefs.go
+++ b/api/bsky/actordefs.go
@@ -88,6 +88,8 @@ type ActorDefs_InterestsPref struct {
 	LexiconTypeID string `json:"$type" cborgen:"$type,const=app.bsky.actor.defs#interestsPref"`
 	// tags: A list of tags which describe the account owner's interests gathered during onboarding.
 	Tags []string `json:"tags" cborgen:"tags"`
+	// updatedAt: The timestamp when the account owner last updated their interests.
+	UpdatedAt *string `json:"updatedAt,omitempty" cborgen:"updatedAt,omitempty"`
 }
 
 // ActorDefs_KnownFollowers is a "knownFollowers" in the app.bsky.actor.defs schema.

--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -469,6 +469,11 @@
       "type": "object",
       "required": ["tags"],
       "properties": {
+        "updatedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "The timestamp when the account owner last updated their interests."
+        },
         "tags": {
           "type": "array",
           "maxLength": 100,


### PR DESCRIPTION
Ports bluesky-social/atproto#5481 to Indigo's vendored Lexicon and generated Go types.

## Summary
- add optional `updatedAt` to `app.bsky.actor.defs#interestsPref`
- regenerate `ActorDefs_InterestsPref` with the optional timestamp field

## Testing
- `make lexgen`
- `go test ./api/bsky ./lex/...`
- `go test ./cmd/lexgen/...`
- `go test ./...` *(all packages passed except the unrelated `util/ssrf` `TestPublicOnlyTransport` localhost timeout assertion)*
